### PR TITLE
fix: bandwidth threshold gate fails closed on missing BM or eval error

### DIFF
--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/expected.json
@@ -1,0 +1,139 @@
+{
+  "Workflow/test-bw-invalid-expr": {
+    "kind": "Workflow",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-bw-invalid-expr",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "test-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "test-image:latest",
+                "command": [
+                  "mpirun"
+                ],
+                "numNodes": 2
+              },
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true"
+          }
+        },
+        "diagnose": {
+          "minGroupSize": 2,
+          "topologyKey": "nvidia.com/gpu.clique"
+        },
+        "execution": {},
+        "iterations": 1
+      },
+      "validation": {
+        "performance": {
+          "enabled": true,
+          "tracking": {},
+          "thresholds": {
+            "thresholds": {
+              "busBandwidthGBps": "not valid cel!!!"
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "IterationsFailed",
+          "message": "No healthy reference node; 2 suspects marked failed"
+        }
+      ],
+      "failedNodesRef": {
+        "apiGroup": null,
+        "kind": "ConfigMap",
+        "name": "failed-nodes"
+      },
+      "orchestration": {
+        "totalNodes": 2,
+        "nodesPerJob": 2,
+        "totalGroups": 1,
+        "currentIteration": 1,
+        "completedIterations": 1,
+        "detectedPlatform": "onprem",
+        "detectedGPUArchitecture": "unknown",
+        "diagnose": {
+          "stage": "complete",
+          "round": 1,
+          "suspectNodes": [
+            "node-a1",
+            "node-a2"
+          ],
+          "screeningResults": {
+            "clique-a": {
+              "nodes": [
+                "node-a1",
+                "node-a2"
+              ],
+              "passed": false
+            }
+          }
+        },
+        "groups": [
+          {
+            "name": "screen-0",
+            "nodes": [
+              "node-a1",
+              "node-a2"
+            ],
+            "domains": [
+              "clique-a"
+            ],
+            "phase": "Succeeded",
+            "jobRef": {
+              "apiVersion": "cre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-bw-invalid-expr-screen-0-iter-1",
+              "namespace": "default"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/input_client_objects.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for the bandwidth gate fail-open bug (issue #5).
+# The busBandwidthGBps threshold expression is syntactically invalid CEL.
+# Previously threshold.Evaluate returning an error caused isBelowBandwidthThreshold
+# to return (false, false) — passing the gate. After the fix it returns an error
+# which causes the group to be treated as failed (fail closed).
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-a1
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-a
+    kubernetes.io/hostname: node-a1
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-a2
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-a
+    kubernetes.io/hostname: node-a2
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-bw-invalid-expr
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - mpirun
+            numNodes: 2
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+    diagnose:
+      minGroupSize: 2
+      topologyKey: nvidia.com/gpu.clique
+  validation:
+    performance:
+      enabled: true
+      thresholds:
+        thresholds:
+          busBandwidthGBps: "not valid cel!!!"
+status:
+  orchestration:
+    totalNodes: 2
+    nodesPerJob: 2
+    totalGroups: 1
+    currentIteration: 1
+    detectedPlatform: onprem
+    detectedGPUArchitecture: unknown
+    diagnose:
+      stage: intra-screening
+      round: 0
+    groups:
+      - name: screen-0
+        nodes: [node-a1, node-a2]
+        domains: [clique-a]
+        phase: Running
+        jobRef:
+          apiVersion: cre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-bw-invalid-expr-screen-0-iter-1
+          namespace: default
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-bw-invalid-expr-screen-0-iter-1
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: cluster-readiness-engine
+    cre.nvidia.com/workflow: test-bw-invalid-expr
+    cre.nvidia.com/group: screen-0
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - mpirun
+        numNodes: 2
+status:
+  conditions:
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadCompleted
+      message: "Workload completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Failed
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: BandwidthMeasurement
+metadata:
+  name: test-bw-invalid-expr-screen-0-bw
+  namespace: default
+spec:
+  jobRef:
+    apiGroup: cre.nvidia.com
+    kind: Job
+    name: test-bw-invalid-expr-screen-0-iter-1
+  logProfileRef: nccl-bandwidth
+  testType: all_reduce
+status:
+  results:
+    - sizeBytes: 17179869184
+      algBW: "300.00"
+      busBW: "500.00"
+      samples: 5

--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-invalid-expr/input_config.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# With an invalid CEL expression, isBelowBandwidthThreshold returns an error
+# and the group is treated as failed. With the sole group failing intra-screening,
+# the workflow advances to the confirmation stage.
+waitFor:
+  kind: Workflow
+  name: test-bw-invalid-expr
+  namespace: default
+  condition: Failed
+  reason: IterationsFailed
+collect:
+  - kind: Workflow
+    name: test-bw-invalid-expr
+    namespace: default

--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/expected.json
@@ -1,0 +1,137 @@
+{
+  "Workflow/test-bw-missing-bm": {
+    "kind": "Workflow",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-bw-missing-bm",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "test-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "test-image:latest",
+                "command": [
+                  "mpirun"
+                ],
+                "numNodes": 2
+              },
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true"
+          }
+        },
+        "diagnose": {
+          "minGroupSize": 2,
+          "topologyKey": "nvidia.com/gpu.clique"
+        },
+        "execution": {},
+        "iterations": 1
+      },
+      "validation": {
+        "performance": {
+          "enabled": true,
+          "tracking": {},
+          "thresholds": {
+            "thresholds": {
+              "busBandwidthGBps": "value \u003e= 400"
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobRunning",
+          "message": "Iteration 1/1: 0 groups running"
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        }
+      ],
+      "orchestration": {
+        "totalNodes": 4,
+        "nodesPerJob": 2,
+        "totalGroups": 2,
+        "currentIteration": 1,
+        "detectedPlatform": "onprem",
+        "detectedGPUArchitecture": "unknown",
+        "diagnose": {
+          "stage": "intra-screening",
+          "round": 0
+        },
+        "groups": [
+          {
+            "name": "screen-0",
+            "nodes": [
+              "node-a1",
+              "node-a2"
+            ],
+            "domains": [
+              "clique-a"
+            ],
+            "phase": "Succeeded",
+            "jobRef": {
+              "apiVersion": "cre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-bw-missing-bm-screen-0-iter-1",
+              "namespace": "default"
+            }
+          },
+          {
+            "name": "screen-1",
+            "nodes": [
+              "node-b1",
+              "node-b2"
+            ],
+            "domains": [
+              "clique-b"
+            ],
+            "phase": "Succeeded",
+            "jobRef": {
+              "apiVersion": "cre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-bw-missing-bm-screen-1-iter-1",
+              "namespace": "default"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/input_client_objects.yaml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for the bandwidth gate fail-open bug (issue #5).
+# screen-0 has a valid BandwidthMeasurement. screen-1 has NO BandwidthMeasurement
+# at all (the CR was never created). Previously isBelowBandwidthThreshold would
+# return (false, false) for screen-1 — treating it as "threshold passed" and
+# marking both nodes healthy. After the fix it returns (false, true) — pending —
+# so collectDiagnoseRoundResults requeues without advancing the diagnose stage.
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-a1
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-a
+    kubernetes.io/hostname: node-a1
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-a2
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-a
+    kubernetes.io/hostname: node-a2
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-b1
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-b
+    kubernetes.io/hostname: node-b1
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-b2
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.clique: clique-b
+    kubernetes.io/hostname: node-b2
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-bw-missing-bm
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - mpirun
+            numNodes: 2
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+    diagnose:
+      minGroupSize: 2
+      topologyKey: nvidia.com/gpu.clique
+  validation:
+    performance:
+      enabled: true
+      thresholds:
+        thresholds:
+          busBandwidthGBps: "value >= 400"
+status:
+  orchestration:
+    totalNodes: 4
+    nodesPerJob: 2
+    totalGroups: 2
+    currentIteration: 1
+    detectedPlatform: onprem
+    detectedGPUArchitecture: unknown
+    diagnose:
+      stage: intra-screening
+      round: 0
+    groups:
+      - name: screen-0
+        nodes: [node-a1, node-a2]
+        domains: [clique-a]
+        phase: Running
+        jobRef:
+          apiVersion: cre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-bw-missing-bm-screen-0-iter-1
+          namespace: default
+      - name: screen-1
+        nodes: [node-b1, node-b2]
+        domains: [clique-b]
+        phase: Running
+        jobRef:
+          apiVersion: cre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-bw-missing-bm-screen-1-iter-1
+          namespace: default
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-bw-missing-bm-screen-0-iter-1
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: cluster-readiness-engine
+    cre.nvidia.com/workflow: test-bw-missing-bm
+    cre.nvidia.com/group: screen-0
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - mpirun
+        numNodes: 2
+status:
+  conditions:
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadCompleted
+      message: "Workload completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Failed
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-bw-missing-bm-screen-1-iter-1
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: cluster-readiness-engine
+    cre.nvidia.com/workflow: test-bw-missing-bm
+    cre.nvidia.com/group: screen-1
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - mpirun
+        numNodes: 2
+status:
+  conditions:
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadCompleted
+      message: "Workload completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Failed
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+---
+# BandwidthMeasurement for screen-0 only — screen-1 has no BandwidthMeasurement.
+apiVersion: cre.nvidia.com/v1alpha1
+kind: BandwidthMeasurement
+metadata:
+  name: test-bw-missing-bm-screen-0-bw
+  namespace: default
+spec:
+  jobRef:
+    apiGroup: cre.nvidia.com
+    kind: Job
+    name: test-bw-missing-bm-screen-0-iter-1
+  logProfileRef: nccl-bandwidth
+  testType: all_reduce
+status:
+  results:
+    - sizeBytes: 17179869184
+      algBW: "300.00"
+      busBW: "500.00"
+      samples: 5

--- a/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-bw-threshold-missing-bm/input_config.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# screen-1 has no BandwidthMeasurement; the workflow must requeue without
+# advancing past intra-screening or marking any nodes healthy.
+waitFor:
+  kind: Workflow
+  name: test-bw-missing-bm
+  namespace: default
+  condition: InProgress
+collect:
+  - kind: Workflow
+    name: test-bw-missing-bm
+    namespace: default

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -519,31 +519,30 @@ func buildTolerations(selectors []burninv1alpha1.TaintSelector) []corev1.Tolerat
 
 // hasRunningGroups returns true if any group is in Running phase.
 // isBelowBandwidthThreshold checks if a Job's BandwidthMeasurement peak BusBW
-// fails the given CEL threshold expression. Returns (below, pending) where
-// pending=true means a measurement exists but has no results yet.
-func (r *WorkflowReconciler) isBelowBandwidthThreshold(ctx context.Context, jobName, namespace, expr string) (below bool, pending bool) {
+// fails the given CEL threshold expression. Returns (below, pending, err) where:
+//   - pending=true means to requeue and try again later (BM absent or has no results yet)
+//   - err!=nil means the gate could not be evaluated; the caller should fail closed
+func (r *WorkflowReconciler) isBelowBandwidthThreshold(ctx context.Context, jobName, namespace, expr string) (below bool, pending bool, err error) {
 	var bwList burninv1alpha1.BandwidthMeasurementList
-	if err := r.List(ctx, &bwList, client.InNamespace(namespace)); err != nil {
-		return false, false
+	if listErr := r.List(ctx, &bwList, client.InNamespace(namespace)); listErr != nil {
+		return false, false, fmt.Errorf("list BandwidthMeasurements: %w", listErr)
 	}
 	for _, bm := range bwList.Items {
 		if bm.Spec.JobRef.Name != jobName {
 			continue
 		}
 		if len(bm.Status.Results) == 0 {
-			return false, true
+			return false, true, nil
 		}
-		last := bm.Status.Results[len(bm.Status.Results)-1]
-		var measured float64
-		_, _ = fmt.Sscanf(last.BusBW, "%f", &measured)
-		passed, err := threshold.Evaluate(measured, expr)
-		if err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to evaluate bandwidth threshold", "job", jobName)
-			return false, false
+		measured := maxBusBandwidth(bm.Status.Results)
+		passed, evalErr := threshold.Evaluate(measured, expr)
+		if evalErr != nil {
+			return false, false, fmt.Errorf("evaluate bandwidth threshold for job %s: %w", jobName, evalErr)
 		}
-		return !passed, false
+		return !passed, false, nil
 	}
-	return false, false
+	// No BandwidthMeasurement found for this job yet — requeue and wait for it.
+	return false, true, nil
 }
 
 // deleteWorkloadForJob deletes the workload (e.g., TrainJob) referenced by a Job
@@ -2219,7 +2218,14 @@ func (r *WorkflowReconciler) collectDiagnoseRoundResults(
 		switch g.Phase {
 		case burninv1alpha1.GroupSucceeded:
 			if bwThresholdExpr != "" && g.JobRef != nil {
-				below, pending := r.isBelowBandwidthThreshold(ctx, g.JobRef.Name, workflow.Namespace, bwThresholdExpr)
+				below, pending, bwErr := r.isBelowBandwidthThreshold(ctx, g.JobRef.Name, workflow.Namespace, bwThresholdExpr)
+				if bwErr != nil {
+					log.Error(bwErr, "Bandwidth threshold could not be evaluated, treating group as failed", "group", g.Name)
+					failedGroups = append(failedGroups, orchestration.Group{
+						Name: g.Name, Nodes: g.Nodes, Domains: g.Domains,
+					})
+					continue
+				}
 				if pending {
 					log.V(1).Info("Bandwidth measurement pending for group, requeueing", "group", g.Name)
 					return nil, true


### PR DESCRIPTION
## Summary

- `isBelowBandwidthThreshold` returned `(false, false)` — "threshold passed" — in three error/missing-data cases, silently certifying nodes without any measurement being evaluated
- Widened return signature to `(below, pending bool, err error)` so callers can distinguish pass, pending (requeue), and error (fail closed)
- Switched from reading the last `BusBW` entry via `fmt.Sscanf` to `maxBusBandwidth` (peak across all results), matching the reference implementation in `checkPerformanceThresholds`

## Behavior change

| Case | Before | After |
|---|---|---|
| `r.List` API error | `(false, false)` → silently passes gate | error → group treated as failed |
| No matching `BandwidthMeasurement` CR | `(false, false)` → silently passes gate | `pending=true` → requeue |
| CEL expression fails to evaluate | `(false, false)` → silently passes gate | error → group treated as failed |
| BM exists, empty results | `(false, true)` → requeue | unchanged |
| BM exists, results present | normal evaluation via last entry | unchanged, uses `maxBusBandwidth` (peak) |

## Test plan

- [x] `TestIntegration/reconcile/workflow-bw-threshold-missing-bm` — no `BandwidthMeasurement` CR → requeue, stage does not advance, no nodes in `healthyNodes`
- [x] `TestIntegration/reconcile/workflow-bw-threshold-invalid-expr` — invalid CEL expression → workflow fails closed with `IterationsFailed`, no nodes in `healthyNodes`
- [x] Existing `diagnose-threshold-pass` and `diagnose-threshold-fail` pass unmodified (regression guard)
- [x] `make test` — full suite green

Closes #5