### PR TITLE
fix: wire JobReconciler event recorder and surface measurement failures

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,6 +179,7 @@ func newRootCommand() *cobra.Command {
 				Client:    mgr.GetClient(),
 				Scheme:    mgr.GetScheme(),
 				Clientset: clientset,
+				Recorder:  mgr.GetEventRecorder("job-controller"),
 			}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("unable to create controller Job: %w", err)
 			}

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -77,6 +77,13 @@ const (
 	ReasonWorkloadCreationError = "WorkloadCreationError"
 	ReasonWorkloadStalled       = "WorkloadStalled"
 
+	// ReasonMeasurementCreationError indicates a GoodputMeasurement or
+	// BandwidthMeasurement child resource could not be created. Handling is
+	// non-fatal, so this event is the operator-visible signal; a threshold that
+	// depends on the missing measurement still fails closed via
+	// ReasonMeasurementTimeout.
+	ReasonMeasurementCreationError = "MeasurementCreationError"
+
 	ReasonHardwareFailureDetected = "HardwareFailureDetected"
 )
 

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -270,13 +270,20 @@ func (r *JobReconciler) reconcileWorkload(ctx context.Context, job *burninv1alph
 
 	// If we already have a workload reference in status, check its status
 	if job.Status.WorkloadRef != nil {
+		// These stay non-fatal so a measurement problem cannot block workload
+		// status updates. Correctness is preserved by checkPerformanceThresholds,
+		// which fails closed when a configured threshold has no measured value.
+		// The event exists so a persistent creation failure is visible rather
+		// than only appearing later as an opaque MeasurementTimeout.
 		if err := r.ensureGoodputMeasurement(ctx, job); err != nil {
 			logf.FromContext(ctx).Error(err, "Failed to ensure GoodputMeasurement")
-			// Non-fatal: don't block workload status updates
+			r.warnf(job, ReasonMeasurementCreationError,
+				"Failed to ensure GoodputMeasurement: %v", err)
 		}
 		if err := r.ensureBandwidthMeasurement(ctx, job); err != nil {
 			logf.FromContext(ctx).Error(err, "Failed to ensure BandwidthMeasurement")
-			// Non-fatal: don't block workload status updates
+			r.warnf(job, ReasonMeasurementCreationError,
+				"Failed to ensure BandwidthMeasurement: %v", err)
 		}
 		return r.updateStatusFromWorkload(ctx, job)
 	}
@@ -333,10 +340,8 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *burninv
 		// Do not mark the Job as Failed — creation errors are transient
 		// (e.g. webhook denial because TrainingRuntime isn't ready yet).
 		log.Error(err, "Failed to create workload, will retry", "kind", gvk.Kind, "name", workloadName)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(job, nil, corev1.EventTypeWarning, ReasonWorkloadCreationError,
-				ReasonWorkloadCreationError, "Failed to create %s/%s: %v", gvk.Kind, workloadName, err)
-		}
+		r.warnf(job, ReasonWorkloadCreationError,
+			"Failed to create %s/%s: %v", gvk.Kind, workloadName, err)
 		return ctrl.Result{}, fmt.Errorf("failed to create workload: %w", err)
 	}
 
@@ -1255,6 +1260,18 @@ func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *bur
 	}
 
 	return nil
+}
+
+// warnf emits a Warning event if the Recorder is configured. Every Job-tier
+// event is a warning; the Workflow reconciler's eventf takes an explicit type
+// because it emits Normal events too.
+//
+// Safe to call when Recorder is nil (e.g. in unit tests, or any embedding that
+// constructs JobReconciler directly).
+func (r *JobReconciler) warnf(obj runtime.Object, reason, messageFmt string, args ...any) {
+	if r.Recorder != nil {
+		r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, reason, reason, messageFmt, args...)
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controller/job_event_test.go
+++ b/pkg/controller/job_event_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+)
+
+// TestJobWarnfNilRecorder pins that warnf tolerates an unset Recorder.
+// It is called from reconcileWorkload and createWorkloadFromSpec, both of which
+// run in tests and in any embedding that constructs JobReconciler directly, so a
+// nil dereference here would panic the reconcile loop rather than drop an event.
+func TestJobWarnfNilRecorder(t *testing.T) {
+	t.Parallel()
+
+	r := &JobReconciler{} // Recorder deliberately unset
+	job := &burninv1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"},
+	}
+
+	r.warnf(job, ReasonMeasurementCreationError,
+		"Failed to ensure BandwidthMeasurement: %v", errNilRecorderProbe)
+}
+
+// errNilRecorderProbe is a sentinel used only to exercise the formatting path.
+var errNilRecorderProbe = &probeError{}
+
+type probeError struct{}
+
+func (e *probeError) Error() string { return "probe" }


### PR DESCRIPTION
## Problem

`JobReconciler` declares a `Recorder` field, but `cmd/manager/main.go` never populated it — only `WorkflowReconciler` got one:

```go
if err := (&controller.JobReconciler{
    Client:    mgr.GetClient(),
    Scheme:    mgr.GetScheme(),
    Clientset: clientset,
    // no Recorder
}).SetupWithManager(mgr); err != nil {
```

So the nil guard at the workload-creation site always evaluated false, and the existing `ReasonWorkloadCreationError` event has **never been emitted in production**.

While wiring it, a second silent gap: `ensureGoodputMeasurement` and `ensureBandwidthMeasurement` failures are logged and deliberately swallowed —

```go
if err := r.ensureBandwidthMeasurement(ctx, job); err != nil {
    logf.FromContext(ctx).Error(err, "Failed to ensure BandwidthMeasurement")
    // Non-fatal: don't block workload status updates
}
```

That handling is *correct*. Correctness is preserved by `checkPerformanceThresholds`, which fails closed when a configured threshold has no measured value. But it left operators with no signal at the moment of failure — a persistent creation problem (RBAC, admission, quota) only resurfaced later as an opaque `MeasurementTimeout`, pointing at the measurement rather than at the reason it never existed.

## Changes

- Wire `Recorder: mgr.GetEventRecorder("job-controller")` in `cmd/manager/main.go`.
- Add `JobReconciler.warnf`, a nil-safe Warning emitter mirroring the Workflow reconciler's `eventf`. The existing inline `if r.Recorder != nil` block now uses it.
- Emit `ReasonMeasurementCreationError` when a measurement child resource cannot be created.

`warnf` takes no event-type parameter because every Job-tier event is a warning — `unparam` flags the unused parameter otherwise. The Workflow reconciler's `eventf` keeps its explicit type since it also emits `Normal` events.

This is an observability change only. No reconcile behaviour, condition, or status field changes; the measurement failures stay non-fatal exactly as before.

## Tests

`TestJobWarnfNilRecorder` pins nil-safety. `warnf` is called from `reconcileWorkload` and `createWorkloadFromSpec`, both of which run with an unset `Recorder` in tests and in any embedding that constructs `JobReconciler` directly — so a nil dereference would panic the reconcile loop rather than drop an event. There is no existing event-testing precedent in the repo (`WorkflowReconciler.eventf` is untested), so this deliberately adds no fake-recorder machinery.

## Verification

| Check | Result |
|---|---|
| `make manifests generate` | no drift |
| `go build ./...` | pass |
| `make lint` | 0 issues |
| unit tests | pass |
| integration (102 cases) | pass, 115.4s |

## Note on scope

This branch originally also proposed removing the Workflow-tier bandwidth threshold evaluation as redundant with the Job tier (issue #5). That is dropped: `main` has since repaired `isBelowBandwidthThreshold` directly — fail-closed on List/CEL errors, `pending` when the measurement is absent, and `maxBusBandwidth` instead of the last sample — and added `workflow-bw-threshold-missing-bm` and `workflow-bw-threshold-invalid-expr` to lock that behaviour in. Those tests also establish that a threshold configured without a `BandwidthMeasurement` is a supported wait-and-retry state rather than a misconfiguration, so a proposed CEL rule rejecting that combination was dropped as well.

What remains here is independent of that design and conflicts with none of it.
