### PR TITLE
docs: fix CLAUDE.md sample cert and ADR range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ spec:
     nodeSelector:
       nvidia.com/gpu.product: NVIDIA-GB300  # NVIDIA-GB200, NVIDIA-GB300, or NVIDIA-H100-80GB-HBM3
   nodesPerJob: 8
-  enableMNNVL: false  # true for GB200 (MNNVL), false for GB300 (RoCE) and H100
+  enableMNNVL: false  # GB200: true (MNNVL); GB300: true for intra-rack (MNNVL), false for inter-rack (RoCE); H100: false
   imagePullSecrets:
     - name: ngc-secret
   categories:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ spec:
     nodeSelector:
       nvidia.com/gpu.product: NVIDIA-GB300  # NVIDIA-GB200, NVIDIA-GB300, or NVIDIA-H100-80GB-HBM3
   nodesPerJob: 8
-  enableMNNVL: false  # GB200: true (MNNVL); GB300: true for intra-rack (MNNVL), false for inter-rack (RoCE); H100: false
+  enableMNNVL: true   # true for GB200/GB300 (multi-node NVLink), false for H100 and others
   imagePullSecrets:
     - name: ngc-secret
   categories:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,8 @@ spec:
   target:
     nodeSelector:
       nvidia.com/gpu.product: NVIDIA-GB300  # NVIDIA-GB200, NVIDIA-GB300, or NVIDIA-H100-80GB-HBM3
-  enableMNNVL: true   # true for GB200/GB300, false for H100
+  nodesPerJob: 8
+  enableMNNVL: false  # true for GB200 (MNNVL), false for GB300 (RoCE) and H100
   imagePullSecrets:
     - name: ngc-secret
   categories:
@@ -209,7 +210,6 @@ spec:
       variant: nemotron5-8b
       options:
         maxSteps: 50
-        nodesPerJob: 8
 ```
 
 ### Render and Verify
@@ -251,4 +251,4 @@ spec:
 
 ## Design Decisions
 
-Architecture decision records are in `docs/designs/` (ADR-000 through ADR-053). Read these before making significant changes to understand why things are the way they are.
+Architecture decision records are in `docs/designs/` (ADR-000 through ADR-069). Read these before making significant changes to understand why things are the way they are.


### PR DESCRIPTION
## Summary

Two corrections to the CLAUDE.md developer guide:

- **`nodesPerJob` placement** — was nested under `categories[].options` in the sample cert YAML; it is a top-level `spec.nodesPerJob` field
- **ADR range** — updated from "ADR-000 through ADR-053" to "ADR-000 through ADR-069" to reflect current state of `docs/designs/`

The `enableMNNVL` comment is unchanged — both GB200 and GB300 correctly default to `true` (multi-node NVLink).

## Test plan

- [ ] Sample YAML in CLAUDE.md is valid against the `CertificationSpec` API