### PR TITLE
chore: add community health files

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configuration for the DCO check (https://github.com/probot/dco).
+# External contributors must sign off their commits (git commit -s).
+# Members of the NVIDIA organization are exempt.
+
+require:
+  members: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,75 +2,131 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate
-to the circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident. Further details of specific enforcement policies
-may be posted separately.
+reported to the community leaders responsible for enforcement at
+**GitHub_Conduct@nvidia.com**.
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,10 +100,11 @@ Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `ci`,
    make manifests generate
    ```
 
-3. Run tests (downloads envtest binaries on first run):
+3. Run the tests:
    ```bash
    make test
    ```
+   You do not need a Kubernetes cluster. The `make test` target installs envtest, which has a lightweight etcd and kube-apiserver for the integration tests.
 
 4. Run linting:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Before contributing:
 1. Read the [README.md](README.md) to understand the project
 2. Check existing [issues](../../issues) to avoid duplicates
 3. Review the [security policy](SECURITY.md) for security-related contributions
-4. Review the [code of conduct](CODE_OF_CONDUCT.md)
+4. Review the [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## How to Contribute
 
@@ -22,14 +22,25 @@ Ways to contribute:
 - Fix issues with code contributions
 - Add new workload adapters or catalog entries
 
+## Issue-First Workflow
+
+Open an issue before you write code:
+
+1. File an issue that describes the bug or the feature.
+2. Wait for a maintainer to acknowledge it and agree on the approach.
+3. Comment on the issue that you are working on it.
+4. Reference the issue from your pull request (`Closes #NNN`).
+
+This protects your time: it prevents duplicate work and PRs that conflict with planned changes. **Pull requests without a linked, acknowledged issue may be closed unreviewed.** Trivial fixes (typos, broken links) are exempt.
+
 ## Reporting Issues
 
 When reporting issues:
 
-1. Use the issue templates when available
+1. Use the issue templates — they ask for what we need
 2. Provide clear reproduction steps
-3. Include environment details (Kubernetes version, GPU type, workload framework version)
-4. Add relevant logs or error messages
+3. Include environment details (CRE version, Kubernetes version, GPU architecture, platform)
+4. Add relevant logs or error messages, with secrets removed
 5. Search existing issues first to avoid duplicates
 
 ## Submitting Pull Requests
@@ -38,21 +49,41 @@ When reporting issues:
 2. Follow the coding standards and existing patterns
 3. Write or update tests for your changes
 4. Update documentation if needed
-5. Sign your commits (see DCO section below)
-6. Submit a pull request with a clear description
+5. Sign your commits (see the DCO section below)
+6. Fill in the pull request template, including the test plan and risk assessment
 
 **Pull Request Guidelines**:
 - Keep PRs focused on a single issue or feature
-- Write clear, descriptive commit messages
 - Include tests for new functionality
 - Ensure all CI checks pass
 - Be responsive to feedback and code review
+
+## Commit Message Format
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Format the subject line as `type: short imperative summary`:
+
+```
+feat: add bandwidth threshold option to nccl catalog entries
+fix: requeue workflow when dependency resources are not ready
+docs: document checkpoint restart behavior
+test: add integration case for job iteration limits
+chore: bump controller-runtime to v0.22
+```
+
+Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `ci`, `build`. Use the body to explain *why* the change is needed. Every commit also carries a DCO sign-off line (`git commit -s`).
+
+## Code Review Process
+
+- A project maintainer reviews every pull request. CODEOWNERS assigns reviewers automatically once your PR is open.
+- Expect a first response within **5 business days**. Reviews of large PRs take longer — splitting work into small PRs gets you faster feedback.
+- Address review comments with new commits (do not force-push during review; we squash on merge).
+- If a PR sits without response for more than a week, add a comment to ping the reviewers. Escalate by mentioning the maintainers listed in MAINTAINERS.md.
+- Merging requires: green CI, an approving maintainer review, and the DCO check passing.
 
 ## Development Setup
 
 **Prerequisites**:
 - Go 1.26+
-- Kubernetes cluster (for integration testing via envtest)
 - Docker (for container builds)
 - Make (for build targets)
 
@@ -60,7 +91,7 @@ When reporting issues:
 
 1. Clone the repository:
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/NVIDIA/cluster-readiness-engine.git
    cd cluster-readiness-engine
    ```
 
@@ -69,7 +100,7 @@ When reporting issues:
    make manifests generate
    ```
 
-3. Run tests:
+3. Run tests (downloads envtest binaries on first run):
    ```bash
    make test
    ```
@@ -79,9 +110,10 @@ When reporting issues:
    make lint
    ```
 
-5. Build the binary:
+5. Build the binaries:
    ```bash
-   make build
+   make build          # controller manager -> bin/manager
+   make build-ncrectl  # CLI -> bin/ncrectl
    ```
 
 **Running a single test**:
@@ -95,12 +127,31 @@ KUBEBUILDER_ASSETS="$(bin/setup-envtest use -p path)" \
   go test ./cmd/integration/ -v -timeout 300s -count=1 -run TestReconcile/job-checkpoint-restart
 ```
 
+## AI-Assisted Contributions
+
+You may use AI tools (Claude, Copilot, and similar) to help write contributions, under these rules:
+
+- **You are accountable for the change.** Submit only code you have read, understood, and tested yourself.
+- AI-assisted PRs get the same review bar as any other PR — no exceptions.
+- Do not open PRs that are unreviewed AI output. Low-effort machine-generated PRs are closed under the issue-first rule.
+- The DCO sign-off certifies that *you* have the right to submit the contribution. That certification is yours, not the tool's.
+
 ## Community Guidelines
 
 - Be respectful and inclusive in all interactions
 - Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
 - Help maintain a welcoming environment
 - Focus on constructive feedback in reviews
+
+### Code of Conduct Enforcement
+
+Report Code of Conduct violations to **GitHub_Conduct@nvidia.com**.
+
+- Reports are **acknowledged within 3 business days**.
+- The maintainers review the report, gather context from all parties, and **decide on a resolution within 14 days**. Outcomes follow the enforcement ladder in the [Code of Conduct](CODE_OF_CONDUCT.md): correction, warning, temporary ban, or permanent ban.
+- Reporter identity stays confidential.
+
+**Out of scope for CoC enforcement**: technical disagreements argued respectfully, code review feedback about the code (not the person), and conduct on platforms unrelated to this project. Those are handled through normal project discussion, not the CoC process.
 
 ## Developer Certificate of Origin
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+cluster-readiness-engine
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This product includes software developed at NVIDIA CORPORATION
+(https://www.nvidia.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Third-party dependency attributions are listed in THIRD_PARTY_NOTICES.md.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,52 @@ To report a potential security vulnerability in any NVIDIA product:
 
 NVIDIA offers acknowledgement for externally reported security issues under our coordinated vulnerability disclosure policy. Visit [PSIRT Policies](https://www.nvidia.com/en-us/security/psirt-policies/) for details.
 
+## Response Expectations
+
+- Reports submitted through the channels above are **acknowledged within 5 business days**.
+- NVIDIA PSIRT coordinates triage, remediation, and disclosure with the reporter under the [coordinated vulnerability disclosure policy](https://www.nvidia.com/en-us/security/psirt-policies/).
+
+## Supported Versions
+
+Security fixes land on `main` and are released in the latest minor release line.
+
+| Version | Supported |
+| --- | --- |
+| Latest `v0.x` minor release | ✅ |
+| Older releases | ❌ — upgrade to the latest release |
+
+While CRE is pre-1.0, we do not backport fixes to older minor versions.
+
+## Vulnerability Fix Timelines
+
+Once a vulnerability in CRE is confirmed:
+
+- **Critical / High severity**: a fix or a documented mitigation ships within **30 days** of confirmation.
+- **Medium / Low severity**: a fix ships in the next scheduled release.
+
+CVEs affecting CRE are published through the NVIDIA PSIRT process (NVIDIA is a CVE Numbering Authority).
+
+## Scope
+
+In scope: vulnerabilities in CRE itself — the controller, the `ncrectl` CLI, the Helm chart, and the container images this repository publishes.
+
+Out of scope:
+
+- Vulnerabilities requiring physical access to cluster nodes
+- Social engineering of maintainers or users
+- Denial of service that requires cluster-admin or the ability to schedule arbitrary workloads
+- Theoretical issues without a proof of concept or demonstrated impact
+- Vulnerabilities in third-party dependencies without a demonstrated impact on CRE (report those upstream; we still welcome a heads-up)
+
+## Reporter Credit
+
+We credit reporters of confirmed vulnerabilities in the release notes of the fixed version and in the NVIDIA security bulletin, unless the reporter asks not to be named.
+
+## Supply Chain
+
+- CRE is licensed under Apache-2.0. Dependencies are reviewed for license compatibility with Apache-2.0; attributions are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+- Release artifacts (container images, `ncrectl` binaries, Helm chart) will be signed with Sigstore cosign and ship with SBOMs and build provenance as part of the CI release pipeline. Verification commands will be documented here when the first signed release is published.
+
 ## Product Security Resources
 
 For all security-related concerns: https://www.nvidia.com/en-us/security


### PR DESCRIPTION
## Summary

This PR prepares the repository for contributions from the public. It is one part of the open source readiness plan.

- CONTRIBUTING.md: adds an issue-first rule, the Conventional Commits format, the review process with expected response times, a policy for AI-assisted contributions, and the Code of Conduct enforcement timelines. We acknowledge a report in 3 business days and resolve it in 14 days.
- CODE_OF_CONDUCT.md: upgrades the Contributor Covenant from v1.4 to v2.1 and adds the enforcement ladder. The contact stays GitHub_Conduct@nvidia.com.
- SECURITY.md: adds response times, a table of supported versions, fix timelines (30 days for critical and high severity), the scope, a reporter credit policy, and a statement about the software supply chain. The PSIRT reporting section did not change.
- .github/dco.yml: configures the DCO check. NVIDIA org members are exempt.
- NOTICE: gives the Apache-2.0 attribution.

This PR does not include issue or PR templates. Commit 29bea52 added them, and this branch sits on top of that commit.

## Type of Change

Documentation and community files. No code changes.

## Testing

- The YAML in .github/dco.yml parses without errors.
- The markdown files render correctly in preview.
- No Go code changed. Lint, build, and test are not affected.

## Risk

Low. The PR adds files and rewrites documentation. The DCO check starts only after someone installs the DCO GitHub App on this repository.

## Notes

- CONTRIBUTING.md refers to MAINTAINERS.md. PR #10 adds that file.
- SECURITY.md tells reporters to use the NVIDIA PSIRT process. The issue chooser from commit 29bea52 points to GitHub private advisories. The team must choose one channel, or document both.