### PR TITLE
docs: add MAINTAINERS.md and GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,46 @@
+# Governance
+
+This document describes how the cluster-readiness-engine (CRE) project makes decisions and how contributors gain responsibility.
+
+## Scope and Charter
+
+CRE is a Kubernetes controller and CLI for GPU cluster burn-in certification: it runs cataloged training and communication workloads against a cluster, measures goodput and bandwidth, and remediates failing nodes. Changes that serve this charter are in scope. Features unrelated to cluster certification are out of scope and are declined, with reasons, in the issue discussion.
+
+## Roles
+
+### Contributor
+
+Anyone who files an issue, improves documentation, or submits a pull request. No formal membership is required. Contributors follow the [contribution workflow](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+### Reviewer
+
+A contributor with a track record of quality contributions who reviews pull requests in one or more areas.
+
+- **How to become one**: sustained contributions over roughly 3 months — several merged PRs and helpful reviews — then nomination by a maintainer.
+- **Responsibilities**: review PRs for correctness and fit with project patterns; a reviewer approval is input to, not a substitute for, the maintainer approval that merges a PR.
+
+### Maintainer
+
+A reviewer trusted with merge rights and project direction. Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+- **How to become one**: act as a reviewer for roughly 3 months, then be nominated by an existing maintainer and approved by a majority vote of the current maintainers. The path is open to external (non-NVIDIA) contributors.
+- **Responsibilities**: review and merge PRs, triage issues, cut releases, maintain CI health, uphold the Code of Conduct, and mentor contributors.
+
+## Decision Making
+
+- **Default: lazy consensus.** Most decisions happen in issues and pull requests. A change is accepted when a maintainer approves it and no maintainer objects within 3 business days of the approval. Routine changes merge on approval.
+- **Significant changes** (CRD schema changes, new subsystems, dependency policy, governance itself) require an issue describing the design, and approval from a majority of maintainers. Design records live in `docs/designs/`.
+- **Voting.** When consensus fails, any maintainer may call a vote in the issue. Each maintainer has one vote; a majority of all current maintainers decides. Votes stay open for 5 business days or until the outcome cannot change.
+- **Tie-breaking.** If a vote ties, the maintainers discuss it synchronously and re-vote once. If it ties again, the change is rejected in its current form — the status quo wins, and the proposal returns to design discussion.
+
+## Adding and Removing Maintainers
+
+- **Adding**: nomination by an existing maintainer, then a majority vote of current maintainers. The nominee's contribution and review history is the evidence.
+- **Stepping down**: maintainers may step down at any time by opening a PR that moves them to the emeritus section of MAINTAINERS.md.
+- **Removal for inactivity**: a maintainer with no project activity (reviews, merges, issue triage) for 6 consecutive months moves to emeritus after an attempt to reach them.
+- **Removal for cause**: Code of Conduct violations or repeated abuse of maintainer rights lead to removal by majority vote of the other maintainers.
+- **Emeritus**: emeritus maintainers are listed in MAINTAINERS.md with our thanks. They may return to active status by a majority vote of current maintainers.
+
+## Amending This Document
+
+Changes to governance follow the significant-change process above: an issue, discussion, and a majority vote of maintainers. Amendments merge as ordinary pull requests to this file.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Maintainers
+
+Maintainers are responsible for reviewing and merging changes, triaging issues, cutting releases, and upholding the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+| Name | GitHub | Areas |
+|---|---|---|
+| Ebot Ndip-Agbor | [@endipagbor](https://github.com/endipagbor) | Project-wide: controllers (`pkg/controller/`), catalog (`pkg/catalog/`), workload adapters (`pkg/workload/`), CLI (`cmd/ncrectl/`), Helm chart (`helm/`), CI |
+| Lalit Adithya | [@lalitadithya](https://github.com/lalitadithya) | Project-wide: controllers (`pkg/controller/`), catalog (`pkg/catalog/`), workload adapters (`pkg/workload/`), CLI (`cmd/ncrectl/`), Helm chart (`helm/`), CI |
+
+While the maintainer group is small, both maintainers share ownership of all areas. Per-area ownership splits as the group grows.
+
+## Becoming a Maintainer
+
+The path from contributor to maintainer, and the process for adding and removing maintainers, is documented in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Emeritus Maintainers
+
+None yet. Maintainers who step down or become inactive move here with our thanks, as described in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Contact
+
+- Open an [issue](../../issues) for bugs and features
+- Use [GitHub Discussions](../../discussions) for questions
+- Report security issues per [SECURITY.md](SECURITY.md) — never through GitHub
+- Report Code of Conduct violations to GitHub_Conduct@nvidia.com


### PR DESCRIPTION
## Summary

This PR adds the two governance files from the open source readiness plan. It also supplies the MAINTAINERS.md file that PR #9 refers to.

- MAINTAINERS.md names the maintainers with their GitHub handles and areas. The maintainers are Ebot Ndip-Agbor (@endipagbor) and Lalit Adithya (@lalitadithya). Both own all areas while the group is small. The file also has an emeritus section and the contact routes.
- GOVERNANCE.md documents the project scope, the contributor, reviewer, and maintainer roles, and the promotion criteria. It documents the decision process, the tie-break rule, and the steps to add, remove, or retire a maintainer. The default decision process is lazy consensus, which means a change is accepted if no maintainer objects in 3 business days. The path to maintainer is open to external contributors.

The model comes from NVIDIA/NVSentinel, reduced for a project with two maintainers.

## Type of Change

Documentation. No code changes.

## Testing

- The markdown renders correctly in preview.
- All relative links point to files on main or in PR #9.

## Risk

Low. The PR adds two files. It does not change existing files.

## Notes

- Merge PR #9 first, or merge both together. The contact section refers to content that PR #9 adds.
- Split the ownership areas by path when the maintainer group grows.