### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Code owners are requested for review automatically on every pull request.
+# Later entries win over earlier ones. Refine per-path ownership as the
+# maintainer group grows (see MAINTAINERS.md).
+
+* @endipagbor @lalitadithya


### PR DESCRIPTION
## Summary

This PR adds .github/CODEOWNERS. It assigns both maintainers (@endipagbor and @lalitadithya) as owners of all paths. It pairs with PR #10, which names the same people in MAINTAINERS.md.

## Type of Change

Repository configuration. No code changes.

## Testing

- The file follows the CODEOWNERS syntax. It has comments and one rule.
- GitHub requests reviews from the owners only when they have write access to this repository.

## Risk

Low. The PR adds one file. The branch protection option "Require review from Code Owners" is a repository setting. Apply that setting separately.