### PR TITLE
docs: expand the README for open source readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
-# CRE
+# Cluster Readiness Engine (CRE)
 
-A Kubernetes controller for GPU cluster certification, orchestrated benchmarking, and hardware failure detection. Run real distributed workloads across topology-aware node groups, measure training performance, detect hardware failures, and automatically quarantine bad nodes — before production workloads touch the cluster.
+[![CI](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
+
+New GPU clusters often contain faulty nodes, and those faults surface only under real distributed load. CRE is a Kubernetes controller that certifies GPU clusters before production workloads run on them. It runs real training and communication workloads across topology-aware node groups, measures performance, detects hardware failures, and quarantines bad nodes.
+
+CRE is for platform and infrastructure teams that bring up, validate, or resell GPU clusters.
+
+## Features
+
+- A certification catalog with NCCL communication tests and multi-node training workloads
+- Platform detection (AWS, GCP, Azure, TogetherAI) and GPU architecture detection (GB200, GB300, H100)
+- Goodput measurement parsed from training logs with configurable LogProfile patterns
+- Per-bus bandwidth measurement parsed from NCCL logs
+- Node health monitoring with CEL expressions while workloads run
+- Automatic remediation of failed nodes (taint and cordon, reversed on deletion)
+- Topology-aware node grouping and adaptive fault isolation
+- Checkpoint restart for training jobs
+- WorkloadRun, a single resource to run a training, NCCL, or custom workload
+- The `ncrectl` CLI for setup, render, run, report, and cleanup
+
+## How it works
+
+The APIs compose like Deployment, ReplicaSet, and Pod:
+
+```mermaid
+flowchart LR
+    C[Certification] -->|one per catalog category| W[Workflow]
+    W -->|one| J[Job]
+    J -->|adapter| T[TrainJob and other workloads]
+    J -.-> G[GoodputMeasurement]
+    J -.-> B[BandwidthMeasurement]
+    C -->|on failure| R[Remediation]
+```
+
+A Certification creates one Workflow per catalog category. Each Workflow creates a Job from its template. The Job creates the workload through an adapter, for example a Kubeflow Trainer TrainJob. Measurement resources parse pod logs with LogProfile regex patterns and compute goodput and bandwidth. When a node fails, a Remediation taints and cordons it. When you delete the Remediation, CRE removes the taint and the cordon.
 
 ## Install
 
@@ -11,6 +46,8 @@ curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/dow
 # Set up the cluster (installs Kubeflow Trainer, CRDs, controller, and LogProfiles)
 ncrectl setup init
 ```
+
+CI pushes the controller image to `ghcr.io/nvidia/cluster-readiness-engine/manager`. Tagged releases will carry the `ncrectl` binaries and the Helm chart.
 
 ## Certify a GPU cluster
 
@@ -43,7 +80,7 @@ ncrectl certification run --cert-file certification.yaml --image-pull-secret $NG
 
 ## Run a training workload
 
-WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Provide an image, framework, and node count — CRE auto-detects the platform and GPU architecture.
+WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Provide an image, framework, and node count. CRE detects the platform and GPU architecture.
 
 ```yaml
 apiVersion: cre.nvidia.com/v1alpha1
@@ -66,19 +103,36 @@ spec:
 ncrectl workloadrun run --image-pull-secret $NGC_API_KEY --wait my-workload.yaml
 ```
 
+## Scope and non-goals
+
+CRE certifies clusters with burn-in workloads and quarantines the nodes that fail. CRE is not:
+
+- A continuous monitoring system. CRE watches nodes only while its workloads run.
+- A general workload scheduler or a training platform for production pipelines.
+- A benchmark leaderboard. The measurements exist to find faults, not to rank hardware.
+
 ## Documentation
 
-Full documentation: **[github.com/NVIDIA/cluster-readiness-engine](https://github.com/NVIDIA/cluster-readiness-engine)**
+- [Architecture Decision Records](docs/designs/) explain the design (ADR-000 to ADR-069).
+- [CONTRIBUTING.md](CONTRIBUTING.md) describes the contribution workflow.
+- [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md) describe who decides what.
+- [SECURITY.md](SECURITY.md) describes how to report a vulnerability.
 
-| | |
-|---|---|
-| Getting Started | Install ncrectl and set up the cluster |
-| Tutorials | Quick Start, WorkloadRun walkthroughs, NCCL test |
-| Concepts | API hierarchy, workload types, health monitoring, remediation, goodput |
-| How-to Guides | Certify clusters, WorkloadRun, benchmarks, adaptive fault isolation, gray failures |
-| Reference | CRD specs (Job, Workflow, Certification, WorkloadRun), ncrectl CLI, metrics |
-| Operations | Deployment, monitoring, troubleshooting, FAQ |
-| Design Decisions | Architecture Decision Records (`docs/designs/`) |
+A hosted documentation site is in progress.
+
+## Roadmap
+
+- First tagged release (v0.1.0) with `ncrectl` binaries and the Helm chart
+- Hosted documentation site
+- Signed artifacts, SBOMs, and build provenance in the release pipeline
+- Branch protection and DCO checks for public contributions
+
+## Community
+
+- Ask questions in [GitHub Discussions](https://github.com/NVIDIA/cluster-readiness-engine/discussions).
+- Report bugs and request features with the [issue templates](https://github.com/NVIDIA/cluster-readiness-engine/issues/new/choose).
+- Report security issues per [SECURITY.md](SECURITY.md), never through GitHub issues.
+- We follow the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Development
 
@@ -89,7 +143,8 @@ make test                  # Unit + integration tests
 make build                 # Build binary
 ```
 
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before you open a pull request. Open an issue first, and sign your commits with `git commit -s`.
+
 ## License
 
-Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
-
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details. Third-party attributions are in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
## Summary

This PR expands the README. It keeps the install, certification, and WorkloadRun examples without change.

New content:

- Badges for CI status, the license, and the Go version.
- A problem statement and the target audience.
- A feature list.
- An architecture diagram (mermaid) with a short explanation of the Certification, Workflow, and Job composition.
- A scope section with explicit non-goals.
- Documentation links to the ADRs, CONTRIBUTING.md, GOVERNANCE.md, MAINTAINERS.md, and SECURITY.md.
- A roadmap section.
- A community section with links to Discussions, the issue templates, SECURITY.md, and the Code of Conduct.
- A note that CI pushes the controller image to ghcr.io.

## Type of Change

Documentation. No code changes.

## Testing

- The markdown and the mermaid diagram render correctly in preview.
- All relative links point to files that exist on main.

## Risk

Low. One file changed. Two notes:

- The Discussions link works after someone enables Discussions in the repository settings.
- The install command downloads from the latest release. The command works after the first release exists. The command was in the README before this PR.