### PR TITLE
ci: harden workflows and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dependabot keeps Go modules and pinned GitHub Actions current.
+# Updates are grouped to keep the pull request count low.
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      go-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -21,10 +24,11 @@ jobs:
     name: Lint
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -36,10 +40,11 @@ jobs:
     name: Build
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -54,10 +59,11 @@ jobs:
     name: Test
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -72,7 +78,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results
           path: |

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -16,6 +16,9 @@ on:
       - .github/workflows/container-build.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,10 +28,11 @@ jobs:
     name: Docker Build
     runs-on: linux-amd64-cpu32
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build container image (no push)
         run: make docker-build-cross

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -25,17 +28,18 @@ jobs:
     name: Build and Push Container
     runs-on: linux-amd64-cpu32
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 40
     permissions:
       contents: read
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

This PR hardens the three workflows and adds a Dependabot configuration. The workflows run the same steps as before.

- All three workflows now set a top-level `permissions: contents: read`. The publish job keeps its own `packages: write`.
- All third-party actions are pinned to full commit SHAs, with the version in a trailing comment. Each pin stays in the same major version the workflow used before (checkout v4.4.0, setup-go v5.6.0, upload-artifact v4.6.2, setup-buildx v3.12.0, login v3.7.0). I resolved each SHA from the action's release tags and checked that the exact tag and the major tag point at the same commit.
- Every job now has `timeout-minutes` (20 for lint and build, 40 for test and the container jobs).
- New `.github/dependabot.yml`: weekly gomod updates with the kubernetes modules (k8s.io, sigs.k8s.io) grouped apart from the rest, and weekly github-actions updates in one group. Dependabot also keeps the SHA pins current, so the pins do not go stale.

## Type of Change

Build/CI. No code changes.

## Testing

- All four YAML files parse without errors.
- The pinned SHAs match the release tags named in the comments (verified through the GitHub API).

## Risk

Low. The pins freeze the action versions the workflows already resolve today. If a pinned action misbehaves, revert the one line that pins it.