### PR TITLE
ci: add CodeQL, govulncheck, and the gosec linter

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: linux-amd64-cpu16
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          category: "/language:go"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  govulncheck:
+    name: Scan Go dependencies
+    runs-on: linux-amd64-cpu16
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
+    - gosec
     - govet
     - ineffassign
     - lll
@@ -26,6 +27,13 @@ linters:
     - unparam
     - unused
   settings:
+    gosec:
+      excludes:
+        # G104 duplicates errcheck, which is already enabled.
+        - G104
+        # G115 flags int -> int32 conversions. Node, step, and
+        # interruption counts are bounded by cluster size and fit in int32.
+        - G115
     revive:
       rules:
         - name: comment-spacings
@@ -43,6 +51,14 @@ linters:
           - dupl
           - lll
         path: pkg/*
+      # Tests and the golden-file helper read and write fixtures with
+      # relaxed permissions. That is intended.
+      - linters:
+          - gosec
+        path: _test\.go$
+      - linters:
+          - gosec
+        path: pkg/testutil/
     paths:
       - third_party$
       - builtin$

--- a/pkg/certification/certification.go
+++ b/pkg/certification/certification.go
@@ -402,7 +402,8 @@ func derefInt32Ptr(p *int32) int32 {
 
 // readCertification parses a Certification YAML file from disk.
 func readCertification(path string) (*burninv1alpha1.Certification, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is a user-provided CLI argument
+
 	if err != nil {
 		return nil, fmt.Errorf("read certification: %w", err)
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -118,7 +118,8 @@ type renderMetadata struct {
 
 // readWorkflow parses a Workflow YAML file from disk.
 func readWorkflow(path string) (*burninv1alpha1.Workflow, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is a user-provided CLI argument
+
 	if err != nil {
 		return nil, fmt.Errorf("read workflow: %w", err)
 	}
@@ -509,7 +510,8 @@ func resolveNodes(platform, gpuArch, nodesFile string) ([]corev1.Node, error) {
 }
 
 func loadNodesFromFile(path string) ([]corev1.Node, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is a user-provided CLI argument
+
 	if err != nil {
 		return nil, fmt.Errorf("read nodes file: %w", err)
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1709,7 +1709,7 @@ func WriteJSON(path string, reports []*CertReport) error {
 	if err != nil {
 		return fmt.Errorf("marshal report: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0644); err != nil { // #nosec G306 -- reports are output files meant to be readable
 		return fmt.Errorf("write report file: %w", err)
 	}
 	return nil

--- a/pkg/setup/helm.go
+++ b/pkg/setup/helm.go
@@ -197,7 +197,7 @@ func uninstallTrainerHelmRelease(kubeconfig, kubeContext string, out io.Writer) 
 // runHelm executes a helm subcommand, printing output only on failure.
 func runHelm(helmPath string, args []string, out io.Writer) error {
 	var buf bytes.Buffer
-	cmd := exec.Command(helmPath, args...)
+	cmd := exec.Command(helmPath, args...) // #nosec G204 -- helmPath and args come from this CLI, not from untrusted input
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 	if err := cmd.Run(); err != nil {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -863,7 +863,7 @@ func defaultImage(version string) string {
 // Image pull secret helpers
 // ---------------------------------------------------------------------------
 
-const pullSecretName = "ncrectl-pull-secret"
+const pullSecretName = "ncrectl-pull-secret" // #nosec G101 -- Kubernetes Secret name, not a credential
 
 // CreateImagePullSecret creates a dockerconfigjson Secret for ghcr.io.
 // token is a GitHub Personal Access Token with read:packages scope.

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -750,7 +750,8 @@ func watchWorkloadRun(
 // --- helpers ---
 
 func readWorkloadRun(file string) (*burninv1alpha1.WorkloadRun, error) {
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(file) // #nosec G304 -- file is a user-provided CLI argument
+
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", file, err)
 	}


### PR DESCRIPTION
## Summary

This PR adds three layers of security scanning.

- A CodeQL workflow analyzes the Go code on pushes to main and pull-request branches, and weekly.
- A govulncheck workflow checks the module graph against the Go vulnerability database on the same triggers.
- The gosec linter is now part of `make lint`.

The gosec rollout is tuned so the gate is green from day one:

- Two rules are excluded in .golangci.yml, with reasons in the config: G104 duplicates errcheck, which is already enabled, and G115 flags int to int32 conversions of node, step, and interruption counts that are bounded by cluster size.
- Tests and pkg/testutil are excluded because they write test fixtures with relaxed permissions on purpose.
- Seven production findings carry inline `#nosec` comments with a reason each: four CLI file reads from user-provided paths (G304), the helm subprocess call (G204), a Kubernetes Secret name constant that is not a credential (G101), and the report file that is meant to be world-readable (G306).

Both new workflows follow the repository conventions: SPDX headers, the repository guard, the internal runner labels, top-level read-only permissions, concurrency groups, timeouts, and SHA-pinned actions.

## Type of Change

Build/CI, plus inline comments in seven Go files. No behavior changes.

## Testing

- `golangci-lint run` with the issue caps disabled reports 0 issues.
- `govulncheck ./...` passes locally: no vulnerabilities found.
- Both new workflow files parse as valid YAML.

## Risk

Low. One coordination point: CodeQL on a private repository needs GitHub Advanced Security (code scanning) enabled in the repository settings. If it is not enabled, the CodeQL workflow fails until someone turns it on or the repository goes public.