### PR TITLE
docs: remove stale remediation references and fix broken README examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,13 +72,14 @@ Kubebuilder-based Kubernetes controller for GPU cluster burn-in certification. S
 
 Follows the Deployment → ReplicaSet → Pod composition pattern:
 
-- **Certification** creates one Workflow per category from the catalog. Auto-creates Remediation on failure. Workflow named `<certName>-<domain>-<variant>`.
+- **Certification** creates one Workflow per category from the catalog. Records failed nodes per category with a reason. Workflow named `<certName>-<domain>-<variant>`.
 - **Workflow** creates a single Job from `spec.jobTemplate`. Applies orchestration target, manages iterations, creates dependency resources. Job named `<workflowName>-job`.
 - **Job** creates a workload (TrainJob) via the adapter pattern. Manages health monitoring, goodput measurement, checkpoint restart.
 - **GoodputMeasurement** watches a Job, parses pod logs via LogProfile regex patterns, computes goodput ratio.
 - **BandwidthMeasurement** watches a Job, parses NCCL log output, and computes per-bus bandwidth metrics.
-- **Remediation** taints (`cre.nvidia.com/preflight-failed:NoExecute`), cordons, and sets conditions on failed nodes. Reverses on deletion.
 - **LogProfile** (cluster-scoped) defines regex patterns with named capture groups for parsing training framework logs.
+
+There is no Remediation controller. ADR-061 removed it. CRE does not taint, cordon, or patch nodes; it records failed nodes with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`) in the Certification status.
 
 ### Key Packages
 
@@ -100,7 +101,7 @@ Follows the Deployment → ReplicaSet → Pod composition pattern:
 - Each tier uses `Owns()` for event-driven reconciliation; polling as safety net
 - Configurable requeue intervals: tests use 1s, production uses 15s
 - Child resource creation: deep-copy spec → set labels → `SetControllerReference()` → Create()
-- Reason constants use tier-specific prefixes: `reasonWorkload*` (Job), `reasonJob*` (Workflow), `reasonWorkflow*` (Certification), `reasonRemediation*` (Remediation)
+- Reason constants use tier-specific prefixes: `reasonWorkload*` (Job), `reasonJob*` (Workflow), `reasonWorkflow*` (Certification)
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,14 @@ Kubebuilder-based Kubernetes controller for GPU cluster burn-in certification. S
 
 Follows the Deployment → ReplicaSet → Pod composition pattern:
 
-- **Certification** creates one Workflow per category from the catalog. Auto-creates Remediation on failure. Workflow named `<certName>-<domain>-<variant>`.
+- **Certification** creates one Workflow per category from the catalog. Records failed nodes per category with a reason. Workflow named `<certName>-<domain>-<variant>`.
 - **Workflow** creates a single Job from `spec.jobTemplate`. Applies orchestration target, manages iterations, creates dependency resources. Job named `<workflowName>-job`.
 - **Job** creates a workload (TrainJob) via the adapter pattern. Manages health monitoring, goodput measurement, checkpoint restart.
 - **GoodputMeasurement** watches a Job, parses pod logs via LogProfile regex patterns, computes goodput ratio.
 - **BandwidthMeasurement** watches a Job, parses NCCL log output, and computes per-bus bandwidth metrics.
-- **Remediation** taints (`cre.nvidia.com/preflight-failed:NoExecute`), cordons, and sets conditions on failed nodes. Reverses on deletion.
 - **LogProfile** (cluster-scoped) defines regex patterns with named capture groups for parsing training framework logs.
+
+There is no Remediation controller. ADR-061 removed it. CRE does not taint, cordon, or patch nodes; it records failed nodes with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`) in the Certification status.
 
 ### Key Packages
 
@@ -100,7 +101,7 @@ Follows the Deployment → ReplicaSet → Pod composition pattern:
 - Each tier uses `Owns()` for event-driven reconciliation; polling as safety net
 - Configurable requeue intervals: tests use 1s, production uses 15s
 - Child resource creation: deep-copy spec → set labels → `SetControllerReference()` → Create()
-- Reason constants use tier-specific prefixes: `reasonWorkload*` (Job), `reasonJob*` (Workflow), `reasonWorkflow*` (Certification), `reasonRemediation*` (Remediation)
+- Reason constants use tier-specific prefixes: `reasonWorkload*` (Job), `reasonJob*` (Workflow), `reasonWorkflow*` (Certification)
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CRE is for platform and infrastructure teams that bring up, validate, or resell 
 - Goodput measurement parsed from training logs with configurable LogProfile patterns
 - Per-bus bandwidth measurement parsed from NCCL logs
 - Node health monitoring with CEL expressions while workloads run
-- Automatic remediation of failed nodes (taint and cordon, reversed on deletion)
+- Per-node failure reporting with a reason for every failed node
 - Topology-aware node grouping and adaptive fault isolation
 - Checkpoint restart for training jobs
 - WorkloadRun, a single resource to run a training, NCCL, or custom workload
@@ -32,10 +32,9 @@ flowchart LR
     J -->|adapter| T[TrainJob and other workloads]
     J -.-> G[GoodputMeasurement]
     J -.-> B[BandwidthMeasurement]
-    C -->|on failure| R[Remediation]
 ```
 
-A Certification creates one Workflow per catalog category. Each Workflow creates a Job from its template. The Job creates the workload through an adapter, for example a Kubeflow Trainer TrainJob. Measurement resources parse pod logs with LogProfile regex patterns and compute goodput and bandwidth. When a node fails, a Remediation taints and cordons it. When you delete the Remediation, CRE removes the taint and the cordon.
+A Certification creates one Workflow per catalog category. Each Workflow creates a Job from its template. The Job creates the workload through an adapter, for example a Kubeflow Trainer TrainJob. Measurement resources parse pod logs with LogProfile regex patterns and compute goodput and bandwidth. When a node fails, CRE records it in the certification result with a reason. CRE does not modify nodes; quarantine is left to your platform.
 
 ## Quickstart
 
@@ -65,8 +64,10 @@ kubectl ncre certification run \
 
 **4. Report**
 
+The report prints when the run completes. To print it again later, pass the name and the namespace from the run output:
+
 ```bash
-kubectl ncre certification report
+kubectl ncre certification report <name> -n <namespace>
 ```
 
 ```
@@ -105,23 +106,34 @@ kubectl ncre certification report
 
 ## Run a training workload
 
-WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Provide an image, framework, and node count. CRE detects the platform and GPU architecture.
+WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Write a YAML file with an image, a framework, and a node count. CRE detects the platform and GPU architecture.
+
+```yaml
+# nccl-all-reduce.yaml
+apiVersion: cre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: nccl-all-reduce
+spec:
+  image: nvcr.io/nvidia/pytorch:26.01-py3
+  numNodes: 4
+  framework:
+    mpi:
+      binary: /usr/local/bin/all_reduce_perf_mpi
+      mpirunPath: /usr/local/bin/mpirun
+      args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
+  bandwidthMeasurement:
+    logProfileRef: nccl-bandwidth
+    testType: all_reduce
+```
 
 ```bash
-kubectl ncre workloadrun run \
-  --image-pull-secret "$(gh auth token)" \
-  --image ghcr.io/nvidia/pytorch:26.01-py3 \
-  --framework mpi \
-  --mpi-binary /usr/local/bin/all_reduce_perf_mpi \
-  --mpi-args "-b 8 -e 32G -f 2 -n 100" \
-  --num-nodes 4 \
-  --bandwidth-measurement \
-  --wait
+kubectl ncre workloadrun run nccl-all-reduce.yaml --wait
 ```
 
 ## Scope and non-goals
 
-CRE certifies clusters with burn-in workloads and quarantines the nodes that fail. CRE is not:
+CRE certifies clusters with burn-in workloads and reports the nodes that fail. CRE is not:
 
 - A continuous monitoring system. CRE watches nodes only while its workloads run.
 - A general workload scheduler or a training platform for production pipelines.


### PR DESCRIPTION
## Summary

ADR-061 removed the Remediation CRD and controller, and the manager ClusterRole grants nodes only get, list, and watch — CRE cannot taint or cordon a node. The README and both agent guides still described that behavior as current. The agent guides matter most: agents read CLAUDE.md and AGENTS.md as live instructions, and both documented the taint key `cre.nvidia.com/preflight-failed:NoExecute`, which exists nowhere in the code.

README fixes:

- The feature bullet, the architecture diagram, the architecture paragraph, and the scope line now say: CRE records failed nodes with a reason and does not modify them. Quarantine is left to the platform.
- Quickstart step 4 now shows `certification report <name> -n <namespace>`. The command requires at least one name, and the run creates its own namespace, so the bare form fails twice over.
- The WorkloadRun example now shows a YAML file plus `workloadrun run <file> --wait`. The previous example used six flags that do not exist (`--framework`, `--mpi-binary`, `--mpi-args`, `--num-nodes`, `--bandwidth-measurement`, and `--image` as a workload image) and pointed at `ghcr.io/nvidia/pytorch` instead of `nvcr.io/nvidia/pytorch`.

CLAUDE.md and AGENTS.md fixes (identical files, kept in sync; `make check-agents-sync` passes):

- Dropped the Remediation bullet, the "auto-creates Remediation on failure" sentence, and the `reasonRemediation*` prefix.
- Added one paragraph stating the current behavior: failed nodes are recorded with a reason (`HardwareFailureDetected`, `ThresholdViolation`, `WorkloadFailed`) in the Certification status.

Out of scope: the ADRs under `docs/designs/` are historical records; ADR-061 already supersedes the remediation design, so those files stay unchanged.

## Type of Change

Documentation. No code changes.

## Testing

- `make check-agents-sync` passes.
- The mermaid diagram parses after removing the Remediation node.
- A repo-wide grep finds no remaining stale remediation claims outside `docs/designs/`.

## Risk

Low. Documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Certification reports failed nodes and their failure reasons without modifying, tainting, or cordoning nodes.
  * Documented platform-managed quarantine instead of automatic remediation.
  * Removed references to the Remediation controller and remediation-specific reason categories.
  * Updated report retrieval requirements to include a name and namespace.
  * Revised workload-run examples to use a YAML manifest and CLI command.
  * Updated scope descriptions to reflect per-node failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->