### PR TITLE
fix: make the ServiceMonitor optional and add a missing chart default

### DIFF
--- a/helm/cluster-readiness-engine/templates/metrics-monitor.yaml
+++ b/helm/cluster-readiness-engine/templates/metrics-monitor.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -22,3 +23,5 @@ spec:
     matchLabels:
       {{- include "cre.selectorLabels" . | nindent 6 }}
       control-plane: manager
+
+{{- end }}

--- a/helm/cluster-readiness-engine/values.yaml
+++ b/helm/cluster-readiness-engine/values.yaml
@@ -28,6 +28,11 @@ manager:
                 operator: DoesNotExist
   tolerations:
     - operator: Exists
+  terminationGracePeriodSeconds: 10
 
 metrics:
   port: 8443
+  serviceMonitor:
+    # The ServiceMonitor needs the Prometheus Operator CRDs
+    # (monitoring.coreos.com/v1). Set to false on clusters without them.
+    enabled: true


### PR DESCRIPTION
## Summary

Two small chart fixes.

**1. The ServiceMonitor is now optional.** The chart created a `monitoring.coreos.com/v1` ServiceMonitor unconditionally, with no values toggle. On a cluster without the Prometheus Operator, `ncrectl setup init` fails in the helm phase with `no matches for kind "ServiceMonitor"`. That made the Prometheus Operator a silent hard dependency for a first install. The template is now gated by `metrics.serviceMonitor.enabled`.

The default is `true`, which preserves today's behavior exactly: existing installs keep their ServiceMonitor, and this change alone changes nothing for anyone. ADR-013 assumes every production cluster runs Prometheus, so `true` matches the stated design. A cluster without the Prometheus Operator now has an escape hatch: `--set metrics.serviceMonitor.enabled=false`. If the maintainers prefer the out-of-box install to work without Prometheus, flipping the default to `false` is a one-line follow-up; the trade-off is that existing Prometheus users would silently lose scraping on upgrade.

**2. A referenced value now has a default.** `deployment.yaml` reads `manager.terminationGracePeriodSeconds`, which `values.yaml` never defined, so the field rendered empty. The default is now `10`, the kubebuilder scaffold convention.

## Type of Change

Bug fix. Helm chart only; no controller code changes.

## Testing

- `helm template` with defaults renders the ServiceMonitor and `terminationGracePeriodSeconds: 10`.
- `helm template --set metrics.serviceMonitor.enabled=false` renders no ServiceMonitor.
- `helm lint` passes.

## Risk

Low. The default preserves current behavior; the new value only fills a field that rendered empty before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Prometheus monitoring through an optional ServiceMonitor, enabled by default.
  * Added a 10-second termination grace period for the manager.

* **Documentation**
  * Included explanatory configuration comments for ServiceMonitor settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->