### PR TITLE
docs: correct the exitDurationMins default in the BuildConfig comment

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -59,7 +59,7 @@ type BuildConfig struct {
 	MaxSteps int32
 
 	// ExitDurationMins is the training duration in minutes for NeMo 6 workloads.
-	// 0 means use template default (7).
+	// 0 means use template default (30).
 	ExitDurationMins int32
 
 	// GPUArchitecture is the GPU architecture string (e.g., "h100", "gb200").


### PR DESCRIPTION
## Summary

One comment fix in `pkg/catalog/catalog.go`. The `ExitDurationMins` field comment said the template default is 7. The constant `DefaultExitDurationMins` in `pkg/catalog/loader.go` is 30, and the CRD doc comment in `api/v1alpha1/certification_types.go` already says 30. Only the Go comment was wrong.

## Type of Change

Documentation. One comment line; no behavior change.

## Testing

- `go build ./pkg/catalog/` passes.

## Risk

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented default exit duration from 7 minutes to 30 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->