### PR TITLE
build: add make ci and document how to replicate CI locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,23 @@ KUBEBUILDER_ASSETS="$(bin/setup-envtest use -p path)" \
   go test ./cmd/integration/ -v -timeout 300s -count=1 -run TestReconcile/job-checkpoint-restart
 ```
 
+## Replicate CI Locally
+
+CI runs four required checks on every pull request: Lint, Build, Test, and Verify. One command runs the same gate locally:
+
+```bash
+make ci
+```
+
+The target chains `make verify` (generated files, `go.mod` tidiness, license headers), `make lint`, `make build`, and `make test`.
+
+Notes:
+
+- Run it on a committed tree. `make verify` regenerates code and fails when the result differs from what is committed.
+- The first run downloads the pinned tools into `bin/` (controller-gen, golangci-lint, addlicense, setup-envtest) and the envtest Kubernetes binaries. Later runs reuse them.
+- Tool versions are pinned in the Makefile. The Go version and the envtest Kubernetes version derive from `go.mod`. Local runs and CI resolve the same versions.
+- CI's Test job runs `make test-ci`, which is the same test suite with JUnit and coverage output for the CI artifacts.
+
 ## AI-Assisted Contributions
 
 You may use AI tools (Claude, Copilot, and similar) to help write contributions, under these rules:

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ verify-license-headers: addlicense ## Verify Go sources carry the SPDX license h
 .PHONY: verify
 verify: verify-codegen verify-mod verify-license-headers ## Run all verification checks.
 
+.PHONY: ci
+ci: verify lint build test ## Run the full CI gate locally: verify, lint, build, and test.
+
 ##@ Build
 
 .PHONY: check-clean-version


### PR DESCRIPTION
## Summary

One command now reproduces the full CI gate locally:

```bash
make ci
```

The target chains `make verify`, `make lint`, `make build`, and `make test` — the same four required checks that run on every pull request. CONTRIBUTING gains a "Replicate CI Locally" section that documents the command, what downloads on the first run, and why local runs and CI resolve identical versions: the tools are pinned in the Makefile, and the Go and envtest Kubernetes versions derive from `go.mod`.

A deliberate omission, for the record: this PR does not add a `.versions.yaml` manifest (the NVSentinel pattern). CRE has three pinned tool versions, all in one file that CI already consumes, and the other versions are single-sourced from `go.mod` — there is no drift surface for a separate manifest to remove, and it would add a `yq` dependency. Worth revisiting if version sources multiply.

## Type of Change

Build/CI plus documentation. No behavior changes to existing targets.

## Testing

- `make ci` runs green end to end in a fresh worktree: verify, lint, build, and the full unit and integration suite pass, with tools downloaded into `bin/` on first run.

## Risk

None. One new phony target and one documentation section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a single `make ci` command to run verification, linting, builds, and tests locally.

* **Documentation**
  * Documented how to reproduce CI checks locally, including prerequisites, pinned tool behavior, and differences between local testing and CI artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->