### PR TITLE
fix: fail docker-buildx on build errors and stop pushing from PR validation

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -35,10 +35,17 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # A branch name such as "pull-request/26" holds a slash, which a docker
-      # tag cannot. Replace each slash with a dash.
+      # tag cannot. Replace every character a tag does not allow, then cut the
+      # result so the tag stays under the 128 character limit. The branch name
+      # goes through the environment, so it cannot run as shell code.
       - name: Compute image tag
         id: tag
-        run: echo "value=$(echo '${{ github.ref_name }}' | tr '/' '-')-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          ref=$(printf '%s' "$REF_NAME" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-80)
+          echo "value=${ref}-${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build container image (no push)
         run: make docker-buildx BUILDX_PUSH=

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -34,7 +34,13 @@ jobs:
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # A branch name such as "pull-request/26" holds a slash, which a docker
+      # tag cannot. Replace each slash with a dash.
+      - name: Compute image tag
+        id: tag
+        run: echo "value=$(echo '${{ github.ref_name }}' | tr '/' '-')-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
       - name: Build container image (no push)
         run: make docker-buildx BUILDX_PUSH=
         env:
-          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ github.ref_name }}-${{ github.sha }}
+          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -35,6 +35,6 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build container image (no push)
-        run: make docker-buildx
+        run: make docker-buildx BUILDX_PUSH=
         env:
           IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ github.ref_name }}-${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -281,13 +281,14 @@ BUILDX_PUSH ?= --push
 
 .PHONY: docker-buildx
 docker-buildx: #check-clean-version ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name cre-builder
-	$(CONTAINER_TOOL) buildx use cre-builder
+	# Run as one shell, so the trap removes the builder and the temporary
+	# Dockerfile even when the build fails.
+	trap '$(CONTAINER_TOOL) buildx rm cre-builder >/dev/null 2>&1 || true; rm -f Dockerfile.cross' EXIT; \
+	set -e; \
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross; \
+	$(CONTAINER_TOOL) buildx create --name cre-builder >/dev/null 2>&1 || true; \
+	$(CONTAINER_TOOL) buildx use cre-builder; \
 	$(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) $(BUILDX_PUSH) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm cre-builder
-	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -274,13 +274,18 @@ PLATFORMS ?= linux/arm64,linux/amd64
 # Platforms for ncrectl CLI cross-compilation (includes macOS and Windows for end-user workstations).
 NCRECTL_PLATFORMS ?= linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
 
+# BUILDX_PUSH controls whether docker-buildx pushes the image.
+# Default pushes. Set BUILDX_PUSH= (empty) to build without pushing,
+# which validates both platforms and discards the result.
+BUILDX_PUSH ?= --push
+
 .PHONY: docker-buildx
 docker-buildx: #check-clean-version ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name cre-builder
 	$(CONTAINER_TOOL) buildx use cre-builder
-	- $(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) $(BUILDX_PUSH) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm cre-builder
 	rm Dockerfile.cross
 

--- a/Makefile
+++ b/Makefile
@@ -257,11 +257,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t "${IMG}" .
 
 .PHONY: docker-push
 docker-push: check-clean-version ## Push docker image with the manager.
-	$(CONTAINER_TOOL) push ${IMG}
+	$(CONTAINER_TOOL) push "${IMG}"
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -284,11 +284,10 @@ docker-buildx: #check-clean-version ## Build and push docker image for the manag
 	# Run as one shell, so the trap removes the builder and the temporary
 	# Dockerfile even when the build fails.
 	trap '$(CONTAINER_TOOL) buildx rm cre-builder >/dev/null 2>&1 || true; rm -f Dockerfile.cross' EXIT; \
-	set -e; \
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross; \
 	$(CONTAINER_TOOL) buildx create --name cre-builder >/dev/null 2>&1 || true; \
 	$(CONTAINER_TOOL) buildx use cre-builder; \
-	$(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) $(BUILDX_PUSH) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) $(BUILDX_PUSH) --platform=$(PLATFORMS) --tag "${IMG}" -f Dockerfile.cross .
 
 ##@ Deployment
 


### PR DESCRIPTION
## Summary

Two related problems in the container build path.

**The build could not fail.** The `docker-buildx` recipe prefixed the `buildx build` line with `-`, which tells make to ignore the exit code (a kubebuilder scaffold leftover). A broken Dockerfile, a compile error inside the image build, or a failed registry push all left the job green. The Publish workflow uses the same target, so a failed image push would not fail a release.

**PR validation pushed, or tried to.** The Container Build workflow's step is named "Build container image (no push)" but ran the pushing target. Every `pull-request/N` branch attempted an unauthenticated push to GHCR; the `-` swallowed the failure. Net effect: the workflow validated nothing.

The fix:

- Remove the `-` from the `buildx build` line. Failures now propagate, including in Publish and Release.
- Add a `BUILDX_PUSH` variable (default `--push`, so the publish path is unchanged). The Container Build workflow sets it empty: PR validation now builds both platforms (linux/amd64, linux/arm64) and discards the result, which is what the step name always claimed.

## Type of Change

Bug fix. Build/CI.

## Testing

- `make -n docker-buildx` renders the build line with `--push` and no `-` prefix.
- `make -n docker-buildx BUILDX_PUSH=` renders it without `--push`.
- The workflow YAML parses.

## Risk

Low. The one behavior change is intentional: build and push failures now fail the jobs that run them, instead of passing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container builds now correctly report failures instead of continuing silently.
  * Builds can complete without automatically publishing container images.
  * Container image tags now consistently include the source reference and commit identifier.

* **Chores**
  * Added configurable control over image publishing during builds.
  * Improved build cleanup and workflow reliability.
  * Enhanced container image traceability across build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->