### PR TITLE
chore: fix CODEOWNERS GitHub handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # Later entries win over earlier ones. Refine per-path ownership as the
 # maintainer group grows (see MAINTAINERS.md).
 
-* @endipagbor @lalitadithya
+* @ndipebot @lalitadithya

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@ Maintainers are responsible for reviewing and merging changes, triaging issues, 
 
 | Name | GitHub | Areas |
 |---|---|---|
-| Ebot Ndip-Agbor | [@endipagbor](https://github.com/endipagbor) | Project-wide: controllers (`pkg/controller/`), catalog (`pkg/catalog/`), workload adapters (`pkg/workload/`), CLI (`cmd/ncrectl/`), Helm chart (`helm/`), CI |
+| Ebot Ndip-Agbor | [@ndipebot](https://github.com/ndipebot) | Project-wide: controllers (`pkg/controller/`), catalog (`pkg/catalog/`), workload adapters (`pkg/workload/`), CLI (`cmd/ncrectl/`), Helm chart (`helm/`), CI |
 | Lalit Adithya | [@lalitadithya](https://github.com/lalitadithya) | Project-wide: controllers (`pkg/controller/`), catalog (`pkg/catalog/`), workload adapters (`pkg/workload/`), CLI (`cmd/ncrectl/`), Helm chart (`helm/`), CI |
 
 While the maintainer group is small, both maintainers share ownership of all areas. Per-area ownership splits as the group grows.


### PR DESCRIPTION
## Summary

- Fixes incorrect GitHub handle in CODEOWNERS (`@endipagbor` → `@ndipebot`)

## Test plan

- [x] Verify GitHub resolves `@ndipebot` as a valid user on the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments to reflect current maintainers.
  * Updated the maintainer roster with the current GitHub handle.
  * Retained the existing secondary owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->