### PR TITLE
chore: narrow CodeRabbit to behavior changing findings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Keep review comments rare and high value. Style, naming, and wording are
+# handled by golangci-lint and by human review.
+tone_instructions: >-
+  Report only defects that change behavior: bugs, data loss, race conditions,
+  security problems, broken error handling, and breaking API or CRD changes.
+  Report a test only when the test itself is wrong. Do not comment on style,
+  naming, formatting, comment wording, documentation phrasing, or missing
+  test coverage. Say nothing when you find no defect.
+
 reviews:
   profile: chill
+  request_changes_workflow: false
+
+  # Drop the report sections that repeat what the diff already shows.
+  high_level_summary: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  poem: false
+  review_status: false
+  collapse_walkthrough: true
+
+  # Generated files and fixtures. Nobody edits these by hand.
+  path_filters:
+    - "!**/zz_generated.*.go"
+    - "!helm/cluster-readiness-engine/crds/**"
+    - "!helm/cluster-readiness-engine/templates/*role*.yaml"
+    - "!helm/cluster-readiness-engine/templates/service_account.yaml"
+    - "!**/testdata/**"
+    - "!THIRD_PARTY_NOTICES.md"
+    - "!PROJECT"
+
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary

CodeRabbit reviews carry style, naming, and wording comments that golangci-lint and human review already cover. This narrows it to findings worth acting on.

- `tone_instructions` asks for bugs, data loss, races, security problems, broken error handling, and breaking API or CRD changes. It asks for silence when there is no defect, and says not to comment on style, naming, formatting, comment wording, documentation phrasing, or missing coverage.
- Turn off the summary, changed-files list, sequence diagrams, poem, and review-status sections. They repeat what the diff already shows. `collapse_walkthrough` keeps the walkthrough folded.
- Skip files nobody edits by hand: `zz_generated.*.go`, the chart CRDs, the generated RBAC and service account templates, `**/testdata/**`, `THIRD_PARTY_NOTICES.md`, and `PROJECT`.
- `request_changes_workflow: false` keeps an opinion from blocking a merge.

`profile` stays `chill`, which is already the quieter of the two settings.

## Type of Change

Repository configuration. No code changes.

## Testing

The file parses as valid YAML. The effect shows up on the next PR CodeRabbit reviews.

## Two things worth knowing

`tone_instructions` is a prompt, so it shifts what CodeRabbit emphasizes rather than filtering output. `path_filters` is the deterministic control.

Excluding `**/testdata/**` is a trade-off. Golden files do sometimes hold real mistakes, and CodeRabbit occasionally catches them. Happy to drop that one line if you would rather keep eyes there.

For reference, NVIDIA/aicr runs the same section toggles with `profile: assertive`.