### PR TITLE
feat: report the DCGM service in setup status

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ A Certification creates one Workflow per catalog category. Each Workflow creates
 
 ## Quickstart
 
+**0. Check the cluster**
+
+CRE needs the NVIDIA GPU Operator. The `diagnostics/dcgm-level4` category also
+needs the standalone DCGM service, which the GPU Operator creates only when
+`spec.dcgm.enabled` is true. That setting is off by default when the operator
+runs its own embedded DCGM for metrics. Your cluster administrator can turn it
+on:
+
+```bash
+kubectl patch clusterpolicy cluster-policy --type=merge \
+  -p '{"spec":{"dcgm":{"enabled":true}}}'
+```
+
+Run `kubectl ncre setup status` at any time to see what is present.
+
 **1. Install the CLI**
 
 ```bash

--- a/pkg/setup/status.go
+++ b/pkg/setup/status.go
@@ -12,17 +12,30 @@ import (
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const outputJSON = "json"
 
+// The diagnostics/dcgm-level4 category runs dcgmi against this service. The
+// GPU Operator creates it only when spec.dcgm.enabled is true.
+const (
+	dcgmServiceName      = "nvidia-dcgm"
+	dcgmServiceNamespace = "gpu-operator"
+)
+
 // SetupStatus is the JSON output structure for ncrectl setup status.
 type SetupStatus struct {
 	// Installed is true when all required components are present and ready.
 	Installed  bool                  `json:"installed"`
 	Components SetupStatusComponents `json:"components"`
+
+	// dcgmAbsent is true only when the API server answered that the service
+	// does not exist. A denied or failed lookup leaves it false, so the
+	// command does not tell the user to enable a service that may be there.
+	dcgmAbsent bool
 }
 
 // SetupStatusComponents reports the status of each individual component.
@@ -32,6 +45,9 @@ type SetupStatusComponents struct {
 	KubeflowTrainer bool `json:"kubeflowTrainer"`
 	LogProfiles     bool `json:"logProfiles"`
 	GPUOperator     bool `json:"gpuOperator"`
+	// DCGM is optional. Only the diagnostics/dcgm-level4 category needs it,
+	// so it does not count toward Installed.
+	DCGM bool `json:"dcgm"`
 }
 
 func newSetupStatusCommand() *cobra.Command {
@@ -51,8 +67,10 @@ Components checked:
   kubeflowTrainer      Kubeflow Trainer TrainJob CRD (kubeflow.org)
   logProfiles          CRE LogProfile resources
   gpuOperator          NVIDIA GPU Operator (nodes with nvidia.com/gpu.present=true)
+  dcgm                 NVIDIA DCGM service (optional; diagnostics/dcgm-level4 only)
 
-'installed' is true only when all components are present.`,
+'installed' is true only when all required components are present. DCGM is
+optional, so it does not affect 'installed'.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			c, err := newSetupClient(configFlags)
@@ -90,6 +108,9 @@ func collectSetupStatus(ctx context.Context, c client.Client) *SetupStatus {
 	comp.LogProfiles = checkLogProfiles(ctx, c)
 	comp.GPUOperator = checkGPUOperator(ctx, c)
 
+	dcgmErr := checkDCGM(ctx, c)
+	comp.DCGM = dcgmErr == nil
+
 	return &SetupStatus{
 		Installed: comp.CRECRDs &&
 			comp.CREController &&
@@ -97,6 +118,7 @@ func collectSetupStatus(ctx context.Context, c client.Client) *SetupStatus {
 			comp.LogProfiles &&
 			comp.GPUOperator,
 		Components: comp,
+		dcgmAbsent: apierrors.IsNotFound(dcgmErr),
 	}
 }
 
@@ -178,6 +200,18 @@ func checkGPUOperator(ctx context.Context, c client.Client) bool {
 	return len(nodeList.Items) > 0
 }
 
+// checkDCGM returns nil if the GPU Operator created the standalone DCGM
+// service. The operator omits it when spec.dcgm.enabled is false, which is the
+// default when dcgmExporter runs its own embedded DCGM. The caller reads the
+// error to tell a missing service apart from a lookup it could not complete.
+func checkDCGM(ctx context.Context, c client.Client) error {
+	svc := &unstructured.Unstructured{}
+	svc.SetAPIVersion("v1")
+	svc.SetKind("Service")
+	key := client.ObjectKey{Name: dcgmServiceName, Namespace: dcgmServiceNamespace}
+	return c.Get(ctx, key, svc)
+}
+
 // printSetupStatus renders a human-readable table.
 func printSetupStatus(s *SetupStatus) {
 	check := func(ok bool) string {
@@ -203,6 +237,7 @@ func printSetupStatus(s *SetupStatus) {
 		check(s.Components.KubeflowTrainer), status(s.Components.KubeflowTrainer))
 	_, _ = fmt.Fprintf(w, "Log Profiles\t%s %s\n", check(s.Components.LogProfiles), status(s.Components.LogProfiles))
 	_, _ = fmt.Fprintf(w, "GPU Operator\t%s %s\n", check(s.Components.GPUOperator), status(s.Components.GPUOperator))
+	_, _ = fmt.Fprintf(w, "DCGM (optional)\t%s %s\n", check(s.Components.DCGM), status(s.Components.DCGM))
 	_ = w.Flush()
 
 	fmt.Println()
@@ -213,5 +248,14 @@ func printSetupStatus(s *SetupStatus) {
 		if !s.Components.GPUOperator {
 			fmt.Println("  GPU Operator must be installed by your cluster administrator")
 		}
+	}
+
+	if s.dcgmAbsent {
+		fmt.Println()
+		fmt.Printf("Note: service %s/%s is missing. Only the diagnostics/dcgm-level4\n",
+			dcgmServiceNamespace, dcgmServiceName)
+		fmt.Println("      category needs it. Your cluster administrator can add it with:")
+		fmt.Println(`      kubectl patch clusterpolicy cluster-policy --type=merge \`)
+		fmt.Println(`        -p '{"spec":{"dcgm":{"enabled":true}}}'`)
 	}
 }

--- a/pkg/setup/status_test.go
+++ b/pkg/setup/status_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newSetupScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, apiextv1.AddToScheme(s))
+	// LogProfile has no typed Go package here, so register the list kind the
+	// check function asks for.
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: creAPIGroup, Version: "v1alpha1", Kind: "LogProfile"},
+		&unstructured.Unstructured{})
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: creAPIGroup, Version: "v1alpha1", Kind: "LogProfileList"},
+		&unstructured.UnstructuredList{})
+	return s
+}
+
+func TestCheckDCGM(t *testing.T) {
+	t.Run("present when the gpu-operator service exists", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(newSetupScheme(t)).
+			WithObjects(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dcgmServiceName,
+					Namespace: dcgmServiceNamespace,
+				},
+			}).
+			Build()
+		assert.NoError(t, checkDCGM(context.Background(), c))
+	})
+
+	t.Run("absent when no service exists", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).Build()
+		assert.True(t, apierrors.IsNotFound(checkDCGM(context.Background(), c)))
+	})
+
+	t.Run("absent when the service is in another namespace", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(newSetupScheme(t)).
+			WithObjects(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dcgmServiceName,
+					Namespace: "default",
+				},
+			}).
+			Build()
+		assert.True(t, apierrors.IsNotFound(checkDCGM(context.Background(), c)))
+	})
+
+	t.Run("a denied lookup is not reported as absent", func(t *testing.T) {
+		status := collectSetupStatus(context.Background(), forbiddenServiceClient(t))
+		assert.False(t, status.Components.DCGM)
+		assert.False(t, status.dcgmAbsent, "a denied lookup must not print the patch command")
+	})
+}
+
+// forbiddenServiceClient answers every Service read with a Forbidden error, the
+// way an API server does when the user may not read the gpu-operator namespace.
+func forbiddenServiceClient(t *testing.T) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(newSetupScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey,
+				obj client.Object, _ ...client.GetOption) error {
+				return apierrors.NewForbidden(
+					schema.GroupResource{Resource: "services"}, key.Name, errors.New("denied"))
+			},
+		}).
+		Build()
+}
+
+// crd builds a CustomResourceDefinition that the check functions can read.
+func crd(name, group, kind string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"group": group,
+			"names": map[string]any{"kind": kind},
+		},
+	}}
+	u.SetAPIVersion("apiextensions.k8s.io/v1")
+	u.SetKind("CustomResourceDefinition")
+	u.SetName(name)
+	return u
+}
+
+// logProfile builds a LogProfile that checkLogProfiles can count.
+func logProfile(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{}}
+	u.SetAPIVersion(creAPIGroup + "/v1alpha1")
+	u.SetKind("LogProfile")
+	u.SetName(name)
+	return u
+}
+
+// readyClusterObjects returns every object needed for installed to be true,
+// with no DCGM service.
+func readyClusterObjects() []client.Object {
+	return []client.Object{
+		crd("certifications."+creAPIGroup, creAPIGroup, "Certification"),
+		crd("trainjobs."+trainerAPIGroup, trainerAPIGroup, "TrainJob"),
+		logProfile("megatron-training"),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "cre-controller", Namespace: creNamespace},
+			Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "gpu-node-0",
+				Labels: map[string]string{"nvidia.com/gpu.present": "true"},
+			},
+		},
+	}
+}
+
+// A missing DCGM service must not make the cluster look unready, because only
+// the diagnostics/dcgm-level4 category needs it.
+func TestCollectSetupStatusDCGMIsOptional(t *testing.T) {
+	objs := readyClusterObjects()
+
+	t.Run("ready without dcgm", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).WithObjects(objs...).Build()
+		s := collectSetupStatus(context.Background(), c)
+		assert.True(t, s.Installed, "installed must not depend on DCGM")
+		assert.False(t, s.Components.DCGM)
+	})
+
+	t.Run("ready with dcgm", func(t *testing.T) {
+		withDCGM := append(objs, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: dcgmServiceName, Namespace: dcgmServiceNamespace},
+		})
+		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).WithObjects(withDCGM...).Build()
+		s := collectSetupStatus(context.Background(), c)
+		assert.True(t, s.Installed)
+		assert.True(t, s.Components.DCGM)
+	})
+}


### PR DESCRIPTION
## Problem

The `diagnostics/dcgm-level4` category runs `dcgmi diag --host nvidia-dcgm.gpu-operator.svc:5555`. The GPU Operator creates that service only when `spec.dcgm.enabled` is true. That setting is false by default when `dcgmExporter` runs its own embedded DCGM for metrics.

So a cluster can meet the stated prerequisite, the GPU Operator, and still fail this category. Nothing in the CLI or the README said why.

Found while running the catalog on a real A100 cluster. `kubectl -n gpu-operator get svc nvidia-dcgm` returned `NotFound`, and the fix took a while to work out.

## Change

`setup status` now reports DCGM as an optional component:

- It does **not** count toward `installed`, because only one category needs it.
- When the service is missing, the command prints the patch that adds it.
- The README quickstart names the setting.

## Output

Service present:

```
GPU Operator                ✓ installed
DCGM (optional)             ✓ installed

Status: ready
```

Service missing:

```
GPU Operator                ✓ installed
DCGM (optional)             ✗ not found

Status: ready

Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
      category needs it. Your cluster administrator can add it with:
      kubectl patch clusterpolicy cluster-policy --type=merge \
        -p '{"spec":{"dcgm":{"enabled":true}}}'
```

JSON gains one field:

```json
"components": { ..., "gpuOperator": true, "dcgm": true }
```

## Verification

- Built and run against a live A100 cluster in both states. Toggled `spec.dcgm.enabled` off and on and confirmed the row, the note, and that `Status: ready` does not change.
- `make lint`, `make build`, `make test` pass.
- Adds `pkg/setup/status_test.go`, the first tests for this file: three cases for `checkDCGM`, and a case proving a missing service leaves `installed` true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA DCGM service status reporting to setup checks, available in both table and JSON output.
  * Setup status now indicates when DCGM is unavailable while keeping overall installation readiness unaffected.
  * Added administrator guidance for enabling standalone DCGM through the GPU Operator configuration.

* **Documentation**
  * Updated the Quickstart with prerequisite checks, DCGM setup instructions, and a command for inspecting installation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->