### PR TITLE
fix: report the GPUs each node really has in cluster info

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"text/tabwriter"
@@ -23,6 +24,9 @@ import (
 
 const outputJSON = "json"
 
+// resourceNvidiaGPU is the extended resource the device plugin advertises.
+const resourceNvidiaGPU corev1.ResourceName = "nvidia.com/gpu"
+
 // Network topology label keys per cloud platform.
 const (
 	topologyKeyAWS   = "topology.k8s.aws/network-node-layer-1"
@@ -36,19 +40,28 @@ const (
 
 // ClusterInfo is the JSON/YAML output structure for ncrectl cluster info.
 type ClusterInfo struct {
-	Platform        string        `json:"platform"`
-	GPUArchitecture string        `json:"gpuArchitecture"`
-	GPUProduct      string        `json:"gpuProduct"`
-	GpusPerNode     int32         `json:"gpusPerNode"`
-	TotalNodes      int           `json:"totalNodes"`
-	TotalGPUs       int           `json:"totalGPUs"`
-	Nodes           []NodeInfo    `json:"nodes"`
-	Topology        *TopologyInfo `json:"topology,omitempty"`
+	Platform        string `json:"platform"`
+	GPUArchitecture string `json:"gpuArchitecture"`
+	GPUProduct      string `json:"gpuProduct"`
+	// GpusPerNode is the smallest GPU count any discovered node reports. A job
+	// asks for the same count on every node, so the smallest node sets what
+	// the cluster can run.
+	GpusPerNode int32 `json:"gpusPerNode"`
+	// CatalogGpusPerNode is what the catalog assumes for this architecture. It
+	// can differ from GpusPerNode, for example on a workstation or a partly
+	// drained node, and then a certification must set gpusPerNode itself.
+	CatalogGpusPerNode int32         `json:"catalogGpusPerNode"`
+	TotalNodes         int           `json:"totalNodes"`
+	TotalGPUs          int           `json:"totalGPUs"`
+	Nodes              []NodeInfo    `json:"nodes"`
+	Topology           *TopologyInfo `json:"topology,omitempty"`
 }
 
 // NodeInfo describes a single GPU node.
 type NodeInfo struct {
-	Name  string `json:"name"`
+	Name string `json:"name"`
+	// GPUs is the node's allocatable nvidia.com/gpu count. It is 0 when the
+	// device plugin has not advertised the resource yet.
 	GPUs  int32  `json:"gpus"`
 	Ready bool   `json:"ready"`
 	Rack  string `json:"rack,omitempty"`
@@ -162,21 +175,28 @@ func buildClusterInfo(
 	gpusPerNode int32, topologyKey string,
 ) ClusterInfo {
 	info := ClusterInfo{
-		Platform:        platform,
-		GPUArchitecture: gpuArch,
-		GPUProduct:      gpuProduct,
-		GpusPerNode:     gpusPerNode,
-		TotalNodes:      len(nodes),
-		TotalGPUs:       len(nodes) * int(gpusPerNode),
+		Platform:           platform,
+		GPUArchitecture:    gpuArch,
+		GPUProduct:         gpuProduct,
+		CatalogGpusPerNode: gpusPerNode,
+		TotalNodes:         len(nodes),
 	}
 
 	// Build per-node info and collect topology domains.
 	rackNodes := map[string][]string{}
-	for _, n := range nodes {
+	for i, n := range nodes {
+		count := nodeGPUCount(n)
 		ni := NodeInfo{
 			Name:  n.Name,
-			GPUs:  gpusPerNode,
+			GPUs:  count,
 			Ready: isNodeReady(n),
+		}
+		info.TotalGPUs += int(count)
+		// A job asks for the same count on every node, so the smallest node
+		// sets what the cluster can run. Track the first node separately,
+		// because 0 is a real count, not an unset marker.
+		if i == 0 || count < info.GpusPerNode {
+			info.GpusPerNode = count
 		}
 		if topologyKey != "" {
 			ni.Rack = n.Labels[topologyKey]
@@ -211,6 +231,23 @@ func buildClusterInfo(
 	return info
 }
 
+// nodeGPUCount returns the node's allocatable nvidia.com/gpu count. It returns
+// 0 when the resource is absent, which is what the scheduler sees: a node
+// labelled gpu.present=true still runs nothing until the device plugin
+// advertises the resource. It also returns 0 for a count it cannot represent,
+// so a value the API server accepted never wraps to a negative one.
+func nodeGPUCount(n corev1.Node) int32 {
+	q, ok := n.Status.Allocatable[resourceNvidiaGPU]
+	if !ok {
+		return 0
+	}
+	count, ok := q.AsInt64()
+	if !ok || count < 0 || count > math.MaxInt32 {
+		return 0
+	}
+	return int32(count)
+}
+
 // isNodeReady returns true if the node has a Ready condition with status True.
 func isNodeReady(n corev1.Node) bool {
 	for _, c := range n.Status.Conditions {
@@ -241,12 +278,42 @@ func printClusterTable(info ClusterInfo) error {
 	fmt.Printf("GPU:          %s (%s, %d GPUs/node)\n", info.GPUProduct, info.GPUArchitecture, info.GpusPerNode)
 
 	readyCount := 0
+	mixed := false
 	for _, n := range info.Nodes {
 		if n.Ready {
 			readyCount++
 		}
+		if n.GPUs != info.GpusPerNode {
+			mixed = true
+		}
 	}
 	fmt.Printf("Nodes:        %d ready\n", readyCount)
+	fmt.Printf("Total GPUs:   %d\n", info.TotalGPUs)
+
+	if mixed {
+		fmt.Println("\nNodes do not all have the same GPU count. The value above is the")
+		fmt.Println("smallest, because a job asks for the same count on every node.")
+		w := tabwriter.NewWriter(os.Stdout, 2, 0, 4, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  NODE\tGPUS\tREADY")
+		for _, n := range info.Nodes {
+			_, _ = fmt.Fprintf(w, "  %s\t%d\t%t\n", n.Name, n.GPUs, n.Ready)
+		}
+		_ = w.Flush()
+	}
+
+	if info.GpusPerNode != info.CatalogGpusPerNode {
+		fmt.Printf("\nThe catalog assumes %d GPUs per node for %s. Set gpusPerNode in the\n",
+			info.CatalogGpusPerNode, info.GPUArchitecture)
+		if info.CatalogGpusPerNode > info.GpusPerNode {
+			fmt.Println("certification, or the pods ask for more GPUs than a node has.")
+		} else {
+			fmt.Println("certification, or the pods leave GPUs on each node unused.")
+		}
+	}
+	if info.GpusPerNode == 0 {
+		fmt.Println("\nAt least one selected node reports 0 allocatable nvidia.com/gpu, so")
+		fmt.Println("nothing schedules on it. If you expect GPUs there, check the GPU Operator.")
+	}
 
 	if info.Topology != nil && len(info.Topology.Racks) > 0 {
 		fmt.Printf("\nTOPOLOGY (%s):\n", info.Topology.Key)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gpuNode builds a ready node. A negative count leaves nvidia.com/gpu unset,
+// which is what a node shows before the device plugin advertises the resource.
+func gpuNode(name string, count int64) corev1.Node {
+	n := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	if count >= 0 {
+		n.Status.Allocatable[resourceNvidiaGPU] = *resource.NewQuantity(count, resource.DecimalSI)
+	}
+	return n
+}
+
+func TestNodeGPUCount(t *testing.T) {
+	assert.Equal(t, int32(8), nodeGPUCount(gpuNode("a", 8)))
+	assert.Equal(t, int32(1), nodeGPUCount(gpuNode("b", 1)))
+	assert.Equal(t, int32(0), nodeGPUCount(gpuNode("c", 0)))
+	// Resource absent: the device plugin has not advertised it.
+	assert.Equal(t, int32(0), nodeGPUCount(gpuNode("d", -1)))
+	// Too large for int32. Without the guard this wraps to a negative count,
+	// which then becomes the reported minimum across every node.
+	assert.Equal(t, int32(0), nodeGPUCount(gpuNode("e", math.MaxInt32+1)))
+}
+
+func TestBuildClusterInfoCountsRealGPUs(t *testing.T) {
+	// The catalog default for a100 is 8. These nodes have 1 each.
+	const catalogDefault = int32(8)
+
+	tests := []struct {
+		name            string
+		nodes           []corev1.Node
+		wantGpusPerNode int32
+		wantTotal       int
+		wantPerNode     []int32
+	}{
+		{
+			name:            "one GPU per node does not report the catalog default",
+			nodes:           []corev1.Node{gpuNode("node002", 1), gpuNode("node003", 1)},
+			wantGpusPerNode: 1,
+			wantTotal:       2,
+			wantPerNode:     []int32{1, 1},
+		},
+		{
+			name:            "eight GPUs per node matches the catalog default",
+			nodes:           []corev1.Node{gpuNode("n0", 8), gpuNode("n1", 8)},
+			wantGpusPerNode: 8,
+			wantTotal:       16,
+			wantPerNode:     []int32{8, 8},
+		},
+		{
+			name:            "mixed counts report the smallest",
+			nodes:           []corev1.Node{gpuNode("n0", 8), gpuNode("n1", 2)},
+			wantGpusPerNode: 2,
+			wantTotal:       10,
+			wantPerNode:     []int32{8, 2},
+		},
+		{
+			// A broken device plugin leaves a node at 0. The smallest must
+			// stay 0 even when it comes first, so 0 is not mistaken for
+			// "not seen yet".
+			name:            "a zero node first keeps the smallest at zero",
+			nodes:           []corev1.Node{gpuNode("n0", 0), gpuNode("n1", 5)},
+			wantGpusPerNode: 0,
+			wantTotal:       5,
+			wantPerNode:     []int32{0, 5},
+		},
+		{
+			name:            "a zero node last keeps the smallest at zero",
+			nodes:           []corev1.Node{gpuNode("n0", 5), gpuNode("n1", 0)},
+			wantGpusPerNode: 0,
+			wantTotal:       5,
+			wantPerNode:     []int32{5, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := buildClusterInfo(tt.nodes, "onprem", "a100", "NVIDIA-A100-PCIE-40GB",
+				catalogDefault, "")
+
+			assert.Equal(t, tt.wantGpusPerNode, info.GpusPerNode)
+			assert.Equal(t, tt.wantTotal, info.TotalGPUs)
+			assert.Equal(t, catalogDefault, info.CatalogGpusPerNode,
+				"the catalog default must still be reported")
+			assert.Equal(t, len(tt.nodes), info.TotalNodes)
+
+			got := make([]int32, 0, len(info.Nodes))
+			for _, n := range info.Nodes {
+				got = append(got, n.GPUs)
+			}
+			assert.Equal(t, tt.wantPerNode, got)
+		})
+	}
+}
+
+// No nodes must not panic or report a stale count.
+func TestBuildClusterInfoNoNodes(t *testing.T) {
+	info := buildClusterInfo(nil, "onprem", "a100", "", 8, "")
+	assert.Equal(t, int32(0), info.GpusPerNode)
+	assert.Equal(t, 0, info.TotalGPUs)
+	assert.Equal(t, 0, info.TotalNodes)
+	assert.Empty(t, info.Nodes)
+}


### PR DESCRIPTION
## Problem

`cluster info` never looked at the nodes. It took the catalog default for the detected architecture and multiplied:

```go
gpusPerNode := catalog.GPUDefaults(gpuArch, platform).GpusPerNode
...
TotalGPUs: len(nodes) * int(gpusPerNode)
GPUs:      gpusPerNode   // same scalar copied onto every node
```

Nothing in `pkg/` read `status.allocatable["nvidia.com/gpu"]`.

On a two node A100 cluster with **one** GPU each, it reported:

```
GPU:          NVIDIA-A100-PCIE-40GB (a100, 8 GPUs/node)
Nodes:        2 ready
```

8 per node and 16 total, against a real 1 and 2. A user who trusts that writes a certification whose pods can never schedule.

## Change

Read the allocatable count from each node.

- Per node `gpus` is what the node advertises.
- `totalGPUs` is the sum, not a multiplication.
- `gpusPerNode` is the smallest count across nodes, because a job asks for the same count on every node.
- New field `catalogGpusPerNode` keeps the architecture default. When the two differ, the table says to set `gpusPerNode` in the certification.
- Mixed counts print a per-node breakdown.

A count of **0** now shows as 0. That is what the scheduler sees when the device plugin has not advertised the resource. The old output hid that behind the architecture default, so a node that could never run a pod looked identical to a healthy one.

## Before and after, same cluster

```
########## OLD ##########
GPU:          NVIDIA-A100-PCIE-40GB (a100, 8 GPUs/node)
Nodes:        2 ready

########## NEW ##########
GPU:          NVIDIA-A100-PCIE-40GB (a100, 1 GPUs/node)
Nodes:        2 ready
Total GPUs:   2

The catalog assumes 8 GPUs per node for a100. Set gpusPerNode in the
certification, or the pods ask for more GPUs than a node has.

--- ground truth ---
node002   1
node003   1
```

## JSON

`gpusPerNode` and `totalGPUs` keep their names and now hold real values. One field is added:

```json
"gpusPerNode": 1,
"catalogGpusPerNode": 8,
"totalGPUs": 2,
```

## Verification

- Run against a live two node A100 cluster. Output matches `kubectl get nodes -o custom-columns=...allocatable`.
- `make lint`, `make build`, `make test` pass.
- Adds `pkg/cluster/cluster_test.go`, the first tests for this package: `nodeGPUCount` including the absent-resource case, and `buildClusterInfo` over uniform, mixed, and zero-count clusters. Two cases pin that a node with 0 GPUs keeps the smallest at 0 whether it comes first or last, since 0 is a real count and not an unset marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster information now reports actual NVIDIA GPU allocations per node and in total.
  * Displays the minimum GPUs available per node, catalog defaults, and mixed node configurations.
  * Reports catalog mismatches and warns when GPUs have not been advertised.

* **Bug Fixes**
  * Missing, invalid, negative, or unavailable GPU values are safely treated as zero.
  * Empty clusters now return zero-valued GPU information without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->