### PR TITLE
build: pin the container base images by digest and let Dependabot raise them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Dependabot keeps Go modules and pinned GitHub Actions current.
+# Dependabot keeps Go modules, pinned GitHub Actions, and the digest-pinned
+# container base images current.
 # Updates are grouped to keep the pull request count low.
 
 version: 2
@@ -32,5 +33,19 @@ updates:
     open-pull-requests-limit: 5
     groups:
       actions:
+        patterns:
+          - "*"
+
+  # Raises the base-image digests in Dockerfile. Without this, pinning by
+  # digest would hold the images at these bits and security fixes published
+  # under the same tag would never arrive.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      docker-images:
         patterns:
           - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Build the manager binary
-FROM golang:1.26.5 AS builder
+# Build the manager binary.
+# Base images are pinned by digest so a rebuild uses the same bits every time.
+# The tag is kept for readability; the digest is what resolves. Dependabot
+# raises the digest on its weekly docker run.
+FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
@@ -26,7 +29,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a -ldflags "-s -w -X main.version=${VERSION}" -o manager ./cmd/manager/
 
-FROM nvcr.io/nvidia/distroless/static:v4.0.0
+FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
## Problem

`Dockerfile` pinned both base images by tag:

```dockerfile
FROM golang:1.26.5 AS builder
FROM nvcr.io/nvidia/distroless/static:v4.0.0
```

A tag can be repointed at different bits, so two builds of the same commit could produce different images. This is the one supply-chain pin the repo was missing — PR #14 already pinned every GitHub Action to a commit SHA, and #20 did the same for `release.yml`.

## Change

Pin both by digest, keeping the tag for readability:

| Image | Digest |
|---|---|
| `golang:1.26.5` | `sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365` |
| `nvcr.io/nvidia/distroless/static:v4.0.0` | `sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69` |

Both digests are **OCI image indexes, not single-platform manifests**, so `make docker-buildx` still produces the `linux/arm64` and `linux/amd64` images that `PLATFORMS` asks for. This is the easy thing to get wrong when pinning by digest, so I checked it explicitly: each digest serves both target platforms.

## Why the Dependabot entry is part of the same change

A digest pin on its own trades one problem for a worse one. The image stops receiving the security fixes that get published under the same tag, and nothing tells you that you are falling behind.

So this adds a `docker` ecosystem to `.github/dependabot.yml`, on the same weekly Monday schedule as `gomod` and `github-actions`, grouped into a single pull request. Dependabot reads the `Dockerfile` and raises the digests. Pinning without it would be a downgrade, not an improvement.

## Verification

- Both digests match what their tags resolve to today.
- Both are pullable by digest.
- Both serve `linux/amd64` and `linux/arm64`.
- `.github/dependabot.yml` parses and declares all three ecosystems.
- `make verify` passes and leaves no generated file dirty.

I could not run `docker build` here — no daemon available — so the image build itself is unverified locally. The digests resolve and cover the target platforms, so a build should behave exactly as before.