### PR TITLE
docs: name UAT as a required check in the local CI instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,17 +130,36 @@ KUBEBUILDER_ASSETS="$(bin/setup-envtest use -p path)" \
 
 ## Replicate CI Locally
 
-CI runs four required checks on every pull request: Lint, Build, Test, and Verify. One command runs the same gate locally:
+Five checks are required before a pull request can merge: Lint, Build, Test, Verify, and UAT.
+
+One command runs the first four:
 
 ```bash
 make ci
 ```
 
-The target chains `make verify` (generated files, `go.mod` tidiness, license headers), `make lint`, `make build`, and `make test`.
+The target chains `make verify` (generated files, `go.mod` tidiness, license headers), `make lint`, `make build`, and `make test`. Run it before every push. It needs no cluster and no container runtime.
+
+UAT is the fifth check and `make ci` does not run it:
+
+```bash
+make test-uat
+```
+
+UAT renders the catalog against a Kind cluster with KWOK-simulated GPU nodes and compares the result to golden files. It needs Docker, Kind and Tilt, and it takes several minutes, so it is not part of `make ci`. Run it when you change anything under `pkg/catalog/`.
+
+`make test-uat` creates the cluster, deploys, tests, and tears down each time. When you are iterating, keep the cluster and re-run only the tests:
+
+```bash
+make setup-test-uat   # once
+make tilt-uat         # leave running in another terminal; hot-reloads
+make test-uat-run     # re-run as needed
+make cleanup-test-uat # when finished
+```
 
 Notes:
 
-- Run it on a committed tree. `make verify` regenerates code and fails when the result differs from what is committed.
+- Run `make ci` on a committed tree. `make verify` regenerates code and fails when the result differs from what is committed.
 - The first run downloads the pinned tools into `bin/` (controller-gen, golangci-lint, addlicense, setup-envtest) and the envtest Kubernetes binaries. Later runs reuse them.
 - Tool versions are pinned in the Makefile. The Go version and the envtest Kubernetes version derive from `go.mod`. Local runs and CI resolve the same versions.
 - CI's Test job runs `make test-ci`, which is the same test suite with JUnit and coverage output for the CI artifacts.


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` told contributors this:

> CI runs four required checks on every pull request: Lint, Build, Test, and Verify. One command runs the same gate locally.

Branch protection on `main` requires five:

```
Build
Lint
Test
Verify generated files, go.mod, and license headers
UAT (Kind + KWOK + Tilt)
```

`make ci` is `verify lint build test`. It does not run UAT. So a contributor can run it, see green, push, and still be blocked by a required check the docs said did not exist.

The section was accurate when #25 added it on 2026-08-06 at 13:16 UTC. UAT became a required check afterwards and the prose did not follow.

## Change

State all five checks, say which four `make ci` covers, and point at `make test-uat` for the fifth.

UAT stays out of `make ci` deliberately, and the docs now say why: it needs Docker, Kind and Tilt and takes minutes, so folding it in would slow the command contributors are told to run before every push. The reason is written down so the next reader does not chain them as an obvious improvement.

Also adds the keep-the-cluster iteration loop, since `make test-uat` creates and tears down the cluster on every run, which is a slow way to work on catalog changes.

No `Makefile` change. Every target named in the section already exists.

## Verification

- All eleven make targets named in the section exist in the `Makefile`.
- The five check names match what `branches/main/protection` returns.
- `CONTRIBUTING.md:133` was the only place in the repo making the four-checks claim, so this is the whole fix.
- `make verify` passes; one file changed.