### PR TITLE
fix: strip CNI annotations from UAT pod golden files

### DIFF
--- a/test/uat/util/helpers.go
+++ b/test/uat/util/helpers.go
@@ -346,6 +346,7 @@ func StripPodVolatile(pod *corev1.Pod) {
 	// Strip random UIDs from annotations and labels.
 	stripAnnotation(pod, "jobset.sigs.k8s.io/jobset-uid")
 	stripAnnotation(pod, "jobset.sigs.k8s.io/job-key")
+	stripCNIAnnotations(pod)
 	stripLabel(pod, "jobset.sigs.k8s.io/jobset-uid")
 	stripLabel(pod, "jobset.sigs.k8s.io/job-key")
 	stripLabel(pod, "batch.kubernetes.io/controller-uid")
@@ -384,6 +385,31 @@ func StripPodVolatile(pod *corev1.Pod) {
 func stripAnnotation(pod *corev1.Pod, key string) {
 	if pod.Annotations != nil {
 		delete(pod.Annotations, key)
+	}
+}
+
+// cniAnnotationPrefixes are annotation keys a CNI plugin writes onto a pod
+// after the pod is created. The values hold a container ID and the assigned
+// pod IP, so they differ on every run. Whether they are present at all also
+// varies, because the test may read the pod before the plugin annotates it.
+//
+// KWOK runs no real CNI, so these never appear in the simulated tests. They do
+// appear on any real cluster, and they make a golden file unusable.
+var cniAnnotationPrefixes = []string{
+	"cni.projectcalico.org/", // Calico
+	"k8s.v1.cni.cncf.io/",    // Multus network-status
+	"io.cilium/",             // Cilium
+}
+
+// stripCNIAnnotations removes every annotation written by a CNI plugin.
+func stripCNIAnnotations(pod *corev1.Pod) {
+	for key := range pod.Annotations {
+		for _, prefix := range cniAnnotationPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				delete(pod.Annotations, key)
+				break
+			}
+		}
 	}
 }
 

--- a/test/uat/util/helpers_test.go
+++ b/test/uat/util/helpers_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build uat
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// A pod read from a real cluster carries CNI annotations whose values change
+// on every run. They must not reach a golden file.
+func TestStripPodVolatileRemovesCNIAnnotations(t *testing.T) {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workload-node-0-0-abcde",
+			Annotations: map[string]string{
+				"cni.projectcalico.org/containerID": "c62cbba8b5c6751f0d078ff3",
+				"cni.projectcalico.org/podIP":       "172.29.112.176/32",
+				"cni.projectcalico.org/podIPs":      "172.29.112.176/32",
+				"k8s.v1.cni.cncf.io/network-status": "[{...}]",
+				"io.cilium/whatever":                "x",
+				"jobset.sigs.k8s.io/jobset-uid":     "1234",
+				// Must survive: CRE writes this one on purpose.
+				"ncrectl.nvidia.com/applied-overrides": "gb200",
+			},
+		},
+	}
+
+	StripPodVolatile(&pod)
+
+	for _, gone := range []string{
+		"cni.projectcalico.org/containerID",
+		"cni.projectcalico.org/podIP",
+		"cni.projectcalico.org/podIPs",
+		"k8s.v1.cni.cncf.io/network-status",
+		"io.cilium/whatever",
+		"jobset.sigs.k8s.io/jobset-uid",
+	} {
+		assert.NotContains(t, pod.Annotations, gone, "%s must be stripped", gone)
+	}
+
+	assert.Equal(t, "gb200", pod.Annotations["ncrectl.nvidia.com/applied-overrides"],
+		"annotations CRE sets on purpose must survive")
+}
+
+// Two reads of the same pod must produce the same stripped result even when
+// one read happened before the CNI plugin annotated it. This is the case that
+// made the real-cluster golden unusable.
+func TestStripPodVolatileIsStableWhenCNIAnnotationsAreAbsent(t *testing.T) {
+	withCNI := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workload-node-0-0-abcde",
+			Annotations: map[string]string{
+				"cni.projectcalico.org/podIP": "172.29.112.176/32",
+				"kubectl.kubernetes.io/x":     "keep",
+			},
+		},
+	}
+	withoutCNI := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workload-node-0-0-zyxwv",
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/x": "keep",
+			},
+		},
+	}
+
+	StripPodVolatile(&withCNI)
+	StripPodVolatile(&withoutCNI)
+
+	assert.Equal(t, withoutCNI.Annotations, withCNI.Annotations,
+		"a pod read before and after CNI annotation must strip to the same thing")
+}
+
+// A pod with no annotations at all must not panic.
+func TestStripPodVolatileNoAnnotations(t *testing.T) {
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "x"}}
+	assert.NotPanics(t, func() { StripPodVolatile(&pod) })
+}


### PR DESCRIPTION
## Problem

A pod on a real cluster carries annotations the CNI plugin writes **after** the pod is created:

```yaml
cni.projectcalico.org/containerID: 4594b6ad303fd8819a9a88254cb6b673...
cni.projectcalico.org/podIP:       172.29.112.181/32
cni.projectcalico.org/podIPs:      172.29.112.181/32
```

The container ID and pod IP change on every run, so a golden file can never match twice.

Worse, whether the annotations are present **at all** varies. The test may read the pod before or after the plugin annotates it, so the comparison is a race, not a stable mismatch. Two consecutive runs on the same cluster gave me a 6-line diff in one direction and a 3-line diff in the other.

`StripPodVolatile` removes UIDs, timestamps, `managedFields` and random name suffixes, but never touched annotations. KWOK runs no real CNI, so none of the simulated tests could surface this.

## Change

Strip annotations from the known CNI prefixes:

| Prefix | Plugin |
|---|---|
| `cni.projectcalico.org/` | Calico |
| `k8s.v1.cni.cncf.io/` | Multus network-status |
| `io.cilium/` | Cilium |

Prefix matching rather than exact keys, because the key set varies by plugin and version. Annotations CRE sets on purpose are untouched — there is a test for that.

## Verification

Against a live two-node A100 cluster, running the same certification twice and diffing the generated pod output:

```
before:  DIFFERS - 6 lines, all cni.projectcalico.org/*
after:   any CNI annotations left?  0  0
         run1 vs run2:  IDENTICAL - golden is reproducible
```

- `make lint`, `make build` pass.
- Adds `test/uat/util/helpers_test.go`, the first tests for this package: CNI prefixes are stripped, a deliberately-set CRE annotation survives, a pod read before and after annotation strips to the same result, and an annotation-less pod does not panic.

## Note

This is a prerequisite for a real-hardware golden set. It does not add one — that needs a separate change, because node names also appear in pod affinity and would need normalising for a golden to be portable between clusters.