### PR TITLE
build: make Dependabot wait before adopting a new version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Wait before adopting a new version. The common supply-chain attack is a
+    # malicious release of a real package that bots pull within hours; a delay
+    # gives the ecosystem time to spot and yank it. Patches wait the shortest
+    # time because they carry most of the security fixes.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       kubernetes:
         patterns:
@@ -25,6 +34,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
 
+  # No cooldown here: GitHub Actions is not one of the ecosystems that supports
+  # it. Actions are pinned to commit SHAs, which Dependabot raises.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -45,6 +56,9 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Docker supports default-days only; the semver bump keys are gomod-only.
+    cooldown:
+      default-days: 7
     groups:
       docker-images:
         patterns:


### PR DESCRIPTION
## Problem

The common supply-chain attack is a malicious release of a real package, relying on update bots to pull it within hours of publication. Nothing in this repository imposed a delay, so a poisoned release would have been proposed on the next weekly run.

## Change

Adds a `cooldown` to the ecosystems that support one:

| Ecosystem | Cooldown |
|---|---|
| `gomod` | 7 days default, 14 major, 7 minor, 3 patch |
| `docker` | 7 days |
| `github-actions` | none — see below |

Patch updates wait the shortest time deliberately. They carry most of the security fixes, so a long patch cooldown works against the thing this is meant to protect.

## Why the three entries differ

This is not an oversight, and the file carries comments saying so:

- **`github-actions` gets no cooldown.** GitHub does not support the option for that ecosystem. An unsupported key here would fail quietly, which is worse than not setting it. Actions are pinned to commit SHAs and Dependabot raises those pins.
- **`docker` gets `default-days` only.** The SemVer bump keys are not supported there.

Both limits are written down so nobody later adds the missing keys and assumes they took effect.

Keys and value ranges were checked against the published Dependabot v2 JSON schema, including the 1-to-90 bounds.

## Related change outside this PR

Dependabot **security updates were disabled** on this repository, which meant version updates were the only route a fix could arrive by — exactly the route this PR slows down. Merging this alone would have been a net negative.

Security updates are now enabled, so a known vulnerability still gets its own pull request without waiting out the cooldown. That is a repository setting rather than a file change, so it is not visible in this diff.

## Verification

- `.github/dependabot.yml` parses; all three ecosystem entries load.
- Every `cooldown` key validates against the published schema, and every value is in range.
- `make verify` passes.