### PR TITLE
ci: scan binaries for malware and gate the release on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,28 @@ jobs:
       - name: Build ncrectl binary
         run: make build-ncrectl
 
+      # The same scan that gates publication in release.yml. Running it here on
+      # every pull request exercises the mechanism continuously, instead of
+      # first running it on the day someone cuts a tag and blocking a release.
+      - name: Scan built binaries for malware
+        env:
+          CLAMAV_IMAGE: clamav/clamav:stable@sha256:d06c1d6a451d616e1dd79b42f44c8c8c291bba9cf4e75ebc4d0e43c1c6dd87bb
+        run: |
+          set -euo pipefail
+          # --entrypoint is required. The image's default entrypoint is /init,
+          # a supervisor that starts freshclam and clamd; without the override
+          # the arguments below reach that supervisor rather than clamscan.
+          # The stable tag ships a virus database, so no freshclam run is needed.
+          # clamscan exits 1 when it finds something and 2 on error, so set -e
+          # fails the step either way.
+          docker run --rm \
+            -v "${PWD}/bin:/scan:ro" \
+            --entrypoint clamscan \
+            "${CLAMAV_IMAGE}" \
+            --recursive --infected --suppress-ok-results \
+            --max-filesize=512M --max-scansize=2048M \
+            /scan
+
   test:
     name: Test
     runs-on: linux-amd64-cpu16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,29 @@ jobs:
           sha256sum installer ncrectl-* > checksums.txt
           cat checksums.txt
 
+      # Gate. This runs after the artifacts exist and before the release is
+      # created, so a finding fails the job and no release is ever published.
+      # Keep it above the Create GitHub Release step; moving it below would
+      # turn the gate into an alert about something already public.
+      - name: Scan release binaries for malware
+        env:
+          CLAMAV_IMAGE: clamav/clamav:stable@sha256:d06c1d6a451d616e1dd79b42f44c8c8c291bba9cf4e75ebc4d0e43c1c6dd87bb
+        run: |
+          set -euo pipefail
+          # --entrypoint is required. The image's default entrypoint is /init,
+          # a supervisor that starts freshclam and clamd; without the override
+          # the arguments below reach that supervisor rather than clamscan.
+          # The stable tag ships a virus database, so no freshclam run is needed.
+          # clamscan exits 1 when it finds something and 2 on error, so set -e
+          # fails the step either way.
+          docker run --rm \
+            -v "${PWD}/dist:/scan:ro" \
+            --entrypoint clamscan \
+            "${CLAMAV_IMAGE}" \
+            --recursive --infected --suppress-ok-results \
+            --max-filesize=512M --max-scansize=2048M \
+            /scan
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:


### PR DESCRIPTION
## Problem

Nothing checks the compiled artifacts between building them and publishing them for the world to download. A compromised build host or a poisoned dependency could put something in `ncrectl` and the release would ship it.

This is the malware-scan half of the supply-chain work in the plan (task 4.5), alongside the base-image pinning that landed in #38.

## Change

A ClamAV scan in two places.

**`release.yml` is the gate.** The step sits after the artifacts exist and after checksums are generated, but *before* `Create GitHub Release`, so a finding fails the job and no release is ever published. Order is load-bearing: placed below that step it would be an alert about something already public, not a gate. There is a comment saying so.

Worth noting CRE gets this cheaply. aicr needs a draft-then-promote dance because GoReleaser creates the release before the scan can run. CRE creates the release as the last step, so a scan before it is already a true gate with no extra machinery.

**`ci.yml` runs the identical scan on every pull request** against `bin/`. That is deliberate rather than belt-and-braces. A step that only runs on tag push is first exercised on the day someone cuts a release, and if it is wrong it blocks that release at the worst possible moment. Running it on pull requests exercises the mechanism continuously — **and this pull request is its own proof.** If the Build check passes here, the scan works.

## Two details that are easy to get wrong

- **`--entrypoint clamscan` is required.** The image's default entrypoint is `/init`, a supervisor that starts `freshclam` and `clamd`. Without the override, the arguments reach that supervisor instead and the scan silently does not happen. Failing open is the worst outcome for a security gate, so this is called out in a comment in both files.
- **The `stable` tag ships a virus database**, so there is no `freshclam` download and no `apt-get` on the runner. That matters because CRE runs on internal runner labels where `apt` availability is not something I wanted to bet a release on.

The image is pinned by digest, matching the convention set for base images in #38.

`clamscan` exits 1 on a finding and 2 on error, and `set -e` fails the step on either, so the gate fails closed.

## Verification

- Both workflows parse; job lists unchanged.
- Scan step is at line 117 of `release.yml`, `Create GitHub Release` at line 136 — gate ordering confirmed.
- The pinned digest resolves.
- `make verify` passes.
- The CI half is exercised by this PR.

## Deliberately not included

No SARIF upload to the Security tab. That needs `security-events: write` and only adds a record of something the failing job already reports loudly. Easy to add later if you want the history.