### PR TITLE
ci: run UAT nightly against main

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -8,6 +8,17 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+  # Nightly run against main. UAT compares rendered catalog output against
+  # golden files, so it can drift without any pull request touching this
+  # repository: an upstream image moves, or a catalog default changes shape.
+  # The push trigger cannot catch that. A schedule can, and finds it the next
+  # morning rather than when someone opens an unrelated pull request.
+  #
+  # workflow_dispatch above also keeps this alive. GitHub disables scheduled
+  # workflows after 60 days of repository inactivity, and a manual run re-arms
+  # the schedule.
+  schedule:
+    - cron: '0 7 * * *' # 07:00 UTC daily; runs on the default branch only
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

UAT compares rendered catalog output against golden files. That comparison can start failing without any pull request touching this repository — an upstream image moves, or a catalog default changes shape.

The push trigger cannot catch that. Today the breakage surfaces when someone opens an unrelated pull request and finds a red required check they did not cause.

## Change

Add a nightly schedule so it surfaces the next morning instead.

```yaml
  schedule:
    - cron: '0 7 * * *' # 07:00 UTC daily; runs on the default branch only
```

That is the whole change. It is three lines because the workflow already had everything else the pattern needs: `workflow_dispatch`, a concurrency group, `timeout-minutes: 60`, `permissions: contents: read`, and an `if: github.repository == ...` guard so forks never run it.

07:00 UTC sits away from the working day in US Pacific, so a failure is waiting in the morning rather than landing mid-afternoon.

## Two things worth knowing

**Concurrency behaves correctly without change.** Scheduled runs use the default branch, so `${{ github.workflow }}-${{ github.ref }}` resolves to the same group as a push to `main`, and `cancel-in-progress` stays false there. A nightly run and a push to `main` queue rather than cancel each other.

**`workflow_dispatch` is doing double duty.** Beyond manual runs, GitHub disables scheduled workflows after 60 days of repository inactivity, and a manual run re-arms the schedule. Worth not removing it later as redundant.

## Context

This closes the scheduled-test half of the plan's task 3.8. Unlike the nightly cloud tests in the sibling repos, which need an IAM role or a Workload Identity pool before they can run at all, this needs no cloud account and no credentials, because UAT runs entirely on Kind and KWOK. That is why it is worth doing now rather than after provisioning work.

## Cost

One extra UAT run per day, bounded by the existing `timeout-minutes: 60`. Recent runs take around nine minutes.