### PR TITLE
docs: add RELEASE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ CRE certifies clusters with burn-in workloads and reports the nodes that fail. C
 - [Architecture Decision Records](docs/designs/) explain the design (ADR-000 to ADR-069).
 - [CONTRIBUTING.md](CONTRIBUTING.md) describes the contribution workflow.
 - [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md) describe who decides what.
+- [RELEASE.md](RELEASE.md) describes how a release is cut and how to verify one.
 - [SECURITY.md](SECURITY.md) describes how to report a vulnerability.
 
 A hosted documentation site is in progress.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,122 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Release Process
+
+How a release of the Cluster Readiness Engine is cut, what it publishes, and how to
+check that you received what we published.
+
+## Versioning
+
+CRE follows [Semantic Versioning](https://semver.org/). Tags are `vMAJOR.MINOR.PATCH`,
+optionally with a pre-release suffix, for example `v0.1.0` or `v0.1.0-rc.7`.
+
+The project is at `v0.x`. Under SemVer that means the public surface can still change in
+a minor release. Treat CRD schemas, the `ncrectl` command line, and Helm values as
+unstable until `v1.0.0`. Breaking changes are called out in the release notes.
+
+## Cadence
+
+There is no fixed schedule. CRE releases when there is something worth releasing.
+
+Do not wait for a date to ship a fix, and do not cut a release to meet one.
+
+## Who can cut a release
+
+The maintainers listed in [MAINTAINERS.md](MAINTAINERS.md). Pushing a tag is what starts
+a release, so anyone with write access to the repository can technically start one; by
+convention it is a maintainer who does.
+
+Announce your intent on the pull request or issue that motivates the release, so two
+people do not tag at the same time.
+
+## Cutting a release
+
+1. Make sure `main` is green. Every required check must pass: Lint, Build, Test, Verify,
+   and UAT.
+2. Decide the version. See Versioning above.
+3. Tag the commit on `main` and push the tag.
+
+   ```bash
+   git checkout main && git pull --ff-only
+   git tag -s v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+
+   If you work from a fork, push the tag to the remote that points at
+   `NVIDIA/cluster-readiness-engine`, which is usually `upstream`.
+
+   Sign the tag (`-s`). Pushing the tag is the release trigger; there is no button to
+   press afterwards.
+4. Watch the `Release` workflow. If it fails, the release is incomplete — see
+   Troubleshooting.
+5. Check the published release, then announce it.
+
+Tags must be clean. `make check-clean-version` refuses to publish a Helm chart when the
+version contains `-dirty`, a `-N-gSHA` suffix, or is `dev`, which is what you get from
+tagging a working tree that is not committed.
+
+### Release candidates
+
+Cut `-rc.N` tags to validate a release before it becomes stable. They publish through the
+same pipeline and are marked as pre-releases on GitHub, so they do not become the
+`latest` release.
+
+When an RC is good, tag the **same commit** with the stable version. Do not rebuild or
+re-merge between the RC and the stable tag; that would ship something nobody validated.
+
+Note that `curl .../releases/latest/download/installer`, the install command in the
+README, resolves to the newest **stable** release. While only pre-releases exist, that URL
+returns 404.
+
+## What a release publishes
+
+Pushing a `v*` tag runs three jobs in `.github/workflows/release.yml`:
+
+| Job | Publishes |
+|---|---|
+| Publish Helm Chart | `oci://ghcr.io/nvidia/cluster-readiness-engine` |
+| Build CLI Binaries | cross-compiled `ncrectl` for linux and macOS, amd64 and arm64 |
+| Create GitHub Release | the GitHub Release, its notes, and the assets below |
+
+The container image is published separately by `.github/workflows/publish.yml` as
+`ghcr.io/nvidia/cluster-readiness-engine/manager:<tag>`.
+
+Release assets:
+
+- `installer` — the install script the README points at
+- `ncrectl-linux-amd64`, `ncrectl-linux-arm64`
+- `ncrectl-darwin-amd64`, `ncrectl-darwin-arm64`
+- `checksums.txt` — SHA-256 of every asset above
+
+## Verifying a release
+
+```bash
+VERSION=v0.1.0
+BASE=https://github.com/NVIDIA/cluster-readiness-engine/releases/download/$VERSION
+curl -sSLO "$BASE/checksums.txt"
+curl -sSLO "$BASE/ncrectl-linux-amd64"
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Releases up to and including `v0.1.0-rc.7` predate the checksum step and carry no
+`checksums.txt`.
+
+## Troubleshooting
+
+**The workflow failed partway.** Jobs publish independently, so a release can be
+half-published: the chart pushed but no GitHub Release, or the reverse. Read the run,
+fix the cause, and re-run the failed jobs from the Actions tab. Do not delete and re-push
+a tag that has already published artifacts — consumers may have it. Cut the next patch
+version instead.
+
+**The Helm push failed on `check-clean-version`.** The tag was not clean. Delete the tag
+if nothing published, commit your work, and tag again.
+
+**`releases/latest` returns 404.** No stable release exists yet. Use an explicit version
+in the download URL.
+
+## See also
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to get a change into `main` before it ships
+- [MAINTAINERS.md](MAINTAINERS.md) — who the maintainers are


### PR DESCRIPTION
## Read this as a starting point, not a finished policy

The mechanics here are checked against the repository and should be correct. The **policy** parts are my best reading of how CRE actually works, and maintainers should correct them rather than inherit them. Two in particular:

- **Cadence.** Written as "releases when there is something worth releasing", with no fixed schedule.
- **Who cuts a release.** Written as the maintainers in `MAINTAINERS.md`, with a note that anyone with write access can technically push a tag, since tags are not covered by branch protection.

If either is wrong, say so on this PR and I will change it. Better to land something that can be corrected than to keep the process undocumented.

## Problem

How a release is cut lived in `release.yml` and in the heads of the people who had done it. Nothing told a maintainer what to tag, what the tag would publish, or what to check afterwards. Nothing told a consumer how to verify what they downloaded.

## Change

`RELEASE.md`, 119 lines: versioning and tag convention, cadence, who cuts a release, the tagging steps, what each job publishes, how to verify a download against `checksums.txt`, and what to do when the pipeline fails partway. Linked from the README's Documentation section.

## Verified against the repo rather than described from memory

- the `'v*'` trigger and the three job names in `release.yml`
- the chart target `oci://ghcr.io/nvidia` from `HELM_OCI_REGISTRY`
- the image name in `publish.yml`
- the `check-clean-version` guard on `helm-push`
- the checksums step
- both relative links resolve; `make verify` passes

## Three warnings worth keeping

These are in the document because they are easy to get wrong and are invisible from reading the workflow:

- **Promote a release candidate by tagging the same commit.** Rebuilding between the RC and the stable tag ships something nobody validated.
- **Do not delete and re-push a tag that has already published artifacts.** Consumers may hold it. Cut the next patch version instead.
- **`releases/latest` resolves to the newest _stable_ release**, so the README's install command returns 404 while only pre-releases exist. That is a live 404 today, and without this note it reads as a broken install script.

## Scope

Deliberately excludes anything unmerged, so there is no mention of the malware-scan gate in #44 or the Dependabot cooldown in #42. Those get a follow-up line once they land.