### PR TITLE
ci: group the generated release notes by category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Groups the release notes that `generate_release_notes: true` produces in
+# .github/workflows/release.yml. Without this file every merged pull request
+# lands in one flat list, so a dependency bump reads the same as a fix.
+#
+# Categories match on pull request LABELS, not on the commit or title prefix.
+# A pull request with no label falls through to Other Changes, so an unlabelled
+# release is no worse off than it is today. Labelling one improves it.
+
+changelog:
+  categories:
+    # Order matters: the first matching category wins, and "*" only catches
+    # what nothing above claimed.
+    - title: New Features
+      labels:
+        - enhancement
+
+    - title: Bug Fixes
+      labels:
+        - bug
+
+    - title: Documentation
+      labels:
+        - documentation
+
+    # Grouped rather than excluded. Dependency bumps are worth publishing —
+    # a consumer deciding whether to upgrade wants to see them — but they are
+    # noise interleaved with the human changes, and they already carry this
+    # label from Dependabot, so this section works with no extra effort.
+    - title: Dependency Updates
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Problem

`release.yml` already sets `generate_release_notes: true`, so GitHub lists every merged pull request. It lists them **flat**. A dependency bump reads the same as a bug fix, and a reader has to scan the whole list to find what changed for them.

## Change

`.github/release.yml`, 38 lines with comments. GitHub groups the list it already generates. No change to how a release is cut, no new tooling, no new workflow.

Sections: New Features, Bug Fixes, Documentation, Dependency Updates, Other Changes.

## The limitation, stated up front

Categories match on **pull request labels**. That is the only thing GitHub's generator can match on — it cannot read a commit or title prefix, so the Conventional Commit prefixes this project already uses do not help here.

Most human pull requests carry no labels today, so they land in **Other Changes**. That is exactly where they land now, so nothing gets worse, and labelling a pull request starts paying immediately.

**Two sections work from day one:** Dependency Updates, because Dependabot applies the `dependencies` label itself, and Other Changes.

## Why dependency bumps are grouped rather than excluded

The obvious move is to drop them from the notes entirely, which is what aicr does via GoReleaser's changelog filters. I did not, because a consumer deciding whether to upgrade wants to see them. The problem was never that dependency bumps are published — it was that they were interleaved with everything else. A section at the bottom fixes that without hiding information.

## Verification

- Parses, and every key checked against the documented schema (`changelog.exclude.{labels,authors}`, `changelog.categories[].{title,labels,exclude}`).
- All four referenced labels — `enhancement`, `bug`, `documentation`, `dependencies` — already exist in the repository.
- The `"*"` catch-all is last, so it only claims what nothing above matched.
- `make verify` passes.

## Possible follow-up

If you want the categories to fill themselves, a small workflow could apply `enhancement`, `bug` or `documentation` from the Conventional Commit prefix already in the pull request title. Titles are consistent enough for it — the last 20 merged pull requests break down as 6 `fix`, 4 `build`, 4 `docs`, 2 `chore`, 2 `feat`, 1 `ci`, 1 `test`. Not included here because it is a separate change with its own trade-offs.