### PR TITLE
docs: name the registry CRE publishes to in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,33 @@ kubectl ncre certification report <name> -n <namespace>
 └────────────────────────────────────────────────────────────────┘
 ```
 
+### Install from the registry instead
+
+`setup init` above is the quickest path. If you would rather manage CRE with
+Helm, or need to pin the controller image in your own manifests, both are
+published to the GitHub Container Registry on every release.
+
+```bash
+CRE_VERSION=v0.1.0-rc.7
+
+# Inspect the chart before installing it
+helm show chart oci://ghcr.io/nvidia/cluster-readiness-engine --version "$CRE_VERSION"
+
+helm install cluster-readiness-engine \
+  oci://ghcr.io/nvidia/cluster-readiness-engine \
+  --version "$CRE_VERSION" \
+  --namespace cluster-readiness-engine \
+  --create-namespace
+```
+
+The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagged
+with the same release version. Builds from `main` are also published, tagged
+`main-<commit-sha>`; use a release tag rather than one of those.
+
+Pin an explicit version rather than installing whatever is newest. Chart and
+image versions move together, so the two commands above and your own manifests
+should all name the same tag.
+
 ## Run a training workload
 
 WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Write a YAML file with an image, a framework, and a node count. CRE detects the platform and GPU architecture.


### PR DESCRIPTION
## Problem

CRE publishes a Helm chart and a controller image to `ghcr.io` on every release. The README named neither.

Someone who wants to manage CRE with Helm, or pin the controller image in their own manifests, had to read the `Makefile` or a workflow to find out where either lives. Both are real, published, and versioned per release — just undiscoverable.

## Change

A short section in the Quickstart with the OCI chart install and the image reference. 27 lines. The existing install path is untouched.

## Verified against what is actually published

Not derived from the Makefile — checked against the registry:

- `v0.1.0-rc.7` exists as a chart tag (chart tags run `rc.2` through `rc.7`)
- `v0.1.0-rc.7` exists as an image tag
- chart at `oci://ghcr.io/nvidia/cluster-readiness-engine`, image at `ghcr.io/nvidia/cluster-readiness-engine/manager`
- the `main-<sha>` tag scheme is real; there are 20 such tags on the image today
- the namespace matches `creNamespace` in `pkg/setup/setup.go`, so a Helm install lands where the CLI expects to find the controller
- `make verify` passes

## Three things called out because a reader would otherwise get them wrong

- **Pin an explicit version.** Chart and image versions move together, so the install and your manifests should name the same tag.
- **`helm show chart` first**, so the chart can be inspected before it is installed.
- **`main-<sha>` images exist but are not for use.** They outnumber the release tags, so someone browsing the package list would plausibly grab one.

## Why this shape

Modelled on NVSentinel's install section rather than aicr's. aicr's README names no registry at all, hiding distribution behind Homebrew and an install script — it reads nicely, but leaves the container path undiscoverable, which is the problem being fixed here.