### PR TITLE
ci: pull docker.io images through a mirror to avoid rate limiting

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -32,7 +32,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pull docker.io images through Google's public mirror. The build pulls
+      # golang from Docker Hub, which rate-limits anonymous pulls per source
+      # IP; the shared runner egress hits that ceiling when several builds run
+      # at once, failing with 429 Too Many Requests. The mirror is a
+      # pull-through cache, so it serves the identical digests the Dockerfile
+      # pins and needs no credentials. Builds fall back to docker.io if the
+      # mirror does not have a layer.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       # A branch name such as "pull-request/26" holds a slash, which a docker
       # tag cannot. Replace every character a tag does not allow, then cut the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pull docker.io images through Google's public mirror. The build pulls
+      # golang from Docker Hub, which rate-limits anonymous pulls per source
+      # IP; the shared runner egress hits that ceiling when several builds run
+      # at once, failing with 429 Too Many Requests. The mirror is a
+      # pull-through cache, so it serves the identical digests the Dockerfile
+      # pins and needs no credentials. Builds fall back to docker.io if the
+      # mirror does not have a layer.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0


### PR DESCRIPTION
## Problem

The container build pulls `golang` from Docker Hub, which rate-limits anonymous pulls per source IP. The runner egress is shared, so when several builds run at once the pull fails:

```
ERROR: failed to solve: golang:1.26.5@sha256:2005724…
  registry-1.docker.io … 429 Too Many Requests
```

This took out `Docker Build` on **five open pull requests simultaneously** (#37, #45, #46, #47, #48) after they were rebased and rebuilt together. Re-running does not help — the quota resets on a six hour window, not per run. I confirmed that by re-running one and getting the same 429.

## Change

Point buildx at Google's public pull-through cache for `docker.io`, in both workflows that build images:

```yaml
        with:
          buildkitd-config-inline: |
            [registry."docker.io"]
              mirrors = ["mirror.gcr.io"]
```

## Why this is safe

- **The pinned digest still resolves.** The mirror is content-addressed, so it serves identical digests. I verified `mirror.gcr.io` resolves `golang@sha256:2005724102f4…c365` — the exact digest pinned in #38. Nothing about digest pinning or the Dependabot `docker` ecosystem changes.
- **No Dockerfile change, no credentials.** Authenticating to Docker Hub would also fix this but needs a secret; this does not.
- **Local builds are unaffected.** The config applies only where buildx is set up in CI.
- **It degrades gracefully.** buildx falls back to `docker.io` when the mirror does not hold a layer.
- **`buildkitd-config-inline` is a real input on the pinned action version.** It is at line 26 of `action.yml` for `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c`. Worth confirming, because an unknown `with:` key is ignored silently rather than failing.
- `make verify` passes.

## Scope note

`Docker Build` is **not** a required status check, so none of the five affected PRs are blocked by this — they are all mergeable with every required check green. This fixes a real recurring failure rather than unblocking anything, and it will keep recurring whenever several builds run at once.