### PR TITLE
ci: pin the last floating action refs to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -47,12 +47,12 @@ jobs:
           sudo docker image prune --all --force
           docker system prune -f
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.19.2
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Kind logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uat-kind-logs-${{ github.run_id }}
           path: /tmp/kind-logs/
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uat-debug-artifacts-${{ github.run_id }}
           path: /tmp/debug-artifacts/


### PR DESCRIPTION
## Problem

#14 pinned every third-party action to a commit SHA, but `codeql.yml` and `uat.yml` kept floating major-version tags. A tag can be repointed at different code, so those two workflows ran whatever the tag owner had published most recently — including on the UAT job, which is a required check.

## Change

Five references pinned:

| File | Was | Now |
|---|---|---|
| `codeql.yml` | `actions/setup-go@v7` | `b7ad1dad…` `# v7.0.0` |
| `uat.yml` | `actions/setup-go@v7` | `b7ad1dad…` `# v7.0.0` |
| `uat.yml` | `azure/setup-helm@v5` | `9bc31f4e…` `# v5.0.1` |
| `uat.yml` | `actions/upload-artifact@v7` ×2 | `043fb46d…` `# v7.0.1` |

`setup-go` resolves to the SHA `ci.yml` already pins, so all three workflows now agree on one version rather than two that happened to coincide.

**After this, no action reference anywhere in `.github/` is unpinned.**

## Verification

- Every SHA was resolved from its tag through the GitHub API, then confirmed to be a real commit in its own repository — not copied across from another workflow.
- Both workflows parse.
- A repo-wide sweep for `uses:` refs without a 40-hex SHA now returns nothing.
- `make verify` passes.

## No behaviour change

Each SHA is the commit its floating tag points at **today**. This fixes what those tags could become tomorrow, not what they are now. Dependabot's `github-actions` ecosystem already groups and raises these pins weekly, so pinning does not freeze them.

## Note for whoever merges

This touches `uat.yml`, as does #45, but in different regions — #45 changes the `on:` block, this changes step `uses:` lines. They should not conflict, though whichever lands second will want a rebase.