### PR TITLE
chore: set rebase strategy for all Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    rebase-strategy: rebase
     # Wait before adopting a new version. The common supply-chain attack is a
     # malicious release of a real package that bots pull within hours; a delay
     # gives the ecosystem time to spot and yank it. Patches wait the shortest
@@ -42,6 +43,7 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    rebase-strategy: rebase
     groups:
       actions:
         patterns:
@@ -56,6 +58,7 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    rebase-strategy: rebase
     # Docker supports default-days only; the semver bump keys are gomod-only.
     cooldown:
       default-days: 7


### PR DESCRIPTION
Set `rebase-strategy: rebase` on all three Dependabot ecosystems (gomod, github-actions, docker).

Without this, Dependabot updates branches with a merge commit whose message (`Merge branch 'main' into ...`) does not match the Conventional Commits branch ruleset, blocking the "Update branch" button on its PRs.

With rebase, Dependabot replays its own commit on top of main — no new commit message is introduced and the existing one already matches the pattern.

Mirrors [NVIDIA/cluster-api-provider-launchlayer#15](https://github.com/NVIDIA/cluster-api-provider-launchlayer/pull/15).