### PR TITLE
docs: correct the GB300 render spot-check in the agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,21 +228,38 @@ spec:
 
 1. **Override tracking** — Check `ncrectl.nvidia.com/applied-overrides` annotation to confirm the right overrides matched, and `detected-gpu-architecture`/`detected-platform` are correct.
 
-2. **Architecture-specific env vars** — EFA vars (`FI_EFA_USE_DEVICE_RDMA`, `LD_LIBRARY_PATH`, `PATH`, `OPAL_PREFIX`) should ONLY appear for GB200 and H100 on AWS (EFA interconnect), NOT for GB300 (RoCE).
+2. **Architecture-specific env vars** — `FI_EFA_USE_DEVICE_RDMA` should ONLY appear for GB200 and H100 on AWS (EFA interconnect), NOT for GB300 (RoCE).
+
+   `LD_LIBRARY_PATH` and `PATH` are **not** EFA markers. GB300 on AWS sets them on purpose (`pkg/catalog/entries/_lib/nccl/aws-gb300-roce-env.yaml`), pointing at `/opt/amazon/openmpi/lib`, which is correct on an AWS instance whatever the interconnect. Do not treat them as leakage.
 
 3. **Resources by architecture**:
    - GB200: `hugepages-2Mi: 10256Mi`, `vpc.amazonaws.com/efa: 4`, `amazon-efa` hostPath volume
    - GB300: `roce-channel` resource claim with `roce.networking.k8s.aws`, NO hugepages, NO EFA
    - H100: `vpc.amazonaws.com/efa: 32`, NO hugepages, NO ComputeDomain
 
-4. **Spot-check with grep**:
-   ```bash
-   # Should return NOTHING for GB300
-   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 | grep -E "FI_EFA|LD_LIBRARY|OPAL_PREFIX|hugepages"
+4. **Spot-check with grep**. Use only markers that really are EFA specific:
 
-   # Should show EFA vars and hugepages for GB200
-   ./bin/ncrectl certification render --platform aws /tmp/cert-gb200.yaml 2>&1 | grep -E "FI_EFA|LD_LIBRARY|OPAL_PREFIX|hugepages"
+   ```bash
+   # Should return NOTHING for GB300 (RoCE)
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 \
+     | grep -E "FI_EFA|hugepages|vpc.amazonaws.com/efa"
+
+   # Should show all three for GB200 (EFA)
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb200.yaml 2>&1 \
+     | grep -E "FI_EFA|hugepages|vpc.amazonaws.com/efa"
+
+   # And GB300 should show RoCE instead
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 | grep -c roce
    ```
+
+   Rendered counts for `communication/nccl-all-reduce` on AWS, for reference:
+
+   | Pattern | gb200 | gb300 |
+   |---|---|---|
+   | `FI_EFA` | 2 | 0 |
+   | `hugepages` | 2 | 0 |
+   | `vpc.amazonaws.com/efa` | 2 | 0 |
+   | `roce` | 0 | 6 |
 
 ### Override Semantics (Critical)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,21 +228,38 @@ spec:
 
 1. **Override tracking** — Check `ncrectl.nvidia.com/applied-overrides` annotation to confirm the right overrides matched, and `detected-gpu-architecture`/`detected-platform` are correct.
 
-2. **Architecture-specific env vars** — EFA vars (`FI_EFA_USE_DEVICE_RDMA`, `LD_LIBRARY_PATH`, `PATH`, `OPAL_PREFIX`) should ONLY appear for GB200 and H100 on AWS (EFA interconnect), NOT for GB300 (RoCE).
+2. **Architecture-specific env vars** — `FI_EFA_USE_DEVICE_RDMA` should ONLY appear for GB200 and H100 on AWS (EFA interconnect), NOT for GB300 (RoCE).
+
+   `LD_LIBRARY_PATH` and `PATH` are **not** EFA markers. GB300 on AWS sets them on purpose (`pkg/catalog/entries/_lib/nccl/aws-gb300-roce-env.yaml`), pointing at `/opt/amazon/openmpi/lib`, which is correct on an AWS instance whatever the interconnect. Do not treat them as leakage.
 
 3. **Resources by architecture**:
    - GB200: `hugepages-2Mi: 10256Mi`, `vpc.amazonaws.com/efa: 4`, `amazon-efa` hostPath volume
    - GB300: `roce-channel` resource claim with `roce.networking.k8s.aws`, NO hugepages, NO EFA
    - H100: `vpc.amazonaws.com/efa: 32`, NO hugepages, NO ComputeDomain
 
-4. **Spot-check with grep**:
-   ```bash
-   # Should return NOTHING for GB300
-   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 | grep -E "FI_EFA|LD_LIBRARY|OPAL_PREFIX|hugepages"
+4. **Spot-check with grep**. Use only markers that really are EFA specific:
 
-   # Should show EFA vars and hugepages for GB200
-   ./bin/ncrectl certification render --platform aws /tmp/cert-gb200.yaml 2>&1 | grep -E "FI_EFA|LD_LIBRARY|OPAL_PREFIX|hugepages"
+   ```bash
+   # Should return NOTHING for GB300 (RoCE)
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 \
+     | grep -E "FI_EFA|hugepages|vpc.amazonaws.com/efa"
+
+   # Should show all three for GB200 (EFA)
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb200.yaml 2>&1 \
+     | grep -E "FI_EFA|hugepages|vpc.amazonaws.com/efa"
+
+   # And GB300 should show RoCE instead
+   ./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 | grep -c roce
    ```
+
+   Rendered counts for `communication/nccl-all-reduce` on AWS, for reference:
+
+   | Pattern | gb200 | gb300 |
+   |---|---|---|
+   | `FI_EFA` | 2 | 0 |
+   | `hugepages` | 2 | 0 |
+   | `vpc.amazonaws.com/efa` | 2 | 0 |
+   | `roce` | 0 | 6 |
 
 ### Override Semantics (Critical)
 


### PR DESCRIPTION
## Problem

`CLAUDE.md` / `AGENTS.md` tell an agent to confirm there is no EFA leakage on GB300 with:

```bash
# Should return NOTHING for GB300
./bin/ncrectl certification render --platform aws /tmp/cert-gb300.yaml 2>&1 \
  | grep -E "FI_EFA|LD_LIBRARY|OPAL_PREFIX|hugepages"
```

It does not return nothing. Two of the four patterns are wrong.

Rendered counts for `communication/nccl-all-reduce` on AWS, measured against `main`:

| Pattern | gb200 | gb300 |
|---|---|---|
| `FI_EFA` | 2 | 0 |
| `hugepages` | 2 | 0 |
| `vpc.amazonaws.com/efa` | 2 | 0 |
| **`LD_LIBRARY`** | 2 | **1** |
| **`OPAL_PREFIX`** | **0** | **0** |
| `roce` | 0 | 6 |

- **`LD_LIBRARY_PATH` is set for GB300 deliberately**, by `pkg/catalog/entries/_lib/nccl/aws-gb300-roce-env.yaml:6-7`, pointing at `/opt/amazon/openmpi/lib`. That is correct on an AWS instance whatever the interconnect. It is not leakage.
- **`OPAL_PREFIX` appears in neither render**, so listing it as a GB200 marker is wrong too.

**The architecture split itself is correct.** Only the check is wrong — and a wrong check here is expensive, because it sends an agent to "fix" catalog code that already works.

## Change

- Spot-check uses `FI_EFA`, `hugepages`, `vpc.amazonaws.com/efa` — the three that really are EFA specific.
- Adds a positive `roce` check for the GB300 side, so the test is not purely negative.
- Records the expected counts in the doc, so the next reader can tell a real regression from a bad pattern.
- Corrects the prose above it, which listed `LD_LIBRARY_PATH` and `OPAL_PREFIX` as EFA vars.

## Verification

Ran the corrected commands verbatim against `main`:

```
GB300, should be empty:      (no output)
GB200, should match:         6
GB300 roce count:            6
```

`AGENTS.md` regenerated from `CLAUDE.md`; `make check-agents-sync` passes. `make lint` clean. Docs only — no code, no behaviour change.

## How this was found

Running the catalog against a real two-node A100 cluster. The spot-check reported a "leak" that turned out to be intentional configuration, which cost time chasing a non-bug.