### PR TITLE
fix: make failureLog usable for triage

### DIFF
--- a/api/v1alpha1/job_types.go
+++ b/api/v1alpha1/job_types.go
@@ -298,6 +298,8 @@ type JobStatus struct {
 	// failureLog captures the tail of pod logs from the most recent workload failure.
 	// Populated when the Job transitions to Failed. Only the pod that caused the
 	// failure (earliest non-zero exit code) is captured. Overwritten on each retry.
+	// Always set on failure: when no pod was available to read, reason and tail
+	// record why rather than leaving the field unset.
 	// +optional
 	FailureLog *FailureLog `json:"failureLog,omitempty"`
 }
@@ -313,7 +315,8 @@ type FailureLog struct {
 	// reason is the termination reason (e.g., "OOMKilled", "Error").
 	// +optional
 	Reason string `json:"reason,omitempty"`
-	// tail is the last ~30 lines of the failed container's logs.
+	// tail is the end of the failed container's logs, up to 32 KB.
+	// When no pod was available to read, this explains why instead.
 	// +optional
 	Tail string `json:"tail,omitempty"`
 }

--- a/helm/cluster-readiness-engine/crds/cre.nvidia.com_jobs.yaml
+++ b/helm/cluster-readiness-engine/crds/cre.nvidia.com_jobs.yaml
@@ -6484,6 +6484,8 @@ spec:
                   failureLog captures the tail of pod logs from the most recent workload failure.
                   Populated when the Job transitions to Failed. Only the pod that caused the
                   failure (earliest non-zero exit code) is captured. Overwritten on each retry.
+                  Always set on failure: when no pod was available to read, reason and tail
+                  record why rather than leaving the field unset.
                 properties:
                   exitCode:
                     description: exitCode is the container's exit code.
@@ -6500,8 +6502,9 @@ spec:
                       "Error").
                     type: string
                   tail:
-                    description: tail is the last ~30 lines of the failed container's
-                      logs.
+                    description: |-
+                      tail is the end of the failed container's logs, up to 32 KB.
+                      When no pod was available to read, this explains why instead.
                     type: string
                 required:
                 - exitCode

--- a/pkg/controller/failure_log_test.go
+++ b/pkg/controller/failure_log_test.go
@@ -5,7 +5,7 @@ package controller
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -17,173 +17,135 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
-func TestReadLogTailKeepsTheEnd(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		max   int
-		want  string
-	}{
-		{
-			name:  "shorter than the cap is returned whole",
-			input: "line one\nline two\n",
-			max:   1024,
-			want:  "line one\nline two\n",
-		},
-		{
-			name:  "longer than the cap keeps the end, not the start",
-			input: "START-DROP-THIS" + strings.Repeat("x", 100) + "END-KEEP-THIS",
-			max:   20,
-			want:  "xxxxxxxEND-KEEP-THIS",
-		},
-		{
-			name:  "empty stream",
-			input: "",
-			max:   1024,
-			want:  "",
-		},
-		{
-			name:  "exactly the cap",
-			input: "abcde",
-			max:   5,
-			want:  "abcde",
-		},
+// The stored tail was 30 lines, right for a workload whose last line is the
+// error and wrong for one printing a structured document: a failed dcgmi diag
+// stored 392 bytes ending in "status" : "Pass". The byte cap also has to trim
+// from the front, because the newest output is the part that matters.
+func TestFailureLogTail(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "failure-log-tail",
+		ExpectedSuffix: ".json",
 	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			MaxBytes int    `yaml:"maxBytes"`
+			Text     string `yaml:"text"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := readLogTail(strings.NewReader(tt.input), tt.max)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-			require.LessOrEqual(t, len(got), tt.max)
-		})
-	}
+		got, err := readLogTail(strings.NewReader(in.Text), in.MaxBytes)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.MarshalIndent(struct {
+			Kept      string `json:"kept"`
+			KeptBytes int    `json:"keptBytes"`
+		}{got, len(got)}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
 }
 
-// The reader must keep the end even when the stream arrives in many small
-// chunks, which is how a live pod log stream behaves.
+// A Job that fails after its pod is gone must still carry a record saying so.
+// captureFailureLog used to return silently, leaving status.failureLog unset.
+func TestFailureLogCapture(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "failure-log-capture",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Pods []struct {
+				Name    string `yaml:"name"`
+				Running bool   `yaml:"running"`
+			} `yaml:"pods"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		scheme := runtime.NewScheme()
+		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+			return err
+		}
+		if err := corev1.AddToScheme(scheme); err != nil {
+			return err
+		}
+
+		objs := make([]client.Object, 0, len(in.Pods))
+		for _, sp := range in.Pods {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sp.Name, Namespace: "ns",
+					Labels: map[string]string{"cre.nvidia.com/job": "j"},
+				},
+			}
+			if sp.Running {
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  "node",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}}
+			}
+			objs = append(objs, pod)
+		}
+
+		job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		// Clientset is only dereferenced once a failed pod is found, which is
+		// the path these cases do not take.
+		r := &JobReconciler{Client: c, Scheme: scheme, Clientset: &kubernetes.Clientset{}}
+
+		r.captureFailureLog(context.Background(), job)
+
+		b, err := json.MarshalIndent(job.Status.FailureLog, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}
+
+// Two properties are not input-in, JSON-out: that the window survives a stream
+// arriving one byte at a time, and the limits themselves.
 func TestReadLogTailAcrossChunkedReads(t *testing.T) {
 	var sb strings.Builder
 	for i := range 5000 {
-		fmt.Fprintf(&sb, "log line %d\n", i)
+		sb.WriteString("log line ")
+		sb.WriteString(strings.Repeat("x", i%3))
+		sb.WriteString("\n")
 	}
 	full := sb.String()
 
-	got, err := readLogTail(iotest_oneByteReader{strings.NewReader(full)}, 512)
+	got, err := readLogTail(oneByteReader{strings.NewReader(full)}, 512)
 	require.NoError(t, err)
 	require.Len(t, got, 512)
-	require.Equal(t, full[len(full)-512:], got, "must be the last 512 bytes of the stream")
-	require.Contains(t, got, "log line 4999", "the most recent line must survive")
+	require.Equal(t, full[len(full)-512:], got)
 }
 
-// oneByteReader forces the loop to append across many iterations.
-type iotest_oneByteReader struct{ r io.Reader }
+type oneByteReader struct{ r io.Reader }
 
-func (o iotest_oneByteReader) Read(p []byte) (int, error) {
+func (o oneByteReader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 	return o.r.Read(p[:1])
 }
 
-// A structured document is why the old 30-line tail was wrong. This is the real
-// shape of dcgmi diag --json, measured on dcgm 4.5.2 against an A100: the run
-// summary and the closing braces are at the end, and the per-test status that
-// matters is earlier in the document.
-func TestReadLogTailOnStructuredOutput(t *testing.T) {
-	doc := `{
-	"Diagnostic" : {
-		"test_categories" : [
-			{
-				"category" : "Hardware",
-				"tests" : [
-					{
-						"name" : "diagnostic",
-						"results" : [ { "status" : "Fail", "gpu_id" : 0 } ]
-					}
-				]
-			}
-		]
-	},
-	"metadata" : { "version" : "4.5.2" }
-}`
-
-	// The old behaviour: a small tail keeps only the closing structure.
-	small, err := readLogTail(strings.NewReader(doc), 60)
-	require.NoError(t, err)
-	require.NotContains(t, small, `"status" : "Fail"`,
-		"a small tail misses the failing test, which is the bug being fixed")
-
-	// The new cap is far larger than this document, so the failure survives.
-	full, err := readLogTail(strings.NewReader(doc), failureLogMaxBytes)
-	require.NoError(t, err)
-	require.Contains(t, full, `"status" : "Fail"`)
-	require.Equal(t, doc, full)
-}
-
 func TestFailureLogLimits(t *testing.T) {
 	require.Equal(t, 800, failureLogTailLines,
 		"30 lines truncated dcgmi diag --json to its closing braces")
 	require.Equal(t, 32*1024, failureLogMaxBytes)
-}
-
-// A Job that fails after its pod is gone must still carry a record saying so.
-// Before this, captureFailureLog returned silently and status.failureLog was
-// absent, so the operator saw a failed Job with no diagnostics at all.
-func TestCaptureFailureLogAlwaysRecordsSomething(t *testing.T) {
-	tests := []struct {
-		name       string
-		pods       []client.Object
-		wantReason string
-		wantTail   string
-	}{
-		{
-			name:       "pod already deleted",
-			pods:       nil,
-			wantReason: "PodNotFound",
-			wantTail:   "deleted before its logs could be read",
-		},
-		{
-			name: "pod present but nothing terminated badly",
-			pods: []client.Object{&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "p", Namespace: "ns",
-					Labels: map[string]string{"cre.nvidia.com/job": "j"},
-				},
-				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
-					Name:  "node",
-					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
-				}}},
-			}},
-			wantReason: "NoTerminatedContainer",
-			wantTail:   "none had a container terminated with a non-zero exit code",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			require.NoError(t, burninv1alpha1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
-
-			job := &burninv1alpha1.Job{
-				ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
-			}
-
-			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.pods...).Build()
-			// Clientset is only dereferenced when a failed pod is found, which is
-			// exactly the path these cases do not take.
-			r := &JobReconciler{Client: c, Scheme: scheme, Clientset: &kubernetes.Clientset{}}
-
-			r.captureFailureLog(context.Background(), job)
-
-			require.NotNil(t, job.Status.FailureLog, "a failed Job must never carry no record")
-			require.Equal(t, tt.wantReason, job.Status.FailureLog.Reason)
-			require.Contains(t, job.Status.FailureLog.Tail, tt.wantTail)
-		})
-	}
 }

--- a/pkg/controller/failure_log_test.go
+++ b/pkg/controller/failure_log_test.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+)
+
+func TestReadLogTailKeepsTheEnd(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		max   int
+		want  string
+	}{
+		{
+			name:  "shorter than the cap is returned whole",
+			input: "line one\nline two\n",
+			max:   1024,
+			want:  "line one\nline two\n",
+		},
+		{
+			name:  "longer than the cap keeps the end, not the start",
+			input: "START-DROP-THIS" + strings.Repeat("x", 100) + "END-KEEP-THIS",
+			max:   20,
+			want:  "xxxxxxxEND-KEEP-THIS",
+		},
+		{
+			name:  "empty stream",
+			input: "",
+			max:   1024,
+			want:  "",
+		},
+		{
+			name:  "exactly the cap",
+			input: "abcde",
+			max:   5,
+			want:  "abcde",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readLogTail(strings.NewReader(tt.input), tt.max)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, len(got), tt.max)
+		})
+	}
+}
+
+// The reader must keep the end even when the stream arrives in many small
+// chunks, which is how a live pod log stream behaves.
+func TestReadLogTailAcrossChunkedReads(t *testing.T) {
+	var sb strings.Builder
+	for i := range 5000 {
+		fmt.Fprintf(&sb, "log line %d\n", i)
+	}
+	full := sb.String()
+
+	got, err := readLogTail(iotest_oneByteReader{strings.NewReader(full)}, 512)
+	require.NoError(t, err)
+	require.Len(t, got, 512)
+	require.Equal(t, full[len(full)-512:], got, "must be the last 512 bytes of the stream")
+	require.Contains(t, got, "log line 4999", "the most recent line must survive")
+}
+
+// oneByteReader forces the loop to append across many iterations.
+type iotest_oneByteReader struct{ r io.Reader }
+
+func (o iotest_oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return o.r.Read(p[:1])
+}
+
+// A structured document is why the old 30-line tail was wrong. This is the real
+// shape of dcgmi diag --json, measured on dcgm 4.5.2 against an A100: the run
+// summary and the closing braces are at the end, and the per-test status that
+// matters is earlier in the document.
+func TestReadLogTailOnStructuredOutput(t *testing.T) {
+	doc := `{
+	"Diagnostic" : {
+		"test_categories" : [
+			{
+				"category" : "Hardware",
+				"tests" : [
+					{
+						"name" : "diagnostic",
+						"results" : [ { "status" : "Fail", "gpu_id" : 0 } ]
+					}
+				]
+			}
+		]
+	},
+	"metadata" : { "version" : "4.5.2" }
+}`
+
+	// The old behaviour: a small tail keeps only the closing structure.
+	small, err := readLogTail(strings.NewReader(doc), 60)
+	require.NoError(t, err)
+	require.NotContains(t, small, `"status" : "Fail"`,
+		"a small tail misses the failing test, which is the bug being fixed")
+
+	// The new cap is far larger than this document, so the failure survives.
+	full, err := readLogTail(strings.NewReader(doc), failureLogMaxBytes)
+	require.NoError(t, err)
+	require.Contains(t, full, `"status" : "Fail"`)
+	require.Equal(t, doc, full)
+}
+
+func TestFailureLogLimits(t *testing.T) {
+	require.Equal(t, 800, failureLogTailLines,
+		"30 lines truncated dcgmi diag --json to its closing braces")
+	require.Equal(t, 32*1024, failureLogMaxBytes)
+}
+
+// A Job that fails after its pod is gone must still carry a record saying so.
+// Before this, captureFailureLog returned silently and status.failureLog was
+// absent, so the operator saw a failed Job with no diagnostics at all.
+func TestCaptureFailureLogAlwaysRecordsSomething(t *testing.T) {
+	tests := []struct {
+		name       string
+		pods       []client.Object
+		wantReason string
+		wantTail   string
+	}{
+		{
+			name:       "pod already deleted",
+			pods:       nil,
+			wantReason: "PodNotFound",
+			wantTail:   "deleted before its logs could be read",
+		},
+		{
+			name: "pod present but nothing terminated badly",
+			pods: []client.Object{&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p", Namespace: "ns",
+					Labels: map[string]string{"cre.nvidia.com/job": "j"},
+				},
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "node",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}}},
+			}},
+			wantReason: "NoTerminatedContainer",
+			wantTail:   "none had a container terminated with a non-zero exit code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, burninv1alpha1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+
+			job := &burninv1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.pods...).Build()
+			// Clientset is only dereferenced when a failed pod is found, which is
+			// exactly the path these cases do not take.
+			r := &JobReconciler{Client: c, Scheme: scheme, Clientset: &kubernetes.Clientset{}}
+
+			r.captureFailureLog(context.Background(), job)
+
+			require.NotNil(t, job.Status.FailureLog, "a failed Job must never carry no record")
+			require.Equal(t, tt.wantReason, job.Status.FailureLog.Reason)
+			require.Contains(t, job.Status.FailureLog.Tail, tt.wantTail)
+		})
+	}
+}

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -782,8 +782,44 @@ func (r *JobReconciler) setJobFailed(ctx context.Context, job *burninv1alpha1.Jo
 	return r.setExclusiveCondition(ctx, job, burninv1alpha1.JobFailed, reason, message)
 }
 
-// failureLogTailLines is the number of log lines to capture from a failed pod.
-const failureLogTailLines = 30
+// failureLogTailLines is the number of log lines requested from a failed pod.
+//
+// This was 30, which is right for a workload whose last line is the error, and
+// wrong for one that prints a structured document. dcgmi diag --json ends with
+// closing braces and a metadata block, so 30 lines of a failed run stored 392
+// bytes ending in "status" : "Pass" and named no failing test. Measured against
+// dcgm 4.5.2 on an A100.
+const failureLogTailLines = 800
+
+// failureLogMaxBytes caps what is stored in Job.status.failureLog.tail. The
+// requested lines are usually well inside this; the cap only guards a workload
+// that prints very long lines.
+const failureLogMaxBytes = 32 * 1024
+
+// readLogTail returns the last max bytes of r.
+//
+// The byte cap has to trim from the front, keeping the end of the stream.
+// Reading the first max bytes instead would drop the most recent output, which
+// is the part a failure record needs.
+func readLogTail(r io.Reader, max int) (string, error) {
+	buf := make([]byte, 0, max)
+	chunk := make([]byte, 32*1024)
+	for {
+		n, readErr := r.Read(chunk)
+		if n > 0 {
+			buf = append(buf, chunk[:n]...)
+			if len(buf) > max {
+				buf = append(buf[:0], buf[len(buf)-max:]...)
+			}
+		}
+		if readErr == io.EOF {
+			return string(buf), nil
+		}
+		if readErr != nil {
+			return string(buf), readErr
+		}
+	}
+}
 
 // captureFailureLog finds the pod that caused the failure and stores its last
 // N log lines in job.Status.FailureLog. Best-effort: errors are logged, not returned.
@@ -820,7 +856,19 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 			}
 		}
 	}
+	// Record why there is no log rather than leaving the field unset. A Job whose
+	// pod was reaped before the failure was recorded (backoff limit exceeded, for
+	// example) would otherwise carry no diagnostics at all, and the operator would
+	// see a failed Job with nothing to read.
 	if failedPod == nil {
+		reason := "NoTerminatedContainer"
+		tail := "pods for this Job were found, but none had a container terminated with a non-zero exit code"
+		if len(podList.Items) == 0 {
+			reason = "PodNotFound"
+			tail = "no pods for this Job were found when the failure was recorded; the pod was most likely deleted before its logs could be read"
+		}
+		job.Status.FailureLog = &burninv1alpha1.FailureLog{Reason: reason, Tail: tail}
+		log.Info("No failed pod available for failure log capture", "reason", reason)
 		return
 	}
 
@@ -845,14 +893,14 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 	}
 	defer stream.Close() //nolint:errcheck
 
-	data, err := io.ReadAll(io.LimitReader(stream, 8*1024)) // cap at 8 KB
+	tail, err := readLogTail(stream, failureLogMaxBytes)
 	if err != nil {
 		log.V(1).Info("Failed to read pod logs", "pod", failedPod.Name, "error", err)
 	}
-	fl.Tail = string(data)
+	fl.Tail = tail
 	job.Status.FailureLog = fl
 	log.Info("Captured failure log", "pod", failedPod.Name, "node", failedPod.Spec.NodeName,
-		"exitCode", fl.ExitCode, "lines", len(fl.Tail))
+		"exitCode", fl.ExitCode, "bytes", len(fl.Tail))
 }
 
 // setJobHardwareFailed sets the HardwareFailed condition and records the failed nodes.

--- a/pkg/controller/testdata/failure-log-capture/pod-already-deleted/expected.json
+++ b/pkg/controller/testdata/failure-log-capture/pod-already-deleted/expected.json
@@ -1,0 +1,7 @@
+{
+  "podName": "",
+  "nodeName": "",
+  "exitCode": 0,
+  "reason": "PodNotFound",
+  "tail": "no pods for this Job were found when the failure was recorded; the pod was most likely deleted before its logs could be read"
+}

--- a/pkg/controller/testdata/failure-log-capture/pod-already-deleted/input.yaml
+++ b/pkg/controller/testdata/failure-log-capture/pod-already-deleted/input.yaml
@@ -1,0 +1,2 @@
+# A Job that fails after its pod is reaped used to carry no record at all.
+pods: []

--- a/pkg/controller/testdata/failure-log-capture/pod-present-nothing-terminated/expected.json
+++ b/pkg/controller/testdata/failure-log-capture/pod-present-nothing-terminated/expected.json
@@ -1,0 +1,7 @@
+{
+  "podName": "",
+  "nodeName": "",
+  "exitCode": 0,
+  "reason": "NoTerminatedContainer",
+  "tail": "pods for this Job were found, but none had a container terminated with a non-zero exit code"
+}

--- a/pkg/controller/testdata/failure-log-capture/pod-present-nothing-terminated/input.yaml
+++ b/pkg/controller/testdata/failure-log-capture/pod-present-nothing-terminated/input.yaml
@@ -1,0 +1,3 @@
+pods:
+  - name: p
+    running: true

--- a/pkg/controller/testdata/failure-log-tail/empty-stream/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/empty-stream/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "",
+  "keptBytes": 0
+}

--- a/pkg/controller/testdata/failure-log-tail/empty-stream/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/empty-stream/input.yaml
@@ -1,0 +1,2 @@
+maxBytes: 1024
+text: ""

--- a/pkg/controller/testdata/failure-log-tail/exactly-the-cap/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/exactly-the-cap/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "abcde",
+  "keptBytes": 5
+}

--- a/pkg/controller/testdata/failure-log-tail/exactly-the-cap/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/exactly-the-cap/input.yaml
@@ -1,0 +1,2 @@
+maxBytes: 5
+text: "abcde"

--- a/pkg/controller/testdata/failure-log-tail/longer-keeps-the-end/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/longer-keeps-the-end/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "xxxxxxxEND-KEEP-THIS",
+  "keptBytes": 20
+}

--- a/pkg/controller/testdata/failure-log-tail/longer-keeps-the-end/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/longer-keeps-the-end/input.yaml
@@ -1,0 +1,4 @@
+# The byte cap has to trim from the front. io.LimitReader kept the first bytes
+# and dropped the newest output, which is the part a failure record needs.
+maxBytes: 20
+text: "START-DROP-THISxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxEND-KEEP-THIS"

--- a/pkg/controller/testdata/failure-log-tail/shorter-than-the-cap/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/shorter-than-the-cap/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "line one\nline two\n",
+  "keptBytes": 18
+}

--- a/pkg/controller/testdata/failure-log-tail/shorter-than-the-cap/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/shorter-than-the-cap/input.yaml
@@ -1,0 +1,4 @@
+maxBytes: 1024
+text: |
+  line one
+  line two

--- a/pkg/controller/testdata/failure-log-tail/structured-doc-real-cap/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/structured-doc-real-cap/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "{\n\t\"Diagnostic\" : {\n\t\t\"tests\" : [ { \"name\" : \"diagnostic\", \"status\" : \"Fail\" } ]\n\t},\n\t\"metadata\" : { \"version\" : \"4.5.2\" }\n}\n",
+  "keptBytes": 125
+}

--- a/pkg/controller/testdata/failure-log-tail/structured-doc-real-cap/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/structured-doc-real-cap/input.yaml
@@ -1,0 +1,9 @@
+# The same document under the real cap keeps the failure.
+maxBytes: 32768
+text: |
+  {
+  	"Diagnostic" : {
+  		"tests" : [ { "name" : "diagnostic", "status" : "Fail" } ]
+  	},
+  	"metadata" : { "version" : "4.5.2" }
+  }

--- a/pkg/controller/testdata/failure-log-tail/structured-doc-small-cap/expected.json
+++ b/pkg/controller/testdata/failure-log-tail/structured-doc-small-cap/expected.json
@@ -1,0 +1,4 @@
+{
+  "kept": "s\" : \"Fail\" } ]\n\t},\n\t\"metadata\" : { \"version\" : \"4.5.2\" }\n}\n",
+  "keptBytes": 60
+}

--- a/pkg/controller/testdata/failure-log-tail/structured-doc-small-cap/input.yaml
+++ b/pkg/controller/testdata/failure-log-tail/structured-doc-small-cap/input.yaml
@@ -1,0 +1,10 @@
+# Why 30 lines was wrong. dcgmi diag --json ends in closing braces, so a small
+# tail keeps the structure and loses the failing test.
+maxBytes: 60
+text: |
+  {
+  	"Diagnostic" : {
+  		"tests" : [ { "name" : "diagnostic", "status" : "Fail" } ]
+  	},
+  	"metadata" : { "version" : "4.5.2" }
+  }

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"sort"
 	"strings"
@@ -1967,7 +1966,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 	}
 	defer stream.Close() //nolint:errcheck
 
-	data, err := io.ReadAll(io.LimitReader(stream, 8*1024))
+	tail, err := readLogTail(stream, failureLogMaxBytes)
 	if err != nil {
 		log.V(1).Info("Failed to read pod logs", "pod", targetPod.Name, "error", err)
 	}
@@ -1976,9 +1975,9 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 		PodName:  targetPod.Name,
 		NodeName: targetPod.Spec.NodeName,
 		Reason:   "Timeout",
-		Tail:     string(data),
+		Tail:     tail,
 	}
-	log.Info("Captured timeout log", "pod", targetPod.Name, "node", targetPod.Spec.NodeName, "bytes", len(data))
+	log.Info("Captured timeout log", "pod", targetPod.Name, "node", targetPod.Spec.NodeName, "bytes", len(tail))
 }
 
 // handleDeletion handles the cleanup when a Workflow is being deleted.


### PR DESCRIPTION
## What was wrong

`status.failureLog` is the one field built for triage. It was unreliable in both directions. Three real failures on an A100 cluster produced two records an operator could not use.

### Present, but misleading

`failureLogTailLines` was 30. That is right for a workload whose last line is the error, which is why it worked well the first time it fired. It is wrong for a workload that prints a structured document.

`dcgmi diag --json` ends with closing braces, an `entity_groups` block and a `metadata` block. A failed level 4 run stored 392 bytes ending in:

```
"test_summary" : { "status" : "Pass" }
...
"metadata" : { "Driver Version Detected" : "580.126.20", "version" : "4.5.2" }
```

**The failure record of a failed job read `Pass`,** and named no failing test.

I measured this again while preparing the fix, running the same image and command the catalog uses (`nvcr.io/nvidia/cloud-native/dcgm:4.5.2-1-ubuntu22.04`, `dcgmi diag --json --verbose`) with `--run 1` for speed:

| | |
|---|---|
| whole document | 50 lines, 705 bytes |
| last 30 lines | **392 bytes** |
| lines holding `"status"` | 18 and 23, i.e. the first half |

So the tail is structurally the wrong end of the document.

### Absent entirely

When the pod was already deleted, `captureFailureLog` found no pod and returned silently, as its best-effort comment allowed. The Job was `Failed` with no diagnostics at all. Seen twice: once after the launcher hit `BackoffLimitExceeded` and JobSet reaped the pod, once after a deliberate worker delete.

## What changed

All in `pkg/controller`:

1. **Request 800 lines rather than 30, and cap the stored text at 32 KB.**
2. **Keep the last bytes when the cap is hit.** The old code used `io.ReadAll(io.LimitReader(stream, 8*1024))`, which keeps the *first* 8 KB and so drops the most recent output, which is the part a failure record needs. `readLogTail` slides a fixed window instead, so the byte cap trims from the front.
3. **Always record something.** When no pod is available, store `PodNotFound` or `NoTerminatedContainer` with a line saying why, rather than leaving the field unset. A failed Job now never carries an empty record.

The timeout capture in `workflow_controller.go` used the same constant and the same `LimitReader`, so it uses the shared helper now.

No schema change. `make manifests` only rewrites two description strings.

## Tests

`pkg/controller/failure_log_test.go`:

- `readLogTail` keeps the end, not the start, including across many small chunked reads such as a live log stream produces
- a structured document keeps its failing entry under the new cap, and loses it under a small one, which is the bug
- `captureFailureLog` records `PodNotFound` when the pod is gone, and `NoTerminatedContainer` when pods exist but none failed

I checked these catch regressions rather than passing by construction. Reverting the tail direction to `io.LimitReader` fails 2 tests. Removing the stub record fails 2 more.

## Verification

`make lint` 0 issues, `make build` clean, `make test` all packages pass. No golden file changed.

## Note on the numbers

800 lines and 32 KB are chosen, not derived. 32 KB per failed Job in status is comfortable against the etcd object limit, and covers the measured document many times over. I could not size against a real `--run 4 --verbose` failure without a 70 minute run on known-bad hardware. If a maintainer would rather see that measured first, say so and I will capture it.
