### PR TITLE
fix: install the Kubeflow Trainer chart that matches the compiled API

### DIFF
--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -72,7 +72,7 @@ The command shows the target cluster and asks for confirmation. Type exactly `ye
 
 Two phases run:
 
-1. `deps` installs Kubeflow Trainer 2.2.0 into the `kubeflow-system` namespace. CRE runs every workload through a Trainer `TrainJob`.
+1. `deps` installs Kubeflow Trainer 2.2.1 into the `kubeflow-system` namespace. CRE runs every workload through a Trainer `TrainJob`.
 2. `helm` installs the CRE chart into the `cluster-readiness-engine` namespace: the controller, seven CRDs, and five `LogProfile` resources that parse workload logs.
 
 The GitHub token creates a ghcr.io pull secret for the controller image and authenticates the chart pull. Verify the result:

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -27,7 +27,10 @@ import (
 )
 
 const (
-	kubeflowTrainerVersion = "v2.2.0"
+	// Keep this in step with github.com/kubeflow/trainer/v2 in go.mod. The
+	// controller compiles against those API types, so installing an older
+	// chart means the CRDs it creates can lag the types CRE writes.
+	kubeflowTrainerVersion = "v2.2.1"
 
 	defaultImageRegistry   = "ghcr.io"
 	defaultImageRepository = "nvidia/cluster-readiness-engine/manager"

--- a/pkg/setup/trainer_version_test.go
+++ b/pkg/setup/trainer_version_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The Helm chart CRE installs and the Go module it compiles against are pinned
+// in two different files, so they can drift apart without anything failing.
+// They did: the chart constant said v2.2.0 while go.mod said v2.2.1, from the
+// initial commit onwards. This test ties them together.
+func TestTrainerChartVersionMatchesGoModule(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "go.mod"))
+	require.NoError(t, err, "go.mod must be readable from pkg/setup")
+
+	m := regexp.MustCompile(`(?m)^\s*github\.com/kubeflow/trainer/v2\s+(v\S+)`).FindSubmatch(data)
+	require.NotNil(t, m, "could not find github.com/kubeflow/trainer/v2 in go.mod")
+
+	require.Equal(t, string(m[1]), kubeflowTrainerVersion,
+		"kubeflowTrainerVersion must match the kubeflow/trainer module in go.mod; "+
+			"bump both together, and remember Trainer v2.3 is a required migration hop")
+}

--- a/test/uat/Tiltfile
+++ b/test/uat/Tiltfile
@@ -52,7 +52,7 @@ local_resource('prometheus-crds',
 
 # ─── 5. Install Kubeflow Trainer via Helm ───
 local_resource('install-trainer',
-    cmd='helm upgrade --install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer --namespace kubeflow-system --create-namespace --version 2.2.0 --set manager.tolerations[0].operator=Exists --set jobset.controller.tolerations[0].operator=Exists --wait --timeout 5m',
+    cmd='helm upgrade --install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer --namespace kubeflow-system --create-namespace --version 2.2.1 --set manager.tolerations[0].operator=Exists --set jobset.controller.tolerations[0].operator=Exists --wait --timeout 5m',
     resource_deps=['kwok-stage-override'],
     labels=['infra'])
 


### PR DESCRIPTION
## What was wrong

CRE installs Kubeflow Trainer chart **2.2.0** but compiles against **`github.com/kubeflow/trainer/v2 v2.2.1`**.

```
pkg/setup/setup.go:30   kubeflowTrainerVersion = "v2.2.0"
go.mod:8                github.com/kubeflow/trainer/v2 v2.2.1
```

This is not dependency drift. `git log -S` shows both values arriving in the initial commit `908cb14`, so the two were never in step.

## Why 2.2.1 is the right target

I checked the three things that could have made 2.2.0 deliberate, and none hold:

**A 2.2.1 chart exists.** The published tags at `oci://ghcr.io/kubeflow/charts/kubeflow-trainer` are `2.1.0`, `2.1.0-rc.1`, `2.2.0`, `2.2.0-rc.0`, `2.2.0-rc.1`, `2.2.1`, `2.3.0`, `2.3.0-rc.3`. (The tag list is paginated — a single unpaginated request returns only `2.1.0` and misleads.)

**v2.2.1 is a patch release with no API breaks.** Its notes cover release-process automation, a Kubernetes 0.36 dependency bump for the release-2.2 branch, and example/manifest fixes.

**The chart delta is CRD schemas only.** Pulling and diffing both charts:

```
Chart.yaml        version 2.2.0 -> 2.2.1
README.md         badge
crds/trainer.kubeflow.org_trainjobs.yaml
crds/trainer.kubeflow.org_trainingruntimes.yaml
crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
```

`values.yaml` is identical, and both pin JobSet `0.11.0` and LWS `0.8.0`. The CRD changes are the newer Kubernetes 0.36 PodSpec schema — an added `schedulingGroup` field and DRA resource-claim wording. CRE sets neither.

## What changed

- `pkg/setup/setup.go` — the constant, with a comment tying it to `go.mod`
- `test/uat/Tiltfile` — pinned `2.2.0` independently, so UAT was testing a different version than `setup init` installs
- `docs/getting-started/first-certification.md` — named 2.2.0 in the phase description
- `pkg/setup/trainer_version_test.go` — new: reads `go.mod` and compares, so the two cannot drift apart again without a failing test

I confirmed the test fails on the old value rather than passing by construction:

```
--- FAIL: TestTrainerChartVersionMatchesGoModule
        expected: "v2.2.1"
        actual  : "v2.2.0"
        kubeflowTrainerVersion must match the kubeflow/trainer module in go.mod
```

## Verified on hardware

On a 2-node A100 cluster, running the same helm command `setup init` runs:

```
BEFORE  kubeflow-trainer-2.2.0   revision 3
AFTER   kubeflow-trainer-2.2.1   revision 4   deployed

jobset-controller-5cf6c6cbc5-7tmp5                    1/1 Running
kubeflow-trainer-controller-manager-76bf87b748-69x9n  1/1 Running
cluster-readiness-engine-manager-7558cdfc65-qcp7p     1/1 Running
```

Then a real certification through the upgraded Trainer:

```
communication/nccl-loopback
  Status:    Succeeded
  Runtime:   27s
  Nodes/Job: 1
  Jobs:      2

  Categories:   1/1 passed
  Failed Nodes: none
  Result:       PASSED
```

`make lint` 0 issues, `make build` clean, `make test` all packages pass.

## Two things worth knowing

**Helm does not update CRDs from a chart's `crds/` directory on upgrade.** I confirmed this on the cluster: the 2.2.1-only `schedulingGroup` field was absent both before and after the upgrade. An existing install keeps the 2.2.0 CRDs; only a fresh install picks up the new ones. That is harmless here, because the added schema is optional fields CRE never sets, but it is worth knowing before assuming an upgrade fully moves a cluster to 2.2.1.

**Trainer v2.3.0 is a required migration hop.** Upstream states that upgrading from v2.0, v2.1 or v2.2 must go through v2.3 before any later version. v2.3.0 also removes Runtime finalizers and moves CRDs into the chart's template directory, which would change how `setup reset` deletes them. That is a larger change than this PR and deserves its own decision — happy to open an issue for it if useful.
