### PR TITLE
fix: give a WorkloadRun a safe way to request a GPU off a DGX

### DIFF
--- a/cmd/integration/testdata/reconcile/workloadrun-mpi/expected.json
+++ b/cmd/integration/testdata/reconcile/workloadrun-mpi/expected.json
@@ -116,11 +116,9 @@
                                 },
                                 "resources": {
                                   "limits": {
-                                    "memory": "800Gi",
                                     "nvidia.com/gpu": "4"
                                   },
                                   "requests": {
-                                    "memory": "800Gi",
                                     "nvidia.com/gpu": "4"
                                   }
                                 },

--- a/cmd/integration/testdata/reconcile/workloadrun-torch/expected.json
+++ b/cmd/integration/testdata/reconcile/workloadrun-torch/expected.json
@@ -150,11 +150,9 @@
                                 "name": "node",
                                 "resources": {
                                   "limits": {
-                                    "memory": "800Gi",
                                     "nvidia.com/gpu": "8"
                                   },
                                   "requests": {
-                                    "memory": "800Gi",
                                     "nvidia.com/gpu": "8"
                                   }
                                 },

--- a/pkg/platform/resources_test.go
+++ b/pkg/platform/resources_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func rl(pairs map[string]string) corev1.ResourceList {
+	out := corev1.ResourceList{}
+	for k, v := range pairs {
+		out[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return out
+}
+
+// A WorkloadRun that sets spec.resources used to lose its GPU request, because
+// the block was taken exactly as written. The pod then landed on a node it
+// could not use and failed inside CUDA.
+func TestWithGPURequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		res         *corev1.ResourceRequirements
+		gpusPerNode int32
+		wantGPU     string // "" means the resource must be absent
+		wantMemory  string
+	}{
+		{
+			name:        "memory only gets the GPU filled in",
+			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "64Gi"})},
+			gpusPerNode: 1,
+			wantGPU:     "1",
+			wantMemory:  "64Gi",
+		},
+		{
+			name:        "an explicit GPU count is kept",
+			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"nvidia.com/gpu": "2"})},
+			gpusPerNode: 8,
+			wantGPU:     "2",
+		},
+		{
+			name:        "an explicit zero is kept, so asking for no GPU still works",
+			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"nvidia.com/gpu": "0"})},
+			gpusPerNode: 8,
+			wantGPU:     "0",
+		},
+		{
+			name: "naming it in requests only is left alone",
+			res: &corev1.ResourceRequirements{
+				Requests: rl(map[string]string{"nvidia.com/gpu": "3"}),
+			},
+			gpusPerNode: 8,
+			wantGPU:     "", // absent from limits; requests keeps the user's 3
+		},
+		{
+			name:        "an empty block still gets a GPU",
+			res:         &corev1.ResourceRequirements{},
+			gpusPerNode: 4,
+			wantGPU:     "4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := withGPURequest(tt.res, tt.gpusPerNode)
+			require.NotNil(t, got)
+
+			q, ok := got.Limits[gpuResourceName]
+			if tt.wantGPU == "" {
+				require.False(t, ok, "expected no GPU entry in limits")
+			} else {
+				require.True(t, ok, "expected a GPU entry in limits")
+				require.Equal(t, tt.wantGPU, q.String())
+			}
+			if tt.wantMemory != "" {
+				m := got.Limits[corev1.ResourceName("memory")]
+				require.Equal(t, tt.wantMemory, m.String(), "the user's own values survive")
+			}
+		})
+	}
+
+	t.Run("nil is passed through", func(t *testing.T) {
+		require.Nil(t, withGPURequest(nil, 8))
+	})
+
+	t.Run("the caller's block is not mutated", func(t *testing.T) {
+		in := &corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "8Gi"})}
+		_ = withGPURequest(in, 2)
+		_, ok := in.Limits[gpuResourceName]
+		require.False(t, ok, "withGPURequest must copy, not edit in place")
+	})
+}

--- a/pkg/platform/resources_test.go
+++ b/pkg/platform/resources_test.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,5 +94,37 @@ func TestWithGPURequest(t *testing.T) {
 		_ = withGPURequest(in, 2)
 		_, ok := in.Limits[gpuResourceName]
 		require.False(t, ok, "withGPURequest must copy, not edit in place")
+	})
+}
+
+// Omitting spec.resources used to add memory: 800Gi, which only a DGX-sized
+// node can satisfy, so the pod stayed Pending everywhere else.
+func TestDefaultWorkerResourcesAsksOnlyForGPUs(t *testing.T) {
+	got := defaultWorkerResources(8)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "memory",
+		"CRE cannot know an arbitrary workload's memory needs, so it must not guess")
+	require.Contains(t, string(b), `"nvidia.com/gpu":"8"`)
+
+	limits, ok := got["limits"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "8", limits["nvidia.com/gpu"])
+	require.Len(t, limits, 1, "GPUs are the only thing CRE knows to ask for")
+}
+
+// The two halves together: whichever branch a user takes, the pod ends up
+// asking for a GPU.
+func TestBothBranchesRequestAGPU(t *testing.T) {
+	t.Run("resources omitted", func(t *testing.T) {
+		b, _ := json.Marshal(defaultWorkerResources(1))
+		require.Contains(t, string(b), "nvidia.com/gpu")
+	})
+	t.Run("resources set without a GPU", func(t *testing.T) {
+		res := withGPURequest(
+			&corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "64Gi"})}, 1)
+		_, ok := res.Limits[gpuResourceName]
+		require.True(t, ok)
 	})
 }

--- a/pkg/platform/resources_test.go
+++ b/pkg/platform/resources_test.go
@@ -10,121 +10,62 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
-func rl(pairs map[string]string) corev1.ResourceList {
-	out := corev1.ResourceList{}
-	for k, v := range pairs {
-		out[corev1.ResourceName(k)] = resource.MustParse(v)
-	}
-	return out
+type workerResourcesInput struct {
+	GpusPerNode int32 `yaml:"gpusPerNode"`
+	// OmitResources models a WorkloadRun that does not set spec.resources.
+	OmitResources bool                         `yaml:"omitResources"`
+	Resources     *corev1.ResourceRequirements `yaml:"resources"`
 }
 
-// A WorkloadRun that sets spec.resources used to lose its GPU request, because
-// the block was taken exactly as written. The pod then landed on a node it
-// could not use and failed inside CUDA.
-func TestWithGPURequest(t *testing.T) {
-	tests := []struct {
-		name        string
-		res         *corev1.ResourceRequirements
-		gpusPerNode int32
-		wantGPU     string // "" means the resource must be absent
-		wantMemory  string
-	}{
-		{
-			name:        "memory only gets the GPU filled in",
-			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "64Gi"})},
-			gpusPerNode: 1,
-			wantGPU:     "1",
-			wantMemory:  "64Gi",
-		},
-		{
-			name:        "an explicit GPU count is kept",
-			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"nvidia.com/gpu": "2"})},
-			gpusPerNode: 8,
-			wantGPU:     "2",
-		},
-		{
-			name:        "an explicit zero is kept, so asking for no GPU still works",
-			res:         &corev1.ResourceRequirements{Limits: rl(map[string]string{"nvidia.com/gpu": "0"})},
-			gpusPerNode: 8,
-			wantGPU:     "0",
-		},
-		{
-			name: "naming it in requests only is left alone",
-			res: &corev1.ResourceRequirements{
-				Requests: rl(map[string]string{"nvidia.com/gpu": "3"}),
-			},
-			gpusPerNode: 8,
-			wantGPU:     "", // absent from limits; requests keeps the user's 3
-		},
-		{
-			name:        "an empty block still gets a GPU",
-			res:         &corev1.ResourceRequirements{},
-			gpusPerNode: 4,
-			wantGPU:     "4",
-		},
+// A WorkloadRun had no safe way to ask for a GPU off a DGX. Omitting
+// spec.resources added memory: 800Gi and the pod never scheduled; setting it
+// dropped nvidia.com/gpu and the pod ran with no GPU, failing inside CUDA.
+// Each case renders the resources block one of those two paths produces.
+func TestWorkerResources(t *testing.T) {
+	p := &testutil.TestCaseParser{
+		Subdir:         "worker-resources",
+		ExpectedSuffix: ".json",
 	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in workerResourcesInput
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := withGPURequest(tt.res, tt.gpusPerNode)
-			require.NotNil(t, got)
+		var out any
+		if in.OmitResources {
+			out = defaultWorkerResources(in.GpusPerNode)
+		} else {
+			out = withGPURequest(in.Resources, in.GpusPerNode)
+		}
 
-			q, ok := got.Limits[gpuResourceName]
-			if tt.wantGPU == "" {
-				require.False(t, ok, "expected no GPU entry in limits")
-			} else {
-				require.True(t, ok, "expected a GPU entry in limits")
-				require.Equal(t, tt.wantGPU, q.String())
-			}
-			if tt.wantMemory != "" {
-				m := got.Limits[corev1.ResourceName("memory")]
-				require.Equal(t, tt.wantMemory, m.String(), "the user's own values survive")
-			}
-		})
-	}
-
-	t.Run("nil is passed through", func(t *testing.T) {
-		require.Nil(t, withGPURequest(nil, 8))
-	})
-
-	t.Run("the caller's block is not mutated", func(t *testing.T) {
-		in := &corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "8Gi"})}
-		_ = withGPURequest(in, 2)
-		_, ok := in.Limits[gpuResourceName]
-		require.False(t, ok, "withGPURequest must copy, not edit in place")
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
 	})
 }
 
-// Omitting spec.resources used to add memory: 800Gi, which only a DGX-sized
-// node can satisfy, so the pod stayed Pending everywhere else.
-func TestDefaultWorkerResourcesAsksOnlyForGPUs(t *testing.T) {
-	got := defaultWorkerResources(8)
+// Two properties cannot be expressed as input-in, JSON-out: that nil passes
+// through, and that the caller's block is not edited in place. They stay as
+// plain Go tests.
+func TestWithGPURequestDoesNotMutateTheCaller(t *testing.T) {
+	in := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{"memory": resource.MustParse("8Gi")},
+	}
+	_ = withGPURequest(in, 2)
 
-	b, err := json.Marshal(got)
-	require.NoError(t, err)
-	require.NotContains(t, string(b), "memory",
-		"CRE cannot know an arbitrary workload's memory needs, so it must not guess")
-	require.Contains(t, string(b), `"nvidia.com/gpu":"8"`)
-
-	limits, ok := got["limits"].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "8", limits["nvidia.com/gpu"])
-	require.Len(t, limits, 1, "GPUs are the only thing CRE knows to ask for")
+	_, ok := in.Limits[gpuResourceName]
+	require.False(t, ok, "withGPURequest must copy, not edit in place")
 }
 
-// The two halves together: whichever branch a user takes, the pod ends up
-// asking for a GPU.
-func TestBothBranchesRequestAGPU(t *testing.T) {
-	t.Run("resources omitted", func(t *testing.T) {
-		b, _ := json.Marshal(defaultWorkerResources(1))
-		require.Contains(t, string(b), "nvidia.com/gpu")
-	})
-	t.Run("resources set without a GPU", func(t *testing.T) {
-		res := withGPURequest(
-			&corev1.ResourceRequirements{Limits: rl(map[string]string{"memory": "64Gi"})}, 1)
-		_, ok := res.Limits[gpuResourceName]
-		require.True(t, ok)
-	})
+func TestWithGPURequestPassesNilThrough(t *testing.T) {
+	require.Nil(t, withGPURequest(nil, 8))
 }

--- a/pkg/platform/runtime.go
+++ b/pkg/platform/runtime.go
@@ -10,8 +10,14 @@ import (
 
 	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// gpuResourceName is the extended resource a container must request to be given
+// a GPU. A container that does not name it is scheduled without one, however
+// many GPUs the node has.
+const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
 
 // defaultWorkerMemory is the memory request/limit applied when a WorkloadRun
 // does not specify spec.resources. Matches values used by training catalog
@@ -24,14 +30,49 @@ func defaultWorkerResources(gpusPerNode int32) map[string]any {
 	gpuStr := strconv.Itoa(int(gpusPerNode))
 	return map[string]any{
 		"limits": map[string]any{
-			"nvidia.com/gpu": gpuStr,
-			"memory":         defaultWorkerMemory,
+			gpuResourceName.String(): gpuStr,
+			"memory":                 defaultWorkerMemory,
 		},
 		"requests": map[string]any{
-			"nvidia.com/gpu": gpuStr,
-			"memory":         defaultWorkerMemory,
+			gpuResourceName.String(): gpuStr,
+			"memory":                 defaultWorkerMemory,
 		},
 	}
+}
+
+// withGPURequest returns res with nvidia.com/gpu filled in from gpusPerNode.
+//
+// The user's block used to be taken exactly as written, so a WorkloadRun that
+// set spec.resources to avoid the memory default also lost its GPU request.
+// The pod then scheduled onto a node it could not use, while numProcPerNode was
+// still set from gpusPerNode, and the run died inside CUDA reporting a driver
+// problem rather than a missing GPU.
+//
+// An explicit value is never overwritten, including an explicit zero, so
+// asking for no GPU stays possible. If the user named the resource in either
+// limits or requests, the block is left entirely alone.
+func withGPURequest(res *corev1.ResourceRequirements, gpusPerNode int32) *corev1.ResourceRequirements {
+	if res == nil || gpusPerNode <= 0 {
+		return res
+	}
+	if _, ok := res.Limits[gpuResourceName]; ok {
+		return res
+	}
+	if _, ok := res.Requests[gpuResourceName]; ok {
+		return res
+	}
+
+	out := res.DeepCopy()
+	qty := *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI)
+	if out.Limits == nil {
+		out.Limits = corev1.ResourceList{}
+	}
+	if out.Requests == nil {
+		out.Requests = corev1.ResourceList{}
+	}
+	out.Limits[gpuResourceName] = qty
+	out.Requests[gpuResourceName] = qty
+	return out
 }
 
 // RuntimeConfig holds all parameters needed to build a TrainingRuntime dependency.
@@ -96,7 +137,7 @@ func BuildTorchRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
 	}
 
 	if cfg.Resources != nil {
-		container["resources"] = cfg.Resources
+		container["resources"] = withGPURequest(cfg.Resources, cfg.GpusPerNode)
 	} else {
 		container["resources"] = defaultWorkerResources(cfg.GpusPerNode)
 	}
@@ -227,7 +268,7 @@ func BuildMPIRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
 	}
 
 	if cfg.Resources != nil {
-		workerContainer["resources"] = cfg.Resources
+		workerContainer["resources"] = withGPURequest(cfg.Resources, cfg.GpusPerNode)
 	} else {
 		workerContainer["resources"] = defaultWorkerResources(cfg.GpusPerNode)
 	}

--- a/pkg/platform/runtime.go
+++ b/pkg/platform/runtime.go
@@ -19,24 +19,19 @@ import (
 // many GPUs the node has.
 const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
 
-// defaultWorkerMemory is the memory request/limit applied when a WorkloadRun
-// does not specify spec.resources. Matches values used by training catalog
-// entries (e.g. nemotron5-8b, nemotron5-56b).
-const defaultWorkerMemory = "800Gi"
-
-// defaultWorkerResources returns the standard worker resources block when the
-// user did not provide spec.resources: GPU count plus a memory default.
+// defaultWorkerResources returns the worker resources block when the user did
+// not provide spec.resources.
+//
+// This used to add memory: 800Gi as well, copied from the training catalog
+// entries, which set their own. CRE cannot know what an arbitrary WorkloadRun
+// needs, and 800Gi is satisfiable only on a DGX-sized node, so omitting
+// spec.resources left the pod Pending forever anywhere else. The GPU count is
+// the part CRE does know, so it is the only part it fills in.
 func defaultWorkerResources(gpusPerNode int32) map[string]any {
 	gpuStr := strconv.Itoa(int(gpusPerNode))
 	return map[string]any{
-		"limits": map[string]any{
-			gpuResourceName.String(): gpuStr,
-			"memory":                 defaultWorkerMemory,
-		},
-		"requests": map[string]any{
-			gpuResourceName.String(): gpuStr,
-			"memory":                 defaultWorkerMemory,
-		},
+		"limits":   map[string]any{gpuResourceName.String(): gpuStr},
+		"requests": map[string]any{gpuResourceName.String(): gpuStr},
 	}
 }
 

--- a/pkg/platform/testdata/worker-resources/empty-block-gets-a-gpu/expected.json
+++ b/pkg/platform/testdata/worker-resources/empty-block-gets-a-gpu/expected.json
@@ -1,0 +1,8 @@
+{
+  "limits": {
+    "nvidia.com/gpu": "4"
+  },
+  "requests": {
+    "nvidia.com/gpu": "4"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/empty-block-gets-a-gpu/input.yaml
+++ b/pkg/platform/testdata/worker-resources/empty-block-gets-a-gpu/input.yaml
@@ -1,0 +1,2 @@
+gpusPerNode: 4
+resources: {}

--- a/pkg/platform/testdata/worker-resources/explicit-gpu-count-kept/expected.json
+++ b/pkg/platform/testdata/worker-resources/explicit-gpu-count-kept/expected.json
@@ -1,0 +1,5 @@
+{
+  "limits": {
+    "nvidia.com/gpu": "2"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/explicit-gpu-count-kept/input.yaml
+++ b/pkg/platform/testdata/worker-resources/explicit-gpu-count-kept/input.yaml
@@ -1,0 +1,5 @@
+# An explicit count is never overwritten, even when it differs from gpusPerNode.
+gpusPerNode: 8
+resources:
+  limits:
+    nvidia.com/gpu: "2"

--- a/pkg/platform/testdata/worker-resources/explicit-zero-kept/expected.json
+++ b/pkg/platform/testdata/worker-resources/explicit-zero-kept/expected.json
@@ -1,0 +1,5 @@
+{
+  "limits": {
+    "nvidia.com/gpu": "0"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/explicit-zero-kept/input.yaml
+++ b/pkg/platform/testdata/worker-resources/explicit-zero-kept/input.yaml
@@ -1,0 +1,5 @@
+# Asking for no GPU stays possible.
+gpusPerNode: 8
+resources:
+  limits:
+    nvidia.com/gpu: "0"

--- a/pkg/platform/testdata/worker-resources/gpu-named-in-requests-only/expected.json
+++ b/pkg/platform/testdata/worker-resources/gpu-named-in-requests-only/expected.json
@@ -1,0 +1,5 @@
+{
+  "requests": {
+    "nvidia.com/gpu": "3"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/gpu-named-in-requests-only/input.yaml
+++ b/pkg/platform/testdata/worker-resources/gpu-named-in-requests-only/input.yaml
@@ -1,0 +1,5 @@
+# Named in either limits or requests means the block is left entirely alone.
+gpusPerNode: 8
+resources:
+  requests:
+    nvidia.com/gpu: "3"

--- a/pkg/platform/testdata/worker-resources/memory-only-gets-a-gpu/expected.json
+++ b/pkg/platform/testdata/worker-resources/memory-only-gets-a-gpu/expected.json
@@ -1,0 +1,9 @@
+{
+  "limits": {
+    "memory": "64Gi",
+    "nvidia.com/gpu": "1"
+  },
+  "requests": {
+    "nvidia.com/gpu": "1"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/memory-only-gets-a-gpu/input.yaml
+++ b/pkg/platform/testdata/worker-resources/memory-only-gets-a-gpu/input.yaml
@@ -1,0 +1,6 @@
+# The case the bug was reported for: a user sets resources to avoid the memory
+# default and loses the GPU request, because the block used to be taken as-is.
+gpusPerNode: 1
+resources:
+  limits:
+    memory: 64Gi

--- a/pkg/platform/testdata/worker-resources/resources-omitted-uses-default/expected.json
+++ b/pkg/platform/testdata/worker-resources/resources-omitted-uses-default/expected.json
@@ -1,0 +1,8 @@
+{
+  "limits": {
+    "nvidia.com/gpu": "8"
+  },
+  "requests": {
+    "nvidia.com/gpu": "8"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/resources-omitted-uses-default/input.yaml
+++ b/pkg/platform/testdata/worker-resources/resources-omitted-uses-default/input.yaml
@@ -1,0 +1,4 @@
+# spec.resources unset. The default asks for GPUs and nothing else; it used to
+# add memory: 800Gi, which only a DGX-sized node can satisfy.
+gpusPerNode: 8
+omitResources: true

--- a/pkg/platform/testdata/worker-resources/zero-gpus-per-node-adds-nothing/expected.json
+++ b/pkg/platform/testdata/worker-resources/zero-gpus-per-node-adds-nothing/expected.json
@@ -1,0 +1,5 @@
+{
+  "limits": {
+    "memory": "8Gi"
+  }
+}

--- a/pkg/platform/testdata/worker-resources/zero-gpus-per-node-adds-nothing/input.yaml
+++ b/pkg/platform/testdata/worker-resources/zero-gpus-per-node-adds-nothing/input.yaml
@@ -1,0 +1,4 @@
+gpusPerNode: 0
+resources:
+  limits:
+    memory: 8Gi


### PR DESCRIPTION
## What was wrong

A WorkloadRun had no safe way to ask for a GPU off a DGX. Both paths through `pkg/platform/runtime.go` were broken, and the failure modes point away from the cause.

```go
if cfg.Resources != nil {
    container["resources"] = cfg.Resources                            // used exactly as written
} else {
    container["resources"] = defaultWorkerResources(cfg.GpusPerNode)  // GPUs + memory: 800Gi
}
```

**Omit `spec.resources`** and you get `memory: 800Gi`. Only a DGX-sized node can satisfy that, so anywhere else the pod stays `Pending` forever.

**Set `spec.resources`** to dodge that, and your block is used verbatim. Kubernetes only attaches a GPU to a container that names `nvidia.com/gpu`, so unless you remembered to write it yourself, the pod schedules onto a node it cannot use.

The second case is the nastier one. `numProcPerNode` is set from `gpusPerNode` *outside* that branch:

```go
"mlPolicy": map[string]any{
    "numNodes": cfg.NodesPerJob,
    "torch": map[string]any{
        "numProcPerNode": cfg.GpusPerNode,   // always runs
    },
},
```

So the runtime is told to start one process per GPU while the container has none. The run dies inside CUDA reporting something like *driver version is insufficient*, which sends whoever is debugging it to check the NVIDIA driver, the GPU Operator and the node image. The actual cause is a missing line in their own YAML.

Both branches were confirmed on a 2-node A100 cluster. It is written up as fact F6 in the test plan because we got caught by it there.

## Commit 1 — keep the GPU request when the user sets `resources`

`withGPURequest` fills `nvidia.com/gpu` in from `gpusPerNode` when the user did not name it.

Deliberately conservative: if the resource appears in **either** `limits` or `requests`, the block is left entirely alone. So an explicit value is never overwritten, including an explicit `0` — asking for no GPU stays expressible. It copies rather than editing the caller's block, which a test checks.

Applies to both the torch and MPI runtimes, which had the same either-or shape (`:98-101` and `:229-232`).

**No golden file changes in this commit.**

## Commit 2 — stop guessing 800Gi

`defaultWorkerResources` no longer invents a memory number.

The 800Gi came from the training catalog entries (`nemotron5-8b`, `nemotron5-56b`), which set their own resources and are unaffected. CRE cannot know what an arbitrary WorkloadRun needs. The GPU count is the part it does know, and stays the only part it fills in.

Regenerates the only two goldens that reach this default:

```
 cmd/integration/testdata/reconcile/workloadrun-mpi/expected.json   | 2 --
 cmd/integration/testdata/reconcile/workloadrun-torch/expected.json | 2 --
```

Both inputs omit `spec.resources`. Each loses two `"memory": "800Gi"` lines; the `nvidia.com/gpu` request is unchanged. Catalog-driven goldens do not move.

## Behaviour change worth calling out

Anyone omitting `spec.resources` today gets a pod that cannot schedule off a DGX, so in practice they are already broken. But anyone relying on the 800Gi reservation **on** a DGX loses it. That seemed better than keeping a number CRE has no basis to pick, and it is the half of the report that says "omit resources → unschedulable".

If maintainers would rather keep a memory default, commit 2 can be dropped on its own and commit 1 still makes `spec.resources` safe to use.

## Tests

`pkg/platform/resources_test.go`:

- memory-only block gets the GPU filled in, and the user's own values survive
- an explicit GPU count is kept; an explicit `0` is kept
- naming it in `requests` only leaves the block alone
- an empty block still gets a GPU; `nil` passes through
- the caller's block is not mutated
- the default asks for GPUs and nothing else
- both branches end up requesting a GPU

## Verification

`make lint` 0 issues, `make build` clean, `make test` all packages pass.
