### PR TITLE
feat: add OCI GB300 RoCE catalog support

### DIFF
--- a/pkg/catalog/entries/_lib/gpu-defaults.yaml
+++ b/pkg/catalog/entries/_lib/gpu-defaults.yaml
@@ -44,3 +44,6 @@ platformOverrides:
     l40s:
       gpusPerNode: 4
       mlnxPerNode: 2
+    gb300:
+      gpusPerNode: 4
+      mlnxPerNode: 4

--- a/pkg/catalog/entries/_lib/nccl/oci-gb300-roce-env.yaml
+++ b/pkg/catalog/entries/_lib/nccl/oci-gb300-roce-env.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# OCI GB300 RoCE environment variables.
+# Applied to both comm entries (via | toMpiArgs) and training entries (via trainer.env).
+#
+# GID index 3: OCI uses RoCEv2 which requires GID index 3. Without this, UCX
+# defaults to GID index 0 (link-local/IB mode) causing IBV_WC_REM_ACCESS_ERR
+# (vendor err 129 on mlx5_x). Both UCX_IB_GID_INDEX and NCCL_IB_GID_INDEX are
+# required — the MPI launcher runs rank 0 and initializes UCX from its container
+# env (not from mpirun -x args), so the container env must also carry the GID index.
+#
+# NCCL_MNNVL_ENABLE: the OCI+GB300 override replaces the full mpirun args from
+# the GB200/GB300 base override, which would otherwise drop this var and let NCCL
+# default to enabled on GB300 hardware. Explicitly setting it ensures MNNVL-on
+# and MNNVL-off runs are correctly differentiated.
+#
+# NCCL_DMABUF_ENABLE=0 when MNNVL disabled: OCI GB300 nodes return error 524
+# (Unknown error) from mlx5dv_reg_dmabuf_mr. NCCL falls back to DMA-BUF for
+# GPU Direct RDMA by default, which fails on this cluster. Only needed when MNNVL
+# is off; with MNNVL enabled this code path is not taken.
+- name: UCX_IB_GID_INDEX
+  value: "3"
+- name: NCCL_IB_GID_INDEX
+  value: "3"
+- name: NCCL_MNNVL_ENABLE
+  value: "{{ if .EnableMNNVL }}1{{ else }}0{{ end }}"
+{{- if not .EnableMNNVL }}
+- name: NCCL_DMABUF_ENABLE
+  value: "0"
+{{- end }}

--- a/pkg/catalog/entries/_lib/nccl/oci-roce-mpirun-args.yaml
+++ b/pkg/catalog/entries/_lib/nccl/oci-roce-mpirun-args.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# OCI GB300 RoCE mpirun args. Mirrors aws-gb300-roce-mpirun-args.yaml with
+# OCI-specific MCA flags. Forces MPI to use TCP for point-to-point transport
+# (NCCL handles RDMA directly on OCI GB300; MPI only needs TCP for coordination).
+# UCC/HCollective disabled: without these flags, UCC calls mca_coll_ucc_comm_query
+# during MPI_Init, which crashes (SIGSEGV) because UCX tries to use mlx5 devices
+# with incorrect GID settings before NCCL_IB_GID_INDEX takes effect.
+- -N
+- "{{ .GpusPerNode }}"
+- --allow-run-as-root
+- --mca
+- plm_rsh_args
+- -o StrictHostKeyChecking=no
+- --mca
+- pml
+- ob1
+- --mca
+- btl
+- tcp,self
+- --mca
+- btl_tcp_if_include
+- eth0
+- --mca
+- oob
+- tcp
+- --mca
+- oob_tcp_if_include
+- eth0
+- --mca
+- coll_ucc_enable
+- "0"
+- --mca
+- coll_hcoll_enable
+- "0"

--- a/pkg/catalog/entries/communication/nccl-all-gather.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-gather.yaml
@@ -439,6 +439,32 @@ overrides:
 {{ lib "nccl/aws-gb300-roce-env.yaml" . | toMpiArgs | indent 12 }}
             - /opt/nccl-tests/build/all_gather_perf
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- OCI + GB300 (RoCE) ---
+# Must come AFTER the GB200/GB300 base block and AWS+GB300 so this override's
+# trainer.args (atomic replacement) wins. Adds SR-IOV NIC resources via
+# oci-mlnxnics-comm.yaml and sets OCI-specific GID index + MNNVL env vars.
+# trainer.env carries UCX_IB_GID_INDEX for the MPI launcher (rank 0), which
+# initializes UCX from its container env, not from mpirun -x args.
+- when:
+    platform:
+      equals: oci
+    gpuArchitecture:
+      equals: gb300
+  dependencies:
+{{ lib "deps/oci-mlnxnics-comm.yaml" . | indent 2 }}
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            env:
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | indent 12 }}
+            args:
+{{ lib "nccl/oci-roce-mpirun-args.yaml" . | indent 12 }}
+{{ lib "nccl/oci-roce-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/all_gather_perf_mpi
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
 # --- Mistral + GB300 (InfiniBand) ---
 - when:
     platform:

--- a/pkg/catalog/entries/communication/nccl-all-reduce.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-reduce.yaml
@@ -442,6 +442,32 @@ overrides:
 {{ lib "nccl/aws-gb300-roce-env.yaml" . | toMpiArgs | indent 12 }}
             - /opt/nccl-tests/build/all_reduce_perf
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- OCI + GB300 (RoCE) ---
+# Must come AFTER the GB200/GB300 base block and AWS+GB300 so this override's
+# trainer.args (atomic replacement) wins. Adds SR-IOV NIC resources via
+# oci-mlnxnics-comm.yaml and sets OCI-specific GID index + MNNVL env vars.
+# trainer.env carries UCX_IB_GID_INDEX for the MPI launcher (rank 0), which
+# initializes UCX from its container env, not from mpirun -x args.
+- when:
+    platform:
+      equals: oci
+    gpuArchitecture:
+      equals: gb300
+  dependencies:
+{{ lib "deps/oci-mlnxnics-comm.yaml" . | indent 2 }}
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            env:
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | indent 12 }}
+            args:
+{{ lib "nccl/oci-roce-mpirun-args.yaml" . | indent 12 }}
+{{ lib "nccl/oci-roce-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/all_reduce_perf_mpi
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
 # --- Mistral + GB300 (InfiniBand) ---
 - when:
     platform:

--- a/pkg/catalog/entries/communication/nccl-alltoall.yaml
+++ b/pkg/catalog/entries/communication/nccl-alltoall.yaml
@@ -469,6 +469,34 @@ overrides:
             - -d
             - uint8
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- OCI + GB300 (RoCE) ---
+# Must come AFTER the GB200/GB300 base block and AWS+GB300 so this override's
+# trainer.args (atomic replacement) wins. Adds SR-IOV NIC resources via
+# oci-mlnxnics-comm.yaml and sets OCI-specific GID index + MNNVL env vars.
+# trainer.env carries UCX_IB_GID_INDEX for the MPI launcher (rank 0), which
+# initializes UCX from its container env, not from mpirun -x args.
+- when:
+    platform:
+      equals: oci
+    gpuArchitecture:
+      equals: gb300
+  dependencies:
+{{ lib "deps/oci-mlnxnics-comm.yaml" . | indent 2 }}
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            env:
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | indent 12 }}
+            args:
+{{ lib "nccl/oci-roce-mpirun-args.yaml" . | indent 12 }}
+{{ lib "nccl/oci-roce-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/alltoall_perf_mpi
+            - -d
+            - uint8
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
 # --- Mistral + GB300 (InfiniBand) ---
 - when:
     platform:

--- a/pkg/catalog/entries/training/nemotron5-56b.yaml
+++ b/pkg/catalog/entries/training/nemotron5-56b.yaml
@@ -310,6 +310,26 @@ overrides:
       equals: gb300
   dependencies:
 {{ lib "deps/gb300-roce-torch.yaml" . | indent 2 }}
+# --- OCI + GB300 (RoCE) ---
+# Adds SR-IOV NIC resources (oci-mlnxnics-comm.yaml) and OCI GB300-specific
+# env vars. Uses trainer.env (not toMpiArgs) because torchrun inherits the
+# container env directly — no MPI SSH launch involved.
+# NCCL_MNNVL_ENABLE and NCCL_DMABUF_ENABLE are conditioned on EnableMNNVL
+# via the template; see oci-gb300-roce-env.yaml for the reasoning.
+- when:
+    platform:
+      equals: oci
+    gpuArchitecture:
+      equals: gb300
+  dependencies:
+{{ lib "deps/oci-mlnxnics-comm.yaml" . | indent 2 }}
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            env:
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | indent 12 }}
 # --- GCP + GB200/GB300 (RoCE) ---
 - when:
     platform:

--- a/pkg/catalog/entries/training/nemotron5-8b.yaml
+++ b/pkg/catalog/entries/training/nemotron5-8b.yaml
@@ -340,6 +340,26 @@ overrides:
       equals: gb300
   dependencies:
 {{ lib "deps/gb300-roce-torch.yaml" . | indent 2 }}
+# --- OCI + GB300 (RoCE) ---
+# Adds SR-IOV NIC resources (oci-mlnxnics-comm.yaml) and OCI GB300-specific
+# env vars. Uses trainer.env (not toMpiArgs) because torchrun inherits the
+# container env directly — no MPI SSH launch involved.
+# NCCL_MNNVL_ENABLE and NCCL_DMABUF_ENABLE are conditioned on EnableMNNVL
+# via the template; see oci-gb300-roce-env.yaml for the reasoning.
+- when:
+    platform:
+      equals: oci
+    gpuArchitecture:
+      equals: gb300
+  dependencies:
+{{ lib "deps/oci-mlnxnics-comm.yaml" . | indent 2 }}
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            env:
+{{ lib "nccl/oci-gb300-roce-env.yaml" . | indent 12 }}
 # --- GCP + GB200/GB300 (RoCE) ---
 - when:
     platform:


### PR DESCRIPTION
## Summary

Adds catalog support for GB300 on OCI (Oracle Cloud Infrastructure). Before this PR, OCI only had entries for L40S. GB300 nodes on OCI fell through to the generic GB200/GB300 base override, which has no OCI-specific NIC attachment, wrong mpirun transport args, and missing RoCEv2 GID configuration.

**4 commits, each independently reviewable:**

1. **New lib fragments** — `oci-roce-mpirun-args.yaml` (MPI transport args for OCI GB300) and `oci-gb300-roce-env.yaml` (GID index, MNNVL flag, conditional DMA-BUF)
2. **gpu-defaults** — OCI GB300 platform override: 4 GPUs, 4 NICs (OCI exposes 4 RDMA planes, not the global GB300 default of 8)
3. **Communication entries** — OCI+GB300 block in `nccl-all-reduce`, `nccl-all-gather`, `nccl-alltoall` (inserted after AWS+GB300 so atomic `trainer.args` replacement wins)
4. **Training entries** — OCI+GB300 block in `nemotron5-8b`, `nemotron5-56b` (deps + `trainer.env` only; torchrun inherits container env directly)

Key design decisions documented in the lib file comments:
- `UCX_IB_GID_INDEX=3` in `trainer.env` (not just `toMpiArgs`): the MPI launcher (rank 0) initializes UCX from its container env, not from `mpirun -x` args
- `coll_ucc_enable 0` / `coll_hcoll_enable 0`: prevents UCC SIGSEGV during MPI_Init when mlx5 devices have wrong GID settings
- `NCCL_DMABUF_ENABLE=0` conditional: OCI GB300 returns error 524 from `mlx5dv_reg_dmabuf_mr`; only needed when MNNVL is disabled

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [x] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally (`make build test`)
- [x] Manual testing completed (confirmed against OCI GB300 cluster)
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review