### PR TITLE
fix: read the logs once more before a goodput measurement completes

### DIFF
--- a/pkg/controller/goodput_final_sample_test.go
+++ b/pkg/controller/goodput_final_sample_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+)
+
+// handleRunning throttles reads so that status updates do not re-trigger one.
+// The final read before a measurement goes terminal happens moments after the
+// previous sample, so without clearing the throttle it would be skipped and the
+// last window of output lost. This checks the throttle really is bypassed.
+func TestFinalSampleBypassesTheThrottle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, burninv1alpha1.AddToScheme(scheme))
+
+	m := &burninv1alpha1.GoodputMeasurement{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+		Spec: burninv1alpha1.GoodputMeasurementSpec{
+			JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
+			LogProfileRef: "does-not-resolve",
+		},
+	}
+	job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(m, job).WithStatusSubresource(m, job).Build()
+	r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
+
+	key := "ns/m"
+	r.mu.Lock()
+	r.lastSample = map[string]time.Time{key: time.Now()}
+	r.mu.Unlock()
+
+	r.finalSample(context.Background(), m, job)
+
+	r.mu.Lock()
+	_, stillThrottled := r.lastSample[key]
+	r.mu.Unlock()
+
+	require.False(t, stillThrottled,
+		"finalSample must clear the sample time so the last read is not skipped")
+}
+
+// A sample taken moments ago would otherwise block the read.
+func TestHandleRunningIsThrottledWithoutFinalSample(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, burninv1alpha1.AddToScheme(scheme))
+
+	m := &burninv1alpha1.GoodputMeasurement{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+		Spec: burninv1alpha1.GoodputMeasurementSpec{
+			JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
+			LogProfileRef: "does-not-resolve",
+		},
+	}
+	job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(m, job).WithStatusSubresource(m, job).Build()
+	r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
+
+	key := "ns/m"
+	r.mu.Lock()
+	r.lastSample = map[string]time.Time{key: time.Now()}
+	r.mu.Unlock()
+
+	// Straight into handleRunning, no finalSample: the throttle holds, and the
+	// requeue it asks for is the remaining interval.
+	res, err := r.handleRunning(context.Background(), m, job)
+	require.NoError(t, err)
+	require.Positive(t, res.RequeueAfter, "the read was throttled, as designed")
+
+	r.mu.Lock()
+	_, stillThrottled := r.lastSample[key]
+	r.mu.Unlock()
+	require.True(t, stillThrottled, "the sample time is untouched when throttled")
+}

--- a/pkg/controller/goodput_final_sample_test.go
+++ b/pkg/controller/goodput_final_sample_test.go
@@ -5,85 +5,90 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
-// handleRunning throttles reads so that status updates do not re-trigger one.
-// The final read before a measurement goes terminal happens moments after the
-// previous sample, so without clearing the throttle it would be skipped and the
-// last window of output lost. This checks the throttle really is bypassed.
-func TestFinalSampleBypassesTheThrottle(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, burninv1alpha1.AddToScheme(scheme))
-
-	m := &burninv1alpha1.GoodputMeasurement{
-		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
-		Spec: burninv1alpha1.GoodputMeasurementSpec{
-			JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
-			LogProfileRef: "does-not-resolve",
-		},
+// handleSucceeded and handleFailed build from the stored status and never read
+// logs again, so everything written in the last sampling window was lost. A
+// script that logged to iteration 100 was recorded as reaching step 90.
+//
+// handleRunning throttles reads so status updates do not re-trigger one, and
+// the final read lands moments after the previous sample. finalSample therefore
+// has to clear the sample time first, or the fix does nothing. These two cases
+// pin both halves.
+func TestGoodputFinalSample(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "goodput-final-sample",
+		ExpectedSuffix: ".json",
 	}
-	job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Call              string `yaml:"call"`
+			SampledSecondsAgo int    `yaml:"sampledSecondsAgo"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(m, job).WithStatusSubresource(m, job).Build()
-	r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
+		scheme := runtime.NewScheme()
+		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+			return err
+		}
 
-	key := "ns/m"
-	r.mu.Lock()
-	r.lastSample = map[string]time.Time{key: time.Now()}
-	r.mu.Unlock()
+		m := &burninv1alpha1.GoodputMeasurement{
+			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+			Spec: burninv1alpha1.GoodputMeasurementSpec{
+				JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
+				LogProfileRef: "does-not-resolve",
+			},
+		}
+		job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
 
-	r.finalSample(context.Background(), m, job)
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(m, job).WithStatusSubresource(m, job).Build()
+		r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
 
-	r.mu.Lock()
-	_, stillThrottled := r.lastSample[key]
-	r.mu.Unlock()
+		key := "ns/m"
+		r.mu.Lock()
+		r.lastSample = map[string]time.Time{
+			key: time.Now().Add(-time.Duration(in.SampledSecondsAgo) * time.Second),
+		}
+		r.mu.Unlock()
 
-	require.False(t, stillThrottled,
-		"finalSample must clear the sample time so the last read is not skipped")
-}
+		requeued := false
+		if in.Call == "finalSample" {
+			r.finalSample(context.Background(), m, job)
+		} else {
+			res, err := r.handleRunning(context.Background(), m, job)
+			if err != nil {
+				return err
+			}
+			requeued = res.RequeueAfter > 0
+		}
 
-// A sample taken moments ago would otherwise block the read.
-func TestHandleRunningIsThrottledWithoutFinalSample(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, burninv1alpha1.AddToScheme(scheme))
+		r.mu.Lock()
+		_, stillThrottled := r.lastSample[key]
+		r.mu.Unlock()
 
-	m := &burninv1alpha1.GoodputMeasurement{
-		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
-		Spec: burninv1alpha1.GoodputMeasurementSpec{
-			JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
-			LogProfileRef: "does-not-resolve",
-		},
-	}
-	job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
-
-	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(m, job).WithStatusSubresource(m, job).Build()
-	r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
-
-	key := "ns/m"
-	r.mu.Lock()
-	r.lastSample = map[string]time.Time{key: time.Now()}
-	r.mu.Unlock()
-
-	// Straight into handleRunning, no finalSample: the throttle holds, and the
-	// requeue it asks for is the remaining interval.
-	res, err := r.handleRunning(context.Background(), m, job)
-	require.NoError(t, err)
-	require.Positive(t, res.RequeueAfter, "the read was throttled, as designed")
-
-	r.mu.Lock()
-	_, stillThrottled := r.lastSample[key]
-	r.mu.Unlock()
-	require.True(t, stillThrottled, "the sample time is untouched when throttled")
+		b, err := json.MarshalIndent(struct {
+			ThrottleCleared bool `json:"throttleCleared"`
+			AskedForRequeue bool `json:"askedForRequeue"`
+		}{!stillThrottled, requeued}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
 }

--- a/pkg/controller/goodputmeasurement_controller.go
+++ b/pkg/controller/goodputmeasurement_controller.go
@@ -132,9 +132,11 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 
 	// Determine Job phase from conditions.
 	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+		r.finalSample(ctx, measurement, job)
 		return r.handleSucceeded(ctx, measurement, job)
 	}
 	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+		r.finalSample(ctx, measurement, job)
 		return r.handleFailed(ctx, measurement, job)
 	}
 	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
@@ -144,6 +146,31 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 	// Job exists but has no conditions yet — requeue.
 	log.Info("Referenced Job has no conditions yet, requeueing", "job", jobKey)
 	return ctrl.Result{RequeueAfter: r.getSampleInterval(measurement)}, nil
+}
+
+// finalSample reads the logs one last time before a measurement goes terminal.
+//
+// handleSucceeded and handleFailed both build from the stored status and never
+// read logs again, so everything written in the last sampling window was lost —
+// up to sampleInterval, 60s by default. That matters most on failure, where the
+// last lines before a crash are the interesting ones. Observed on hardware: a
+// script that logged to iteration 100 was recorded as reaching step 90.
+//
+// The throttle in handleRunning exists to stop status updates re-triggering a
+// read, and would usually skip this one, so the sample time is cleared first.
+// Best effort: a failure here leaves the previous status in place, which is
+// what would have happened anyway.
+func (r *GoodputMeasurementReconciler) finalSample(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, job *burninv1alpha1.Job) {
+	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
+
+	r.mu.Lock()
+	delete(r.lastSample, key)
+	r.mu.Unlock()
+
+	if _, err := r.handleRunning(ctx, measurement, job); err != nil {
+		logf.FromContext(ctx).Error(err, "Final log read before completion failed",
+			"measurement", key)
+	}
 }
 
 // handleRunning processes a running job: reads logs, parses them, computes goodput.

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/expected.json
@@ -1,0 +1,4 @@
+{
+  "throttleCleared": true,
+  "askedForRequeue": false
+}

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/input.yaml
@@ -1,0 +1,4 @@
+# The final read lands moments after the previous sample, so without clearing
+# the sample time it would be skipped and the last window of output lost.
+call: finalSample
+sampledSecondsAgo: 1

--- a/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/expected.json
@@ -1,0 +1,4 @@
+{
+  "throttleCleared": false,
+  "askedForRequeue": true
+}

--- a/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/input.yaml
@@ -1,0 +1,4 @@
+# The throttle exists so a status update does not re-trigger a read. This is
+# the behaviour finalSample has to work around.
+call: handleRunning
+sampledSecondsAgo: 1


### PR DESCRIPTION
## What was wrong

`handleSucceeded` and `handleFailed` both build from the stored status via `buildCumulativeFromStatus` and never read logs again. Anything the workload wrote in the last sampling window was dropped — `sampleInterval`, 60 seconds by default.

Seen on hardware (test-plan P3.1): a script that logged up to iteration 100 was recorded as reaching `currentStep: 90`. The workaround at the time was to make the workload sleep before exiting, which is not something a user should have to know about.

It matters most on failure, where the last lines before a crash are the interesting ones.

## The shape already exists

The bandwidth controller does exactly this. On `JobSucceeded` and `JobFailed` it calls `handleRunning` for one more parse before going terminal:

```go
if cond := ...JobSucceeded...; cond.Status == metav1.ConditionTrue {
    if len(measurement.Status.Results) == 0 {
        if _, err := r.handleRunning(ctx, measurement, job); err != nil { ... }
    }
    return r.handleTerminal(...)
}
```

`bandwidthmeasurement_controller.go:152-167`. `finalSample` gives goodput the same shape.

## The detail that makes it work

`handleRunning` throttles reads so a status update does not re-trigger one:

```go
if last, ok := r.lastSample[key]; ok && time.Since(last) < interval {
    return ctrl.Result{RequeueAfter: interval - time.Since(last)}, nil
}
```

The final read lands moments after the previous sample, so it would normally be skipped — the throttle would silently defeat the fix. `finalSample` clears the recorded sample time first.

Two tests cover both halves, so the mechanism is pinned rather than assumed:

- `TestHandleRunningIsThrottledWithoutFinalSample` — a plain call is throttled and asks for a requeue
- `TestFinalSampleBypassesTheThrottle` — `finalSample` clears the sample time

## Scope

Best effort, matching the bandwidth version: a failure in the final read logs and leaves the previous status in place, which is what would have happened anyway.

## Verification

`make lint` 0 issues, `make build` clean, `make test` all packages pass. No golden file changes — the existing goodput cases read the same fixture logs, so one extra read produces the same result.
