### PR TITLE
docs: state the training GPU minimums and namespace the chart install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,9 @@ jobs:
             ```bash
             helm install cluster-readiness-engine \
               oci://ghcr.io/nvidia/cluster-readiness-engine \
-              --version ${{ steps.tag.outputs.value }}
+              --version ${{ steps.tag.outputs.value }} \
+              --namespace cluster-readiness-engine \
+              --create-namespace
             ```
 
             The controller image for this release is

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -91,7 +91,7 @@ List what the catalog offers:
 kubectl ncre certification list-categories
 ```
 
-The catalog has eight categories today. `communication/nccl-all-reduce`, `nccl-all-gather`, and `nccl-alltoall` run NCCL performance tests across all target nodes at once. `nccl-loopback` and `nccl-loopback-nvswitch` run one single-node Job per node and isolate per-node problems. `diagnostics/dcgm-level4` runs the deep DCGM diagnostic on each node. `training/nemotron5-8b` and `nemotron5-56b` run real Megatron-LM pretraining and measure goodput; the 56B model needs at least 32 GPUs.
+The catalog has eight categories today. `communication/nccl-all-reduce`, `nccl-all-gather`, and `nccl-alltoall` run NCCL performance tests across all target nodes at once. `nccl-loopback` and `nccl-loopback-nvswitch` run one single-node Job per node and isolate per-node problems. `diagnostics/dcgm-level4` runs the deep DCGM diagnostic on each node. `training/nemotron5-8b` and `nemotron5-56b` run real Megatron-LM pretraining and measure goodput. Both have a minimum GPU count: 4 for the 8B model, 32 for the 56B. The total must also divide evenly by the tensor-parallel width, which varies by architecture — it is 8 on A100, so the 8B model needs 8 GPUs there rather than 4.
 
 Start with `nccl-all-reduce`. It works on any node count and finishes in minutes on a healthy cluster:
 


### PR DESCRIPTION
## Two accuracy fixes, both verified against source

### The guide understates the training GPU minimums

`docs/getting-started/first-certification.md` named the 32-GPU minimum for the 56B model and said nothing about the 8B one, so a reader reasonably concluded 8B had none. It does:

```yaml
# pkg/catalog/entries/training/nemotron5-8b/meta.yaml
minGPUs: 4
```

**There is a second constraint the guide did not mention at all.** `validateParallelism` (`pkg/catalog/loader.go:561`) enforces `minGPUs` *and* requires the GPU total to divide by the tensor-parallel width. That width is per architecture:

| Arch | TP for 8B | Effective minimum |
|---|---|---|
| default | 1 | 4 |
| H100 | 2 | 4 |
| **A100** | **8** | **8, not 4** |

The two limits produce different errors, so an operator on A100 with 4 GPUs passes the documented check and fails the undocumented one:

```
requires at least 4 GPUs (...); set nodesPerJob to N or higher
totalGPUs=N must be divisible by TP×PP=8 (TP=8, PP=1); try ...
```

This is why a 2-GPU A100 cluster could not run the 8B entry.

### The release notes' helm command has no namespace

`.github/workflows/release.yml` generated:

```bash
helm install cluster-readiness-engine \
  oci://ghcr.io/nvidia/cluster-readiness-engine \
  --version <tag>
```

Every other install path puts the controller in `cluster-readiness-engine`, and the chart carries no default namespace, so following the release notes verbatim installed into whatever the current kubeconfig context pointed at. Added `--namespace cluster-readiness-engine --create-namespace`.

## Verification

`make lint` 0 issues. `release.yml` re-parsed as YAML after the edit. Docs-only otherwise — no code, no golden files.
