### PR TITLE
fix: do not lose a group's completion when the Workflow conditions do not change

### DIFF
--- a/pkg/controller/group_completion_persist_test.go
+++ b/pkg/controller/group_completion_persist_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// A group whose Job has gone terminal must have its phase written to the
+// Workflow status even when the Workflow's conditions do not change in the same
+// reconcile. The group phases are mutated on workflow.Status directly, and used
+// to be persisted only as a side effect of the condition write — which
+// updateStatusWithRetry skips when its mutate reports no change.
+func TestGroupCompletionPersists(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "group-completion-persist",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Groups                      int    `yaml:"groups"`
+			JobCondition                string `yaml:"jobCondition"`
+			PreexistingConditionMessage string `yaml:"preexistingConditionMessage"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		scheme := runtime.NewScheme()
+		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+			return err
+		}
+
+		groups := make([]burninv1alpha1.GroupStatus, 0, in.Groups)
+		jobs := make([]*burninv1alpha1.Job, 0, in.Groups)
+		for i := 0; i < in.Groups; i++ {
+			name := []string{"g0", "g1", "g2"}[i]
+			job := &burninv1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-job", Namespace: "ns"},
+				Status: burninv1alpha1.JobStatus{Conditions: []metav1.Condition{{
+					Type: in.JobCondition, Status: metav1.ConditionTrue,
+					Reason: "WorkloadCompleted", LastTransitionTime: metav1.Now(),
+				}}},
+			}
+			jobs = append(jobs, job)
+			groups = append(groups, burninv1alpha1.GroupStatus{
+				Name:   name,
+				Phase:  burninv1alpha1.GroupRunning,
+				Nodes:  []string{"node" + name},
+				JobRef: &burninv1alpha1.WorkloadReference{Name: name + "-job", Namespace: "ns"},
+			})
+		}
+
+		wf := &burninv1alpha1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "ns", Generation: 1},
+			Spec: burninv1alpha1.WorkflowSpec{
+				Orchestration: burninv1alpha1.OrchestrationSpec{Iterations: 1},
+			},
+			Status: burninv1alpha1.WorkflowStatus{
+				// Seed every condition exactly as the reconcile will recompute them,
+				// ObservedGeneration included. Without that the condition write
+				// reports a change for an unrelated reason and masks the bug.
+				Conditions: []metav1.Condition{
+					{
+						Type: burninv1alpha1.WorkflowInProgress, Status: metav1.ConditionTrue,
+						Reason: ReasonJobRunning, Message: in.PreexistingConditionMessage,
+						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type: burninv1alpha1.WorkflowSucceeded, Status: metav1.ConditionFalse,
+						Reason: ReasonNotApplicable, Message: "",
+						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type: burninv1alpha1.WorkflowFailed, Status: metav1.ConditionFalse,
+						Reason: ReasonNotApplicable, Message: "",
+						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
+					},
+				},
+				Orchestration: &burninv1alpha1.OrchestrationStatus{
+					CurrentIteration: 1,
+					Groups:           groups,
+				},
+			},
+		}
+
+		b := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wf).WithStatusSubresource(wf)
+		for _, j := range jobs {
+			b = b.WithObjects(j).WithStatusSubresource(j)
+		}
+		c := b.Build()
+
+		r := &WorkflowReconciler{Client: c, Scheme: scheme, JobRequeueInterval: time.Second}
+		if _, err := r.updateStatusFromJobs(context.Background(), wf); err != nil {
+			return err
+		}
+
+		got := &burninv1alpha1.Workflow{}
+		if err := c.Get(context.Background(), types.NamespacedName{Name: "wf", Namespace: "ns"}, got); err != nil {
+			return err
+		}
+
+		type groupOut struct {
+			Name          string `json:"name"`
+			Phase         string `json:"phase"`
+			HasCompletion bool   `json:"hasCompletionTime"`
+		}
+		out := struct {
+			Groups []groupOut `json:"groups"`
+		}{}
+		for _, g := range got.Status.Orchestration.Groups {
+			out.Groups = append(out.Groups, groupOut{
+				Name: g.Name, Phase: string(g.Phase), HasCompletion: g.CompletionTime != nil,
+			})
+		}
+		bts, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(bts) + "\n"
+		return nil
+	})
+}
+
+var _ = ctrl.Result{}

--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -73,10 +73,20 @@ func setExclusiveStatusCondition[T client.Object](
 	conditions func(T) *[]metav1.Condition,
 	allTypes []string,
 	conditionType, reason, message string,
+	extra ...func(T) bool,
 ) (bool, error) {
 	wrote := false
 	err := updateStatusWithRetry(ctx, c, obj, func(o T) bool {
 		changed := false
+		// Apply any caller-supplied status mutation inside this same callback, so
+		// it is re-applied after the refetch on conflict and so it keeps the write
+		// from being skipped as a no-op. Status mutated outside the callback is
+		// silently lost on both paths.
+		for _, f := range extra {
+			if f != nil && f(o) {
+				changed = true
+			}
+		}
 		for _, ct := range allTypes {
 			status := metav1.ConditionFalse
 			condReason := ReasonNotApplicable

--- a/pkg/controller/testdata/group-completion-persist/both-jobs-succeeded/expected.json
+++ b/pkg/controller/testdata/group-completion-persist/both-jobs-succeeded/expected.json
@@ -1,0 +1,14 @@
+{
+  "groups": [
+    {
+      "name": "g0",
+      "phase": "Succeeded",
+      "hasCompletionTime": true
+    },
+    {
+      "name": "g1",
+      "phase": "Succeeded",
+      "hasCompletionTime": true
+    }
+  ]
+}

--- a/pkg/controller/testdata/group-completion-persist/both-jobs-succeeded/input.yaml
+++ b/pkg/controller/testdata/group-completion-persist/both-jobs-succeeded/input.yaml
@@ -1,0 +1,8 @@
+# Two groups whose Jobs have both Succeeded, and a Workflow whose conditions are
+# already InProgress/JobRunning with the message the reconcile will compute again.
+# The conditions therefore do not change, so the old code skipped Status().Update
+# and never wrote the group phases. Seen on hardware: the run passed and was
+# reported as a 15 minute timeout.
+groups: 2
+jobCondition: Succeeded
+preexistingConditionMessage: "Iteration 1/1: 0 groups running"

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -993,7 +993,22 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 		runningCount := countRunningGroups(orch)
 		msg := fmt.Sprintf("Iteration %d/%d: %d groups running",
 			orch.CurrentIteration, effectiveIterations(workflow.Spec.Orchestration), runningCount)
-		if err := r.setWorkflowInProgress(ctx, workflow, ReasonJobRunning, msg); err != nil {
+		// The loop above mutated orch.Groups on workflow.Status directly. Hand
+		// those phases to the condition write so they land in the same update:
+		// updateStatusWithRetry skips the write when its mutate reports no change,
+		// and refetches on conflict, so status mutated outside the callback is
+		// dropped on both paths. That left a completed group stuck Running and the
+		// Workflow never finished — a passing run reported as a timeout.
+		want := make([]burninv1alpha1.GroupStatus, len(orch.Groups))
+		copy(want, orch.Groups)
+		applyGroups := func(w *burninv1alpha1.Workflow) bool {
+			if w.Status.Orchestration == nil || !statusChanged {
+				return false
+			}
+			w.Status.Orchestration.Groups = want
+			return true
+		}
+		if err := r.setWorkflowInProgress(ctx, workflow, ReasonJobRunning, msg, applyGroups); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -1846,8 +1861,8 @@ func collectAllDomainNodes(groups []burninv1alpha1.GroupStatus) map[string][]str
 }
 
 // setWorkflowInProgress sets the Workflow to InProgress state.
-func (r *WorkflowReconciler) setWorkflowInProgress(ctx context.Context, workflow *burninv1alpha1.Workflow, reason, message string) error {
-	return r.setExclusiveCondition(ctx, workflow, burninv1alpha1.WorkflowInProgress, reason, message)
+func (r *WorkflowReconciler) setWorkflowInProgress(ctx context.Context, workflow *burninv1alpha1.Workflow, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
+	return r.setExclusiveCondition(ctx, workflow, burninv1alpha1.WorkflowInProgress, reason, message, extra...)
 }
 
 // setWorkflowSucceeded sets the Workflow to Succeeded state.
@@ -1861,7 +1876,7 @@ func (r *WorkflowReconciler) setWorkflowFailed(ctx context.Context, workflow *bu
 }
 
 // setExclusiveCondition sets one condition True and all others False (mutually exclusive).
-func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow *burninv1alpha1.Workflow, conditionType, reason, message string) error {
+func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow *burninv1alpha1.Workflow, conditionType, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
 	changed, err := setExclusiveStatusCondition(ctx, r.Client, workflow,
 		func(w *burninv1alpha1.Workflow) *[]metav1.Condition { return &w.Status.Conditions },
 		[]string{
@@ -1869,7 +1884,7 @@ func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow
 			burninv1alpha1.WorkflowSucceeded,
 			burninv1alpha1.WorkflowFailed,
 		},
-		conditionType, reason, message,
+		conditionType, reason, message, extra...,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## The problem

`updateStatusFromJobs` marks a group `Succeeded` or `Failed` by mutating
`orch.Groups` on `workflow.Status`, then relies on the condition write to persist
it as a side effect. That is not safe, because `updateStatusWithRetry` drops
status mutated outside its own callback in two different ways:

```go
return retry.RetryOnConflict(retry.DefaultRetry, func() error {
    if !mutate(obj) { return nil }                            // (1) no write at all
    err := c.Status().Update(ctx, obj)
    ...
    if getErr := c.Get(ctx, key, obj); getErr != nil { ... }  // (2) refetch overwrites obj
    return err
})
```

1. `setExclusiveStatusCondition`'s mutate reports only on the **conditions**. A
   reconcile that completed a group but left the conditions identical returns
   false, so **no write happens**.
2. On conflict the retry **refetches**, discarding the group phases, and
   re-applies only the conditions.

Two Jobs finishing seconds apart is exactly when conflicts occur.

## What it looked like

On a two-node cluster, both Jobs reached `Succeeded=True/WorkloadCompleted` with
`ValidationFailed=False/ThresholdsMet`, and the Workflow still showed:

```
group-0: phase=Running     completionTime=None
group-1: phase=Succeeded   completionTime=2026-08-08T10:10:04Z
```

group-0 stayed `Running` for four minutes and roughly sixteen reconcile
intervals, with no error logged. The consequence chain:

```
group stuck Running
  -> Workflow never leaves InProgress
    -> WorkloadRun never completes
      -> `ncrectl workloadrun run --wait` hits its timeout
        -> a run whose thresholds all passed is reported as FAILED
```

The stalled Workflow also never cleaned up its pods, so they lingered. A
successful run in the same batch cleaned up normally, which isolates the stall as
the cause. Reproduced on roughly one run in three.

## The fix

Hand the group phases to the condition write as an **extra mutation**, so they
land in the same update, survive the refetch, and stop the write being skipped.
`setExclusiveStatusCondition` now accepts optional extra mutations, which helps
any caller in this position rather than just this one site.

Doing it as a *second, separate* write instead made **thirteen integration tests
flaky** — the extra update bumped `resourceVersion` and triggered another
reconcile. One write is both correct and quiet.

## Verification

- New case `group-completion-persist/both-jobs-succeeded` **fails without this
  change**, leaving both groups `Running` with no completion time, which is what
  the cluster showed.
- `make lint` 0 issues, unit tests 0 failures, full integration suite green.
- On hardware afterwards: **six consecutive multi-group runs, none wedged**,
  against roughly two expected if unfixed.