### PR TITLE
fix: catch a goodput measurement that computed zero, not just an absent one

### DIFF
--- a/cmd/integration/testdata/reconcile/goodput-measurement-job-succeed/expected.json
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-job-succeed/expected.json
@@ -29,15 +29,15 @@
           "status": "True",
           "observedGeneration": 1,
           "lastTransitionTime": null,
-          "reason": "JobSucceeded",
-          "message": "Referenced Job completed successfully"
+          "reason": "NoDataCollected",
+          "message": "Job succeeded but no goodput was computed; check spec.logProfileRef"
         },
         {
           "type": "Measuring",
           "status": "False",
           "observedGeneration": 1,
           "lastTransitionTime": null,
-          "reason": "JobSucceeded",
+          "reason": "NoDataCollected",
           "message": "Measurement completed"
         }
       ]

--- a/pkg/controller/goodputmeasurement_controller.go
+++ b/pkg/controller/goodputmeasurement_controller.go
@@ -615,7 +615,12 @@ func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, meas
 
 	// A measurement that computed no goodput did not measure anything, whatever
 	// the Job did. Reporting JobSucceeded here reads as a successful measurement.
-	if measurement.Status.Result == "" {
+	// The ratio has to be checked as well as the empty string. writeStatusFromCumulative
+	// stores it through formatFloat, and formatFloat(0) is "0.000000", so a measurement
+	// that sampled but parsed nothing ends up with a result that is present and zero,
+	// never absent. Observed on hardware: a run whose logs missed the trainingStep
+	// pattern reported Complete/JobSucceeded with result 0.000000 and no steps.
+	if measurement.Status.Result == "" || parseFloat(measurement.Status.Result) == 0 {
 		return ctrl.Result{}, r.setComplete(ctx, measurement, reasonGoodputNoData,
 			"Job succeeded but no goodput was computed; check spec.logProfileRef")
 	}

--- a/pkg/controller/testdata/unresolved-log-profile/goodput-succeeded-zero-result/expected.json
+++ b/pkg/controller/testdata/unresolved-log-profile/goodput-succeeded-zero-result/expected.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "Complete",
+      "status": "True",
+      "reason": "NoDataCollected",
+      "message": "Job succeeded but no goodput was computed; check spec.logProfileRef"
+    },
+    {
+      "type": "Measuring",
+      "status": "False",
+      "reason": "NoDataCollected",
+      "message": "Measurement completed"
+    }
+  ],
+  "resultCount": 0
+}

--- a/pkg/controller/testdata/unresolved-log-profile/goodput-succeeded-zero-result/input.yaml
+++ b/pkg/controller/testdata/unresolved-log-profile/goodput-succeeded-zero-result/input.yaml
@@ -1,0 +1,10 @@
+# The Job succeeded and the measurement did sample, but nothing matched the
+# trainingStep pattern, so every metric came out zero. writeStatusFromCumulative
+# stores the ratio through formatFloat, and formatFloat(0) is "0.000000", so the
+# result is present and zero rather than absent. Guarding on the empty string
+# alone misses this and reports Complete=True/JobSucceeded on a measurement that
+# measured nothing. Seen on hardware, 2026-08-08.
+measurement: goodput
+jobCondition: Succeeded
+logProfileRef: megatron-training
+existingResult: "0.000000"

--- a/pkg/controller/unresolved_log_profile_test.go
+++ b/pkg/controller/unresolved_log_profile_test.go
@@ -43,6 +43,7 @@ func TestUnresolvedLogProfile(t *testing.T) {
 			JobCondition    string `yaml:"jobCondition"`
 			LogProfileRef   string `yaml:"logProfileRef"`
 			ExistingResults int    `yaml:"existingResults"`
+			ExistingResult  string `yaml:"existingResult"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
 			return err
@@ -51,6 +52,22 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		scheme := runtime.NewScheme()
 		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
 			return err
+		}
+
+		// A LogProfile that resolves. The zero-result case needs the profile to be
+		// found and simply parse nothing, which is different from the profile being
+		// missing, and reaches a different branch now that the final sample runs
+		// before the terminal handling.
+		profile := &burninv1alpha1.LogProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: "megatron-training"},
+			Spec: burninv1alpha1.LogProfileSpec{
+				Timestamp: burninv1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05.999999"},
+				Patterns: burninv1alpha1.LogPatternSet{
+					TrainingStep: &burninv1alpha1.EventPattern{
+						Regex: `iteration\s+(?P<iteration>\d+)`,
+					},
+				},
+			},
 		}
 
 		job := &burninv1alpha1.Job{
@@ -104,8 +121,12 @@ func TestUnresolvedLogProfile(t *testing.T) {
 					LogProfileRef: in.LogProfileRef,
 				},
 			}
+			// A measurement that sampled but parsed nothing already carries a
+			// formatted zero, never an empty string. Seed it so the terminal
+			// path sees what it sees in production.
+			m.Status.Result = in.ExistingResult
 			c := fake.NewClientBuilder().WithScheme(scheme).
-				WithObjects(job, m).WithStatusSubresource(job, m).Build()
+				WithObjects(job, m, profile).WithStatusSubresource(job, m).Build()
 			r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
 			if _, err := r.Reconcile(context.Background(), req); err != nil {
 				return err


### PR DESCRIPTION
## The problem

The `NoDataCollected` guard added in #54 cannot fire in the case it was written
for:

```go
// goodputmeasurement_controller.go
if measurement.Status.Result == "" {
    return ctrl.Result{}, r.setComplete(ctx, measurement, reasonGoodputNoData, ...)
}
```

but the writer is

```go
measurement.Status.Result = formatFloat(cm.Goodput)   // numstr.Format(0.0) == "0.000000"
```

Once the controller has written any status — which it does on every sample —
`Result` is `"0.000000"`, never `""`. The constant's own comment states the
intent and the bug in one line: *"so its result is **absent rather than zero**"*.
The intent is to catch absent; the writer makes it present-and-zero.

The **bandwidth** version of the same guard is correct, because it tests
`len(Status.Results) == 0` and a slice can genuinely be empty. This one was
written by analogy, and the analogy breaks on the underlying type.

## What it looked like

A ten-minute run whose logs never matched the `trainingStep` pattern:

```
result = 0.000000, currentStep = <unset>, avgTFLOPSPerGPU = <unset>
Complete=True/JobSucceeded :: "Referenced Job completed successfully"
```

Green, successful-looking, and it had measured nothing.

After this change, on the same logs:

```
result = 0.000000
Complete=True/NoDataCollected :: "Job succeeded but no goodput was computed; check spec.logProfileRef"
```

Worth noting for anyone re-testing: the field read **empty** mid-run — which the
pre-existing check would have caught on its own — and became `"0.000000"` only at
the terminal write. A workload shorter than one sample interval therefore
exercises the old path and proves nothing about this addition.

## Test changes

- New case `unresolved-log-profile/goodput-succeeded-zero-result`, which **fails
  without this change**, reporting `JobSucceeded`.
- That case now creates the `LogProfile` it names, so it exercises *profile
  resolves, parses nothing* rather than *profile missing*. Those two only
  separated once #63's final sample began running before the terminal handling;
  seeding the object keeps the case correct regardless of merge order.
- `goodput-measurement-job-succeed` golden moves `JobSucceeded` →
  `NoDataCollected`. That fixture supplies **no pod logs at all** and its golden
  records no result, no `currentStep` and no TFLOPs, so the measurement genuinely
  collects nothing. The diff is three lines; no metric values move.

`make lint` 0 issues, unit 0 failures, full integration suite green.