### PR TITLE
fix: report the test scale that was asked for, not one inferred from the result

### DIFF
--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -43,7 +43,11 @@ const (
 	labelCertification   = "cre.nvidia.com/certification"
 	labelCategoryDomain  = "cre.nvidia.com/category-domain"
 	labelCategoryVariant = "cre.nvidia.com/category-variant"
-	labelManagedBy       = "app.kubernetes.io/managed-by"
+	// annotationRequestedTestScale carries the testScale the operator asked for
+	// through to the report, which otherwise infers it from what was applied.
+	annotationRequestedTestScale = "cre.nvidia.com/requested-test-scale"
+
+	labelManagedBy = "app.kubernetes.io/managed-by"
 )
 
 // CertificationReconciler reconciles a Certification object
@@ -432,6 +436,15 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 			},
 		},
 		Spec: workflowSpec,
+	}
+	// Record what the operator asked for. The report otherwise infers the scale
+	// from what was applied, and those differ: an entry whose template ignores
+	// testScale still partitions one node per group, so an intra-rack request came
+	// out as "intra-node" in the report.
+	if opts.TestScale != "" {
+		workflow.Annotations = map[string]string{
+			annotationRequestedTestScale: opts.TestScale,
+		}
 	}
 
 	if err := controllerutil.SetControllerReference(certification, workflow, r.Scheme); err != nil {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -865,7 +865,20 @@ func buildCliqueReport(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1
 
 // detectTestScale infers the testScale from the workflow orchestration spec.
 // Returns "" when no explicit test scale was set (e.g., training workloads).
+// annotationRequestedTestScale carries the testScale the operator asked for, set
+// by the Certification controller when it creates the Workflow.
+const annotationRequestedTestScale = "cre.nvidia.com/requested-test-scale"
+
 func detectTestScale(wf *burninv1alpha1.Workflow) string {
+	// What the operator asked for, when the Certification recorded it. The
+	// fallback below infers the scale from what was applied, which is not the
+	// same thing: an entry whose template ignores testScale still partitions one
+	// node per group, so a run that asked for intra-rack was reported as
+	// intra-node. Prefer the request; infer only for Workflows created before
+	// this annotation existed, or created directly rather than by a Certification.
+	if req := wf.GetAnnotations()[annotationRequestedTestScale]; req != "" {
+		return req
+	}
 	o := wf.Spec.Orchestration
 	if o.Topology != nil && o.Topology.StrictDomain {
 		return burninv1alpha1.TestScaleIntraRack

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -841,13 +841,19 @@ func TestDetectTestScale(t *testing.T) {
 				TopologyKey  string `yaml:"topologyKey"`
 				StrictDomain bool   `yaml:"strictDomain"`
 			} `yaml:"topology"`
-			NodesPerJob int `yaml:"nodesPerJob"`
+			NodesPerJob        int    `yaml:"nodesPerJob"`
+			RequestedTestScale string `yaml:"requestedTestScale"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
 		wf := &burninv1alpha1.Workflow{}
+		if input.RequestedTestScale != "" {
+			wf.Annotations = map[string]string{
+				annotationRequestedTestScale: input.RequestedTestScale,
+			}
+		}
 		if input.Topology != nil {
 			wf.Spec.Orchestration.Topology = &burninv1alpha1.TopologySpec{
 				TopologyKey:  input.Topology.TopologyKey,

--- a/pkg/report/testdata/detect-test-scale/requested-beats-inference/expected.json
+++ b/pkg/report/testdata/detect-test-scale/requested-beats-inference/expected.json
@@ -1,0 +1,3 @@
+{
+  "testScale": "intra-rack"
+}

--- a/pkg/report/testdata/detect-test-scale/requested-beats-inference/input.yaml
+++ b/pkg/report/testdata/detect-test-scale/requested-beats-inference/input.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The operator asked for intra-rack. The entry's template ignores testScale, so
+# it still partitioned one node per group — and inferring from nodesPerJob == 1
+# reported "intra-node", contradicting the cert file. Seen on hardware with
+# communication/nccl-loopback, which hardcodes numNodes: 1.
+requestedTestScale: intra-rack
+nodesPerJob: 1


### PR DESCRIPTION
## The problem

`detectTestScale` re-derives the scale from the resolved Workflow rather than
reading what was requested:

```go
if o.Topology != nil && o.Topology.StrictDomain { return TestScaleIntraRack }
if o.Diagnose != nil                            { return TestScaleDiagnose }
if wf.Status.Orchestration.NodesPerJob == 1     { return TestScaleIntraNode }
return TestScaleFullScale
```

That last branch answers "did this run one node per group?", which is a different
question from "what did the operator ask for".

## What it looked like

`communication/nccl-loopback` hardcodes `numNodes: 1` and its orchestration block
has **no `{{ if eq .TestScale ... }}` branch at all**, because loopback is a
single-GPU test. So a certification requesting `intra-rack` on that entry ran,
passed, and printed:

```
Scale:  intra-node        <- asked for intra-rack
Result: PASSED
```

exit 0. The operator asked for one thing, a second thing happened, and the report
named a third — with nothing to indicate any of it.

The same cert on `communication/nccl-all-reduce`, whose template *does* consume
`testScale`, correctly reports `intra-rack` and fails with `PartitionError` on a
cluster without clique labels. So the inference is only wrong when the entry
ignores the setting — which is silent by construction.

## The fix

Record the request on the Workflow as an annotation when the Certification
creates it, and prefer it in the report.

This is the pattern already in use for `cre.nvidia.com/group-nodes`, written by
the workflow controller (`workflow_controller.go:794`) and read by both the job
controller (`job_controller.go:1113`) and the report (`report.go:1359`), plus the
`ncrectl.nvidia.com/detected-*` annotations in `render.go`. **No schema change,
no new condition, no `make manifests`.**

The inference remains as the fallback, so Workflows created before this
annotation existed — or created directly rather than through a Certification —
render exactly as they do today.

## Verification

- New case `detect-test-scale/requested-beats-inference` **fails without this
  change**, reporting `intra-node` for an `intra-rack` request, which is what the
  cluster showed.
- `make lint` 0 issues, unit 0 failures, full integration suite green.

## Note

This does not change *behaviour*, only what the report claims. Whether an entry
should silently accept a `testScale` it cannot honour is a separate question, and
a better error than a misleading report — worth considering as a follow-up.