### PR TITLE
docs: correct four claims a reader would act on and get wrong

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,15 +153,15 @@ jobs:
 
             ```bash
             # Requires gh CLI authenticated, or GITHUB_TOKEN set.
-            # -p includes pre-releases. Every release is a pre-release
-            # until v0.1.0, so keep -p until then.
-            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash -s -- -p
+            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
             ```
 
-            To install this exact version instead of the newest one:
+            The version is named explicitly because `releases/latest` resolves only to
+            the newest **stable** release, and every release so far is a pre-release.
+            Once `v0.1.0` is tagged, this shorter form installs the newest stable one:
 
             ```bash
-            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
+            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
             ```
 
             ## Helm Chart

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
 
-New GPU clusters often contain faulty nodes, and those faults surface only under real distributed load. CRE is a Kubernetes controller that certifies GPU clusters before production workloads run on them. It runs real training and communication workloads across topology-aware node groups, measures performance, detects hardware failures, and quarantines bad nodes.
+New GPU clusters often contain faulty nodes, and those faults surface only under real distributed load. CRE is a Kubernetes controller that certifies GPU clusters before production workloads run on them. It runs real training and communication workloads across topology-aware node groups, measures performance, detects hardware failures, and reports every bad node with a reason. Quarantine is left to your platform: CRE never cordons, taints, or otherwise modifies a node.
 
 CRE is for platform and infrastructure teams that bring up, validate, or resell GPU clusters.
 
 ## Features
 
 - A certification catalog with NCCL communication tests and multi-node training workloads
-- Platform detection (AWS, GCP, Azure, TogetherAI) and GPU architecture detection (GB200, GB300, H100)
+- Platform detection (AWS, GCP, Azure, OCI, nscale, TogetherAI, Mistral, Forge, on-prem) and GPU architecture detection (GB200, GB300, H100, A100, L40S, L40)
 - Goodput measurement parsed from training logs with configurable LogProfile patterns
 - Per-bus bandwidth measurement parsed from NCCL logs
 - Node health monitoring with CEL expressions while workloads run
@@ -55,11 +55,24 @@ Run `kubectl ncre setup status` at any time to see what is present.
 
 **1. Install the CLI**
 
+Every release so far is a pre-release, and `releases/latest` resolves only to the
+newest **stable** release. Until `v0.1.0` is tagged, name the version explicitly:
+
 ```bash
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash -s -- -p
+CRE_VERSION=v0.1.0-rc.7
+curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
+  | bash -s -- -v "${CRE_VERSION}"
+```
+
+Once a stable release exists, this shorter form works and picks up the newest one:
+
+```bash
+curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 ```
 
 The installer places `ncrectl` on your `$PATH` and creates a `kubectl-ncre` symlink so the CLI is also available as `kubectl ncre`.
+
+The installer needs a GitHub token while this repository is internal: authenticate with `gh auth login`, or set `GITHUB_TOKEN`.
 
 **2. Set up the cluster**
 

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -18,7 +18,7 @@ You need:
 - At least one node without GPUs. The CRE controller schedules only on nodes that do not have the `nvidia.com/gpu.present` label.
 - `kubectl` access with permission to create CRDs, cluster roles, and namespaces. The setup step needs this. Later certification runs need less.
 - `helm` on your PATH. The setup step calls it.
-- The Prometheus Operator CRDs (`monitoring.coreos.com/v1`). The CRE chart always creates a `ServiceMonitor`, and the install fails without them. The [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) chart provides them.
+- The Prometheus Operator CRDs (`monitoring.coreos.com/v1`), **or** the ServiceMonitor turned off. The chart creates a `ServiceMonitor` by default, so the install fails without those CRDs. Either install them — the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) chart provides them — or set `metrics.serviceMonitor.enabled=false` and skip them. Turning it off only disables the Prometheus scrape config; the controller still serves metrics.
 - A GitHub token with the `read:packages` scope. The controller image and the Helm chart live on ghcr.io. Run `gh auth login` once, or set `GITHUB_TOKEN`.
 - For GB200 and GB300 clusters only: the NVIDIA DRA driver, because those catalog entries create `ComputeDomain` resources. GB300 RoCE entries also need a Kubernetes version that serves `resource.k8s.io/v1`.
 - For training categories only: egress to `github.com` from worker nodes. The training pods clone Megatron-LM at start.
@@ -27,11 +27,19 @@ Cordoned nodes are skipped. If a node is cordoned, CRE does not select it, and i
 
 ## Step 1: install the CLI
 
+Every release so far is a pre-release, and `releases/latest` resolves only to the newest **stable** release, so that URL cannot be fetched yet. Name the version explicitly instead:
+
 ```bash
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash -s -- -p
+CRE_VERSION=v0.1.0-rc.7
+curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
+  | bash -s -- -v "${CRE_VERSION}"
 ```
 
-The `-p` flag accepts pre-releases. All releases are pre-releases today, so keep it until the first stable release exists.
+Once `v0.1.0` is tagged, the shorter `releases/latest/download/installer` form works and installs the newest stable release.
+
+The installer takes `-p` to accept pre-releases when it resolves a version itself. That flag is an argument to the script, so it cannot help you download the script — which is why the version is named in the URL above.
+
+While this repository is internal, downloading a release asset needs a GitHub token. Authenticate with `gh auth login`, or set `GITHUB_TOKEN`, before running the command.
 
 The installer detects your OS and architecture, downloads the matching `ncrectl` binary, installs it to `/usr/local/bin` (with sudo if needed), and adds a `kubectl-ncre` symlink. After it finishes, both forms work and are the same binary:
 
@@ -161,7 +169,7 @@ kubectl ncre setup reset
 | `setup init` hangs, then fails after 5 minutes in the helm phase | The controller cannot schedule. It requires a node without the `nvidia.com/gpu.present` label. | Add a CPU-only node or node pool. |
 | `GHCR returned 403` | The token lacks the `read:packages` scope. | `gh auth refresh -s read:packages` |
 | `helm not found in PATH` | Setup shells out to helm. | Install helm 3. |
-| `no matches for kind "ServiceMonitor"` in the helm phase | The Prometheus Operator CRDs are not installed. The chart requires them. | Install the Prometheus Operator (or at least its CRDs) first. |
+| `no matches for kind "ServiceMonitor"` in the helm phase | The Prometheus Operator CRDs are not installed, and the chart creates a `ServiceMonitor` by default. | Install the Prometheus Operator (or at least its CRDs), or skip the ServiceMonitor with `metrics.serviceMonitor.enabled=false`. |
 | `no nodes have nvidia.com/gpu.product label` | GPU Operator (feature discovery) is not running. | Install or fix the GPU Operator. |
 | `heterogeneous GPUs: ...` | Target nodes mix GPU products. | Certify one product at a time with a narrower `spec.target.nodeSelector` in a `--cert-file` YAML. |
 | `no GPU nodes match target` | All candidate nodes are cordoned or lack `nvidia.com/gpu.present=true`. | `kubectl uncordon` the nodes you want tested. |


### PR DESCRIPTION
Swept the getting-started guide, README and RELEASE.md against source. Most claims held; four did not, and each misleads at the point of use.

## 1. The documented install command is a 404

README Quickstart step 1, getting-started step 1, and the release notes on every release all say:

```bash
curl -sSL .../releases/latest/download/installer | bash -s -- -p
```

```
$ curl -sSL -o /dev/null -w "%{http_code}" .../releases/latest/download/installer
404
```

GitHub resolves `/releases/latest` to the newest **stable** release. Every release so far is a pre-release (`isLatest=false` on all of them), so there is nothing behind that URL.

`-p` looks like it covers this and does not — it is an argument to the installer script, and the script is what fails to download.

`RELEASE.md` already states this plainly:

> Note that `curl .../releases/latest/download/installer`, the install command in the README, resolves to the newest **stable** release. While only pre-releases exist, that URL returns 404.

The three user-facing places never picked it up. Fixed by naming the version in the URL, keeping the short form documented for when `v0.1.0` exists.

**Note on scope:** while this repository is internal, *any* unauthenticated fetch of a release asset 404s, so this is not the only reason the command fails today. That part resolves when the repo goes public. The `releases/latest` problem is independent and **will still be there after that**, which is why it is worth fixing now. The guide also now mentions the token requirement, since that is the other half of why a copy-paste fails.

## 2. The README said CRE quarantines bad nodes

Opening paragraph, before this PR:

> ...detects hardware failures, and **quarantines bad nodes**.

It does not, and it cannot:

- [ADR-061](docs/designs/061-excalibur-nvsentinel-remediation-decoupling.md) removed the Remediation controller that used to apply taints and cordons.
- `manager-role.yaml` grants `get, list, watch` on nodes — no `patch`, no `update`.

The README’s own "How it works" section already said quarantine is left to your platform, so the document contradicted itself two paragraphs apart.

## 3. The Prometheus Operator CRDs were described as mandatory

The chart guards the ServiceMonitor:

```
{{- if .Values.metrics.serviceMonitor.enabled }}
```

and `values.yaml` carries the escape hatch as a comment:

```yaml
  serviceMonitor:
    # The ServiceMonitor needs the Prometheus Operator CRDs
    # (monitoring.coreos.com/v1). Set to false on clusters without them.
    enabled: true
```

The default is `true`, so the CRDs are needed out of the box — that part was right. But an operator not running Prometheus was being told to install it with no way out. Corrected in both the prerequisites list and the troubleshooting row.

## 4. The feature list undercounted detection

| | Documented | Actual |
|---|---|---|
| Platforms | 4 | 9 — `aws, azure, forge, gcp, mistral, nscale, oci, onprem, togetherai` |
| GPU architectures | 3 | 6 — `gb200, gb300, h100, a100, l40s, l40` |

OCI is the notable omission; it has its own catalog overrides.

## What was checked and held

Roughly 35 verifiable claims in the guide, one wrong. Confirmed correct against source: all four ADR links resolve, seven CRDs, five LogProfiles, eight catalog categories, `minGPUs` 4 and 32, A100 `tp: 8`, default `--timeout` 30m, the `ncrectl-<timestamp>` namespace, the controller `DoesNotExist` node affinity, `-n` defaulting to `default`, the installer’s `-p` / `/usr/local/bin` / `kubectl-ncre` behaviour, and every literal output string the guide quotes.

Two claims I expected to be wrong were right: Kubeflow Trainer really is **v2.2.1** (`pkg/setup/setup.go:33`), and `ncrectl --version` is correct since cobra generates it from `Command.Version`.

`docs/designs/038-installer-script.md` also carries the old URL. Left alone deliberately — an ADR is a record of a decision at a point in time, not live documentation.

## Verification

`make lint` reports 0 issues, and `release.yml` still parses as valid YAML. No Go code is touched.