### PR TITLE
fix: report INCOMPLETE when a certification skipped cordoned nodes

### DIFF
--- a/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/expected.json
@@ -1,0 +1,115 @@
+{
+  "Workflow/test-cordoned": {
+    "kind": "Workflow",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-cordoned",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "test-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "test-image:latest",
+                "command": [
+                  "python",
+                  "train.py"
+                ],
+                "numNodes": 1
+              },
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true"
+          }
+        },
+        "execution": {},
+        "iterations": 1
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobRunning",
+          "message": "Iteration 1/1: 2 groups running"
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        }
+      ],
+      "orchestration": {
+        "totalNodes": 2,
+        "nodesPerJob": 1,
+        "totalGroups": 2,
+        "currentIteration": 1,
+        "detectedPlatform": "aws",
+        "detectedGPUArchitecture": "h100",
+        "excludedNodes": [
+          "cordon-node-02"
+        ],
+        "exclusionReason": "1 node(s) matched the target but were unschedulable (cordoned): cordon-node-02",
+        "groups": [
+          {
+            "name": "group-0",
+            "nodes": [
+              "cordon-node-01"
+            ],
+            "phase": "Running",
+            "jobRef": {
+              "apiVersion": "cre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-cordoned-group-0-iter-1",
+              "namespace": "default"
+            }
+          },
+          {
+            "name": "group-1",
+            "nodes": [
+              "cordon-node-03"
+            ],
+            "phase": "Running",
+            "jobRef": {
+              "apiVersion": "cre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-cordoned-group-1-iter-1",
+              "namespace": "default"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/input_client_objects.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# A uniform H100 fleet with one node cordoned. Discovery drops the cordoned
+# node, the run certifies the other two and succeeds — and before this change
+# nothing recorded that cordon-node-02 was targeted and never tested, so the
+# report said PASSED over a fleet it had only partly certified.
+#
+# The cordoned node is declared in the middle and out of name order so the case
+# does not depend on declaration order: the names are sorted before they reach
+# status.
+#
+# The names are deliberately not the usual gpu-node-NN. Nodes are cluster-scoped
+# and six other cases use those names, so a cordoned gpu-node-02 outliving its
+# case — cleanup is best-effort, and the manager cache lags deletion — would
+# silently change how those cases group their nodes.
+apiVersion: v1
+kind: Node
+metadata:
+  name: cordon-node-01
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: cordon-node-01
+spec:
+  providerID: "aws://us-east-1a/i-aaaa"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: cordon-node-02
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: cordon-node-02
+spec:
+  providerID: "aws://us-east-1a/i-bbbb"
+  # The whole point of the case. kubectl cordon sets exactly this.
+  unschedulable: true
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: cordon-node-03
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: cordon-node-03
+spec:
+  providerID: "aws://us-east-1a/i-cccc"
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-cordoned
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - python
+              - train.py
+            numNodes: 1
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"

--- a/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-cordoned-node-excluded/input_config.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: Workflow
+  name: test-cordoned
+  namespace: default
+  condition: InProgress
+  reason: JobRunning
+collect:
+  - kind: Workflow
+    name: test-cordoned
+    namespace: default

--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -357,7 +357,10 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 	}
 
 	// --- 1. Discover nodes (shared context for nodesPerJob + overlays) ---
-	nodes, err := discoverTargetNodes(ctx, r.Client, &certification.Spec.Target)
+	// Cordoned nodes are discarded here. The Workflow runs the same discovery and
+	// records them on its own status, which is where the report reads coverage
+	// from, so recording them twice would only risk the two disagreeing.
+	nodes, _, err := discoverTargetNodes(ctx, r.Client, &certification.Spec.Target)
 	if err != nil {
 		return "", fmt.Errorf("discovering target nodes: %w", err)
 	}

--- a/pkg/controller/discover_cordoned_test.go
+++ b/pkg/controller/discover_cordoned_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// Discovery drops cordoned nodes because they cannot run workload pods. It used
+// to drop them silently, so nothing downstream could tell a fleet that was
+// fully certified from one where a leftover cordon meant half of it was never
+// tested — both reported PASSED. These cases pin what discovery hands back.
+//
+// The names come back sorted for the same reason the node list does: they are
+// written to status and printed in the report, so an unsorted list would make
+// one cluster produce a different report on each reconcile.
+func TestDiscoverCordonedNodes(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "discover-cordoned",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Nodes []struct {
+				Name       string `yaml:"name"`
+				Cordoned   bool   `yaml:"cordoned"`
+				NoGPU      bool   `yaml:"noGPU"`
+				Unlabelled bool   `yaml:"unlabelled"`
+			} `yaml:"nodes"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		const present = "true"
+
+		given := make([]corev1.Node, 0, len(input.Nodes))
+		for _, n := range input.Nodes {
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			if !n.Unlabelled {
+				node.Labels = map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
+				}
+				if !n.NoGPU {
+					node.Labels[GPUNodeLabel] = present
+				}
+			}
+			node.Spec.Unschedulable = n.Cordoned
+			given = append(given, node)
+		}
+
+		nodes, cordoned, err := discoverTargetNodes(context.Background(),
+			unorderedReader{nodes: given},
+			&burninv1alpha1.TargetSpec{})
+		if err != nil {
+			return err
+		}
+
+		certified := make([]string, 0, len(nodes))
+		for i := range nodes {
+			certified = append(certified, nodes[i].Name)
+		}
+
+		out := struct {
+			Certified []string `json:"certified"`
+			Cordoned  []string `json:"cordoned"`
+		}{certified, cordoned}
+
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/discover_node_order_test.go
+++ b/pkg/controller/discover_node_order_test.go
@@ -61,7 +61,7 @@ func TestDiscoverNodeOrder(t *testing.T) {
 			}})
 		}
 
-		nodes, err := discoverTargetNodes(context.Background(),
+		nodes, _, err := discoverTargetNodes(context.Background(),
 			unorderedReader{nodes: given},
 			&burninv1alpha1.TargetSpec{
 				NodeSelector: map[string]string{"nvidia.com/gpu.present": "true"},

--- a/pkg/controller/exclusion_summary_test.go
+++ b/pkg/controller/exclusion_summary_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// A node can be left uncertified for more than one reason at once, and the
+// report derives its INCOMPLETE verdict from this one list. So the summary has
+// to carry every cause: a fleet that is part cordoned and part
+// mixed-architecture must report both, not whichever was recorded last.
+//
+// The empty case matters as much as the rest. A run that certified everything
+// it targeted must produce no list at all, because any list at all turns a
+// PASSED into an INCOMPLETE.
+func TestExclusionSummary(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "exclusion-summary",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Cordoned     []string `yaml:"cordoned"`
+			ArchExcluded []string `yaml:"archExcluded"`
+			GPUArch      string   `yaml:"gpuArch"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		nodes, reason := exclusionSummary(input.Cordoned, input.ArchExcluded, input.GPUArch)
+
+		out := struct {
+			ExcludedNodes []string `json:"excludedNodes"`
+			Reason        string   `json:"exclusionReason"`
+			// Verdict mirrors what pkg/report does with the list, which is the
+			// reason any of this is recorded. Keeping it in the golden means a
+			// change that empties the list shows up as a verdict change.
+			Verdict string `json:"verdictAfterPassingRun"`
+		}{ExcludedNodes: nodes, Reason: reason, Verdict: "PASSED"}
+		if len(nodes) > 0 {
+			out.Verdict = "INCOMPLETE"
+		}
+
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/testdata/discover-cordoned/cordoned-names-are-sorted/expected.json
+++ b/pkg/controller/testdata/discover-cordoned/cordoned-names-are-sorted/expected.json
@@ -1,0 +1,10 @@
+{
+  "certified": [
+    "node005"
+  ],
+  "cordoned": [
+    "node001",
+    "node002",
+    "node009"
+  ]
+}

--- a/pkg/controller/testdata/discover-cordoned/cordoned-names-are-sorted/input.yaml
+++ b/pkg/controller/testdata/discover-cordoned/cordoned-names-are-sorted/input.yaml
@@ -1,0 +1,12 @@
+# client.List gives no ordering guarantee, and these names are written to
+# status and printed in the report. Fed in reverse, they must still come back
+# sorted — the same non-determinism #57 fixed for the node list itself, which
+# there made two identical runs certify different subsets.
+nodes:
+  - name: node009
+    cordoned: true
+  - name: node002
+    cordoned: true
+  - name: node005
+  - name: node001
+    cordoned: true

--- a/pkg/controller/testdata/discover-cordoned/cordoned-non-gpu-node-is-not-a-loss/expected.json
+++ b/pkg/controller/testdata/discover-cordoned/cordoned-non-gpu-node-is-not-a-loss/expected.json
@@ -1,0 +1,8 @@
+{
+  "certified": [
+    "node002"
+  ],
+  "cordoned": [
+    "node003"
+  ]
+}

--- a/pkg/controller/testdata/discover-cordoned/cordoned-non-gpu-node-is-not-a-loss/input.yaml
+++ b/pkg/controller/testdata/discover-cordoned/cordoned-non-gpu-node-is-not-a-loss/input.yaml
@@ -1,0 +1,14 @@
+# A cordoned node with no GPU was never a certification candidate, so losing it
+# costs no coverage and must not be reported. Counting it would turn a fully
+# certified fleet into INCOMPLETE over a node that could never have been tested.
+#
+# This is reachable whenever the target is not the usual
+# `nvidia.com/gpu.present: "true"` selector — a nodeNames list or a custom label
+# can pull in CPU nodes, and the cordon filter runs before the GPU filter.
+nodes:
+  - name: node001
+    cordoned: true
+    noGPU: true
+  - name: node002
+  - name: node003
+    cordoned: true

--- a/pkg/controller/testdata/discover-cordoned/nothing-cordoned/expected.json
+++ b/pkg/controller/testdata/discover-cordoned/nothing-cordoned/expected.json
@@ -1,0 +1,7 @@
+{
+  "certified": [
+    "node002",
+    "node003"
+  ],
+  "cordoned": null
+}

--- a/pkg/controller/testdata/discover-cordoned/nothing-cordoned/input.yaml
+++ b/pkg/controller/testdata/discover-cordoned/nothing-cordoned/input.yaml
@@ -1,0 +1,5 @@
+# A healthy fleet must report no cordons at all, not an empty-but-present list.
+# Anything non-empty here would turn every clean run into INCOMPLETE.
+nodes:
+  - name: node002
+  - name: node003

--- a/pkg/controller/testdata/discover-cordoned/one-node-cordoned/expected.json
+++ b/pkg/controller/testdata/discover-cordoned/one-node-cordoned/expected.json
@@ -1,0 +1,9 @@
+{
+  "certified": [
+    "node002",
+    "node004"
+  ],
+  "cordoned": [
+    "node003"
+  ]
+}

--- a/pkg/controller/testdata/discover-cordoned/one-node-cordoned/input.yaml
+++ b/pkg/controller/testdata/discover-cordoned/one-node-cordoned/input.yaml
@@ -1,0 +1,8 @@
+# The ordinary case: an operator cordons a node for maintenance and forgets.
+# The run certifies node002 and node004, and node003 has to come back named
+# rather than vanish.
+nodes:
+  - name: node002
+  - name: node003
+    cordoned: true
+  - name: node004

--- a/pkg/controller/testdata/exclusion-summary/arch-only-is-unchanged/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/arch-only-is-unchanged/expected.json
@@ -1,0 +1,8 @@
+{
+  "excludedNodes": [
+    "node002",
+    "node004"
+  ],
+  "exclusionReason": "target set has more than one GPU architecture; certified h100 only",
+  "verdictAfterPassingRun": "INCOMPLETE"
+}

--- a/pkg/controller/testdata/exclusion-summary/arch-only-is-unchanged/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/arch-only-is-unchanged/input.yaml
@@ -1,0 +1,8 @@
+# The behaviour #73 shipped, pinned so this change does not alter it. With no
+# cordons the output must be byte-identical to what the architecture filter
+# produced on its own — same list, same wording, no leading separator.
+cordoned: []
+archExcluded:
+  - node002
+  - node004
+gpuArch: h100

--- a/pkg/controller/testdata/exclusion-summary/both-causes-are-reported/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/both-causes-are-reported/expected.json
@@ -1,0 +1,8 @@
+{
+  "excludedNodes": [
+    "node003",
+    "node007"
+  ],
+  "exclusionReason": "1 node(s) matched the target but were unschedulable (cordoned): node003. target set has more than one GPU architecture; certified h100 only",
+  "verdictAfterPassingRun": "INCOMPLETE"
+}

--- a/pkg/controller/testdata/exclusion-summary/both-causes-are-reported/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/both-causes-are-reported/input.yaml
@@ -1,0 +1,9 @@
+# Both causes at once, which is the case that forced a merge rather than an
+# assignment. Recording each cause as it is found let the architecture filter
+# overwrite the cordon, so an operator saw one reason and chased one remedy
+# while the other node stayed silently untested.
+cordoned:
+  - node003
+archExcluded:
+  - node007
+gpuArch: h100

--- a/pkg/controller/testdata/exclusion-summary/cordoned-node-is-excluded/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/cordoned-node-is-excluded/expected.json
@@ -1,0 +1,7 @@
+{
+  "excludedNodes": [
+    "node003"
+  ],
+  "exclusionReason": "1 node(s) matched the target but were unschedulable (cordoned): node003",
+  "verdictAfterPassingRun": "INCOMPLETE"
+}

--- a/pkg/controller/testdata/exclusion-summary/cordoned-node-is-excluded/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/cordoned-node-is-excluded/input.yaml
@@ -1,0 +1,7 @@
+# The case this change exists for. One cordoned node in an otherwise uniform
+# fleet: discovery drops it, the run certifies the rest and succeeds, and before
+# this the report said PASSED without ever naming node003.
+cordoned:
+  - node003
+archExcluded: []
+gpuArch: h100

--- a/pkg/controller/testdata/exclusion-summary/nothing-excluded/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/nothing-excluded/expected.json
@@ -1,0 +1,5 @@
+{
+  "excludedNodes": null,
+  "exclusionReason": "",
+  "verdictAfterPassingRun": "PASSED"
+}

--- a/pkg/controller/testdata/exclusion-summary/nothing-excluded/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/nothing-excluded/input.yaml
@@ -1,0 +1,6 @@
+# A run that certified everything it targeted. The list must stay empty:
+# pkg/report promotes PASSED to INCOMPLETE on any non-empty list, so an
+# accidental empty-but-present slice would downgrade every clean run.
+cordoned: []
+archExcluded: []
+gpuArch: h100

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -186,6 +186,39 @@ func (r *WorkflowReconciler) reconcileJob(ctx context.Context, workflow *burninv
 	return r.launchPendingGroups(ctx, workflow, orch)
 }
 
+// exclusionSummary lists every node that was targeted but left uncertified, and
+// says why. The report turns a non-empty list into an INCOMPLETE verdict, so
+// this is what stops a partly-certified fleet reporting a clean PASSED.
+//
+// Both causes can apply to one run, which is why they are merged rather than
+// assigned in turn: on a fleet that is part cordoned and part mixed-architecture,
+// writing each cause as it is found lets the second silently drop the first.
+func exclusionSummary(cordoned, archExcluded []string, gpuArch string) ([]string, string) {
+	var nodes, reasons []string
+
+	if len(cordoned) > 0 {
+		nodes = append(nodes, cordoned...)
+		reasons = append(reasons, fmt.Sprintf(
+			"%d node(s) matched the target but were unschedulable (cordoned): %s",
+			len(cordoned), strings.Join(cordoned, ", ")))
+	}
+
+	if len(archExcluded) > 0 {
+		nodes = append(nodes, archExcluded...)
+		reasons = append(reasons, fmt.Sprintf(
+			"target set has more than one GPU architecture; certified %s only",
+			gpuArch))
+	}
+
+	if len(nodes) == 0 {
+		return nil, ""
+	}
+	// ". " rather than "; ", because the architecture reason already contains a
+	// semicolon and joining on one leaves a reader unable to tell the separator
+	// from the punctuation. notEnoughNodesMessage chains its clauses the same way.
+	return nodes, strings.Join(reasons, ". ")
+}
+
 // notEnoughNodesMessage explains a node shortfall. "Schedulable" is Kubernetes
 // vocabulary for cordons, taints and capacity, so the bare form sends an operator
 // looking at the wrong thing when the real cause is that a heterogeneous target
@@ -207,7 +240,7 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	log := logf.FromContext(ctx)
 	target := workflow.Spec.Orchestration.Target
 
-	nodes, err := discoverTargetNodes(ctx, r.Client, target)
+	nodes, cordoned, err := discoverTargetNodes(ctx, r.Client, target)
 	if err != nil {
 		log.Error(err, "Failed to discover target nodes")
 		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonNodeDiscoveryError,
@@ -239,30 +272,36 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	}
 	orch.DetectedPlatform = platform
 
+	// A cordoned node matched the target and was never tested. discoverTargetNodes
+	// dropped it before anything here saw it, which is why the run is otherwise
+	// unaware of it.
+	if len(cordoned) > 0 {
+		log.Info("Cordoned nodes excluded from certification", "cordoned", cordoned)
+		r.eventf(workflow, corev1.EventTypeWarning, "CordonedNodesExcluded",
+			"Excluded %d cordoned node(s) from certification: %s",
+			len(cordoned), strings.Join(cordoned, ", "))
+	}
+
 	// archExcluded records nodes dropped for having a different GPU architecture,
 	// so a later shortfall can say that is why rather than blaming schedulability.
 	var archExcluded []string
 	gpuArch, filteredNodes := detectGPUArchConsistent(nodes)
 	if len(filteredNodes) < len(nodes) {
-		// Record the dropped nodes on the status, not just in an event. A run
-		// that excludes nodes still reports Succeeded, so without this the
-		// report says PASSED and never mentions what went untested.
-		excluded := excludedNodeNames(nodes, filteredNodes)
-		orch.ExcludedNodes = excluded
-		orch.ExclusionReason = fmt.Sprintf(
-			"target set has more than one GPU architecture; certified %s only",
-			gpuArch)
-		// The shortfall message below needs the same list.
-		archExcluded = excluded
+		archExcluded = excludedNodeNames(nodes, filteredNodes)
 		log.Info("Heterogeneous GPU architectures detected, filtering to primary",
 			"primary", gpuArch, "total", len(nodes), "filtered", len(filteredNodes),
-			"excluded", excluded)
+			"excluded", archExcluded)
 		r.eventf(workflow, corev1.EventTypeWarning, "HeterogeneousGPU",
 			"Filtered %d/%d nodes to primary GPU architecture %s; excluded: %s",
-			len(filteredNodes), len(nodes), gpuArch, strings.Join(excluded, ", "))
+			len(filteredNodes), len(nodes), gpuArch, strings.Join(archExcluded, ", "))
 		nodes = filteredNodes
 	}
 	orch.DetectedGPUArchitecture = gpuArch
+
+	// Record the dropped nodes on the status, not just in an event. A run that
+	// excludes nodes still reports Succeeded, so without this the report says
+	// PASSED and never mentions what went untested.
+	orch.ExcludedNodes, orch.ExclusionReason = exclusionSummary(cordoned, archExcluded, gpuArch)
 
 	// Apply overrides now that platform/gpuArch are known, before computing nodesPerJob.
 	// This is the authoritative call — emit events, log details, and populate status.
@@ -409,7 +448,12 @@ func (r *WorkflowReconciler) logOverrideResults(ctx context.Context, workflow *b
 
 // discoverTargetNodes lists and filters nodes based on the target spec.
 // Accepts a client.Reader so it can be called from both the reconciler and CLI tools.
-func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burninv1alpha1.TargetSpec) ([]corev1.Node, error) {
+//
+// The second return value names the nodes that matched the target but were
+// dropped for being cordoned. Callers that record coverage need it: a cordoned
+// node was targeted and never tested, and without the names the run reports a
+// clean PASSED over a fleet it only partly certified.
+func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burninv1alpha1.TargetSpec) ([]corev1.Node, []string, error) {
 	nodeList := &corev1.NodeList{}
 	var opts []client.ListOption
 
@@ -418,7 +462,7 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burn
 	}
 
 	if err := reader.List(ctx, nodeList, opts...); err != nil {
-		return nil, fmt.Errorf("failed to list nodes: %w", err)
+		return nil, nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
 	nodes := nodeList.Items
@@ -462,11 +506,23 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burn
 
 	// Filter out unschedulable (cordoned) nodes — they can't run workload pods
 	// and would cause immediate JobHardwareFailed from the node health monitor.
+	// Their names go back to the caller so the run can report what it skipped.
+	//
+	// Only GPU nodes count as skipped. A cordoned node without a GPU was never a
+	// certification candidate, so losing it costs no coverage, and reporting it
+	// would turn a fully certified fleet into INCOMPLETE over a node that could
+	// never have been tested. That is reachable whenever the target is not the
+	// usual gpu.present selector — a nodeNames list can pull in CPU nodes.
 	var schedulable []corev1.Node
+	var cordoned []string
 	for _, n := range nodes {
-		if !n.Spec.Unschedulable {
-			schedulable = append(schedulable, n)
+		if n.Spec.Unschedulable {
+			if n.Labels["nvidia.com/gpu.present"] == "true" {
+				cordoned = append(cordoned, n.Name)
+			}
+			continue
 		}
+		schedulable = append(schedulable, n)
 	}
 	nodes = schedulable
 
@@ -487,7 +543,12 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burn
 	// matches how pkg/orchestration already chunks nodes into groups.
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 
-	return nodes, nil
+	// Sort the cordoned names for the same reason: they are written to status and
+	// printed in the report, so an unsorted list would make the same cluster
+	// produce a different report on each reconcile.
+	sort.Strings(cordoned)
+
+	return nodes, cordoned, nil
 }
 
 // nodeMatchesTaints returns true if the node has ALL of the specified taints.

--- a/pkg/controller/workflow_detect_export.go
+++ b/pkg/controller/workflow_detect_export.go
@@ -33,6 +33,12 @@ func ApplyOverridesWithTracking(spec *burninv1alpha1.WorkflowSpec, octx Override
 }
 
 // DiscoverTargetNodes is the exported version of discoverTargetNodes for use by CLI tools.
+//
+// It drops the cordoned-node list that discoverTargetNodes also returns. Only
+// the Workflow reconciler records coverage on status; CLI callers want the
+// nodes a run would actually use. Widen this if a CLI ever needs to report what
+// was skipped.
 func DiscoverTargetNodes(ctx context.Context, reader client.Reader, target *burninv1alpha1.TargetSpec) ([]corev1.Node, error) {
-	return discoverTargetNodes(ctx, reader, target)
+	nodes, _, err := discoverTargetNodes(ctx, reader, target)
+	return nodes, err
 }

--- a/pkg/controller/workloadrun_controller.go
+++ b/pkg/controller/workloadrun_controller.go
@@ -193,7 +193,9 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 	enableMNNVL := false
 	detectedPlatform := ""
 	gpuArch := ""
-	nodes, _ := discoverTargetNodes(ctx, r.Client, spec.Target)
+	// Cordoned nodes are discarded here: this call only detects GPU and platform
+	// defaults, and a WorkloadRun has no coverage verdict to qualify.
+	nodes, _, _ := discoverTargetNodes(ctx, r.Client, spec.Target)
 	if len(nodes) > 0 {
 		gpuArch = DetectGPUArchitecture(nodes)
 		detectedPlatform = DetectPlatform(nodes)


### PR DESCRIPTION
Follow-up to #73, which settled the `INCOMPLETE` verdict in #71.

#73 gave a certification an `INCOMPLETE` verdict when it left targeted nodes untested, but only for nodes dropped by the GPU architecture filter. **A cordoned node was still lost in silence.** `discoverTargetNodes` removes it before the reconciler sees it, so the run certifies whatever remains and reports a clean `PASSED` over a fleet it only partly covered.

That is the same surprise for an operator, from a more common cause. A forgotten cordon is ordinary, and the report gave no sign of one.

## What changed

Discovery now hands back the cordoned nodes it drops, and the Workflow records them on status.

**`pkg/report` needed no change.** It already promotes a non-empty `excludedNodes` to `INCOMPLETE` at exit 0, and its comment already named a leftover cordon as a cause — the information simply never arrived. **No CRD change**; `make manifests generate` produces no drift.

Before, on a three-node fleet with one node cordoned:

```
Nodes:     2
Result:    PASSED
```

After:

```
Nodes:     2
Excluded:  1 (cordon-node-02)
           1 node(s) matched the target but were unschedulable (cordoned): cordon-node-02
Result:    INCOMPLETE
exit 0
```

## Two defects this uncovered

Neither was the thing I set out to fix; both surfaced while writing the tests.

**1. `ExcludedNodes` was assigned once per cause.** On a fleet that is *both* cordoned and mixed-architecture, the architecture filter overwrote the cordon — one node left untested and unmentioned, while the operator chased the other. A new pure `exclusionSummary()` merges the causes instead of assigning them in turn. That is the `both-causes-are-reported` case, and it fails without the fix.

**2. A cordoned node with no GPU was counted as lost coverage.** It was never a certification candidate, so losing it costs nothing — but counting it would turn a fully certified fleet `INCOMPLETE` over a node that could not have been tested. The cordon filter runs *before* the GPU filter, so this is reachable whenever the target is not the usual `gpu.present` selector; a `nodeNames` list can pull in CPU nodes.

The cordoned names are also sorted before reaching status. `client.List` gives no ordering guarantee and these names are printed in the report, so unsorted they would reproduce the non-determinism #57 fixed for the node list itself.

## Tests

`exclusion-summary` covers each cause alone, both together, and neither. The `arch-only-is-unchanged` case pins #73's wording as **byte-identical**, so this cannot quietly reword the existing behaviour. `discover-cordoned` covers the ordinary cordon, a clean fleet, sorting, and the non-GPU node. One integration case proves the verdict end to end.

**Every new test was run with the fix reverted first and fails without it.** Reverting the cordon reporting fails 3 of 4 discovery cases, with `nothing-cordoned` correctly still passing; reverting the merge to assign-per-cause fails `both-causes-are-reported` alone.

**No existing golden file changes**, because no prior test had a cordoned node.

## Verification

- `make manifests generate` — no drift
- `make lint` — 0 issues
- `make build` — clean
- `make test` — green; the integration suite was run **5 consecutive times**, all passing

## Out of scope

A run where **every** node is cordoned still fails with `No target nodes found matching orchestration target` rather than reporting `INCOMPLETE`, because there is no partial coverage to describe. Naming cordons in that message is a separate behaviour change, tracked alongside the deferred half of #74.
