### PR TITLE
test: cover the WorkloadRun render path, which had no tests

### DIFF
--- a/pkg/workloadrun/build_workflow_spec_test.go
+++ b/pkg/workloadrun/build_workflow_spec_test.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadrun
+
+import (
+	"encoding/json"
+	"testing"
+
+	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"sigs.k8s.io/yaml"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// BuildWorkflowSpec renders the Workflow that "ncrectl workloadrun render" and
+// "--dry-run" print. The controller does not call it. The controller has its
+// own copy in pkg/controller/workloadrun_controller.go, and the two copies have
+// already drifted apart, so these cases cover the preview only. A passing run
+// here tells you nothing about what happens on a cluster.
+//
+// Each case records only the fields it is about, instead of the whole spec. The
+// whole spec is about 1040 lines, and about 85% of it is the platform override
+// block, which cmd/integration/testdata/reconcile/workloadrun-torch already
+// records line for line. If these cases recorded it again, then every edit to
+// pkg/platform/overrides/workloadrun.yaml or to the catalog _lib files it reads
+// would fail all of them, even though none of those edits touch this package.
+func TestBuildWorkflowSpec(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "build-workflow-spec",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		// The tags below are json, not yaml. sigs.k8s.io/yaml converts the YAML
+		// to JSON and then calls encoding/json, which ignores a yaml tag and
+		// leaves an unmatched field at its zero value without reporting an
+		// error. With yaml tags, a typo in a key would go unnoticed and would
+		// write gpusPerNode: 0 into the expected file.
+		var input struct {
+			Run           burninv1alpha1.WorkloadRun `json:"run"`
+			GpusPerNode   int32                      `json:"gpusPerNode"`
+			MlnxPerNode   int32                      `json:"mlnxPerNode"`
+			EnableMNNVL   bool                       `json:"enableMNNVL"`
+			FrameworkType string                     `json:"frameworkType"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		got := BuildWorkflowSpec(&input.Run, input.GpusPerNode, input.MlnxPerNode,
+			input.EnableMNNVL, input.FrameworkType)
+
+		b, err := json.MarshalIndent(project(got), "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}
+
+// projection holds the parts of a rendered WorkflowSpec that these cases check.
+type projection struct {
+	Trainer         *trainerv1alpha1.Trainer `json:"trainer"`
+	TimeoutPerJob   string                   `json:"timeoutPerJob"`
+	Iterations      int                      `json:"iterations"`
+	DependencyKinds []string                 `json:"dependencyKinds"`
+	// Validation records the contents and not only whether the block is
+	// present. The exact threshold key is part of it, because issue #52 is open
+	// about one unknown key turning off every threshold check without saying so.
+	Validation *burninv1alpha1.ValidationSpec `json:"validation"`
+	// WorkerEnv holds "NAME=value" for the worker container of the runtime
+	// dependency, which is the container the workload runs in. It records values
+	// and not only names, so a case can tell a variable the user asked for apart
+	// from a default that has the same name.
+	WorkerEnv []string `json:"workerEnv"`
+	// WorkerVolumeMounts and RuntimeVolumes cover the two halves of an inline
+	// config, which a person can remove one at a time.
+	WorkerVolumeMounts []string `json:"workerVolumeMounts"`
+	RuntimeVolumes     []string `json:"runtimeVolumes"`
+	// OverrideCount is the number of overrides, not their contents. The count
+	// is enough to catch an override that goes missing, and it does not change
+	// when someone edits an override body.
+	OverrideCount int `json:"overrideCount"`
+}
+
+func project(s *burninv1alpha1.WorkflowSpec) projection {
+	out := projection{
+		Iterations:    s.Orchestration.Iterations,
+		Validation:    s.Validation,
+		OverrideCount: len(s.Overrides),
+	}
+	if tj := s.JobTemplate.Spec.Workload.TrainJob; tj != nil {
+		out.Trainer = tj.Trainer
+	}
+	if t := s.Orchestration.Execution.TimeoutPerJob; t != nil {
+		out.TimeoutPerJob = t.Duration.String()
+	}
+	for i := range s.Dependencies {
+		out.DependencyKinds = append(out.DependencyKinds, dependencyKind(&s.Dependencies[i]))
+	}
+	out.WorkerEnv, out.WorkerVolumeMounts, out.RuntimeVolumes = runtimeWorker(s)
+	return out
+}
+
+// dependencyKind reads the Kind out of a dependency's embedded raw resource.
+func dependencyKind(d *burninv1alpha1.DependencySpec) string {
+	var obj struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(d.Raw, &obj); err != nil {
+		return ""
+	}
+	return obj.Kind
+}
+
+// runtimeWorker reads the worker container out of the runtime dependency and
+// returns its environment variables, its volume mounts, and the pod volumes.
+//
+// It follows one named path rather than searching the document, because a
+// search would also find containers that the workload does not run in, such as
+// an init container or an MPI launcher. A variable on one of those does not
+// reach the worker processes, and a search would report it as though it did.
+func runtimeWorker(s *burninv1alpha1.WorkflowSpec) (env, mounts, volumes []string) {
+	if len(s.Dependencies) == 0 || len(s.Dependencies[0].Raw) == 0 {
+		return nil, nil, nil
+	}
+
+	// The path below is the TrainingRuntime shape that pkg/platform builds.
+	var dep struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					ReplicatedJobs []struct {
+						Name     string `json:"name"`
+						Template struct {
+							Spec struct {
+								Template struct {
+									Spec struct {
+										Containers []struct {
+											Name string `json:"name"`
+											Env  []struct {
+												Name  string `json:"name"`
+												Value string `json:"value"`
+											} `json:"env"`
+											VolumeMounts []struct {
+												Name      string `json:"name"`
+												MountPath string `json:"mountPath"`
+											} `json:"volumeMounts"`
+										} `json:"containers"`
+										Volumes []struct {
+											Name string `json:"name"`
+										} `json:"volumes"`
+									} `json:"spec"`
+								} `json:"template"`
+							} `json:"spec"`
+						} `json:"template"`
+					} `json:"replicatedJobs"`
+				} `json:"spec"`
+			} `json:"template"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(s.Dependencies[0].Raw, &dep); err != nil {
+		return nil, nil, nil
+	}
+	// Pick the job by name. An MPI runtime holds two jobs, "node" and
+	// "launcher", and only "node" runs the worker processes. Taking the first
+	// job would read whichever one pkg/platform happens to write first.
+	idx := -1
+	for i, j := range dep.Spec.Template.Spec.ReplicatedJobs {
+		if j.Name == "node" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, nil, nil
+	}
+
+	pod := dep.Spec.Template.Spec.ReplicatedJobs[idx].Template.Spec.Template.Spec
+	for _, v := range pod.Volumes {
+		volumes = append(volumes, v.Name)
+	}
+	for _, c := range pod.Containers {
+		// "node" is the name pkg/platform gives the worker container.
+		if c.Name != "node" {
+			continue
+		}
+		for _, e := range c.Env {
+			env = append(env, e.Name+"="+e.Value)
+		}
+		for _, m := range c.VolumeMounts {
+			mounts = append(mounts, m.Name+" at "+m.MountPath)
+		}
+	}
+	return env, mounts, volumes
+}

--- a/pkg/workloadrun/run_overrides_test.go
+++ b/pkg/workloadrun/run_overrides_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadrun
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// applyRunOverrides merges the command line flags into the spec that was read
+// from a file. A flag can contradict the file, so each case records the four
+// fields the flags can change, rather than only the flag that was set.
+func TestApplyRunOverrides(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "apply-run-overrides",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Run            burninv1alpha1.WorkloadRun `yaml:"run"`
+			NameOverride   string                     `yaml:"nameOverride"`
+			NodeList       string                     `yaml:"nodeList"`
+			TopologyDomain string                     `yaml:"topologyDomain"`
+			TopologyKey    string                     `yaml:"topologyKey"`
+			TestScale      string                     `yaml:"testScale"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		run := input.Run
+		applyRunOverrides(&run, input.NameOverride, input.NodeList,
+			input.TopologyDomain, input.TopologyKey, input.TestScale)
+
+		out := struct {
+			Name     string                                `json:"name"`
+			NumNodes int32                                 `json:"numNodes"`
+			Target   *burninv1alpha1.TargetSpec            `json:"target"`
+			Orch     *burninv1alpha1.WorkloadOrchestration `json:"orchestration"`
+		}{run.Name, run.Spec.NumNodes, run.Spec.Target, run.Spec.Orchestration}
+
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}
+
+// The repository holds two copies of resolveWRTimeout. One is here, on the
+// command line render path, and the other is in
+// pkg/controller/workloadrun_controller.go. PR #64 changed both copies but
+// added a test for the controller copy only.
+//
+// The cases below cover the copy in this package. They do not detect drift
+// between the two copies on their own, because each test calls one copy. The
+// way to remove the risk is to delete this copy and call the controller copy,
+// which is possible because pkg/workloadrun already imports pkg/controller and
+// pkg/controller does not import pkg/workloadrun.
+func TestResolveWRTimeoutUsesTheDefaultWhenTheValueIsUnusable(t *testing.T) {
+	// A value the user wrote is used as written.
+	require.Equal(t, "45m0s", resolveWRTimeout("45m").Duration.String())
+
+	// An empty value returns the WorkloadRun default instead of nil. A nil
+	// value is what left a run with no time limit, because isJobTimedOut
+	// returns false when the limit is nil.
+	require.Equal(t, "24h0m0s", resolveWRTimeout("").Duration.String())
+
+	// A value that does not parse also returns the default. The first report of
+	// T2 missed this case. It is worse than leaving the field out, because the
+	// YAML looks correct to the person who wrote it.
+	require.Equal(t, "24h0m0s", resolveWRTimeout("2 hours").Duration.String())
+}

--- a/pkg/workloadrun/testdata/apply-run-overrides/no-flags-leaves-the-spec-alone/expected.json
+++ b/pkg/workloadrun/testdata/apply-run-overrides/no-flags-leaves-the-spec-alone/expected.json
@@ -1,0 +1,6 @@
+{
+  "name": "wr-untouched",
+  "numNodes": 3,
+  "target": null,
+  "orchestration": null
+}

--- a/pkg/workloadrun/testdata/apply-run-overrides/no-flags-leaves-the-spec-alone/input.yaml
+++ b/pkg/workloadrun/testdata/apply-run-overrides/no-flags-leaves-the-spec-alone/input.yaml
@@ -1,0 +1,18 @@
+# Every flag is empty, so the four recorded fields must come back unchanged. No
+# empty Target is created, and no empty Orchestration block is created.
+#
+# A helper that allocates an empty block on the way through is how a later nil
+# check starts taking the wrong branch.
+#
+# The case checks the four fields that the flags can change. It does not check
+# image, framework, env, volumes, resources or thresholds, so it would not
+# notice a helper that overwrote one of those.
+run:
+  metadata:
+    name: wr-untouched
+  spec:
+    image: img:latest
+    numNodes: 3
+    framework:
+      torch:
+        script: /t.py

--- a/pkg/workloadrun/testdata/apply-run-overrides/node-list-clamps-numnodes-down/expected.json
+++ b/pkg/workloadrun/testdata/apply-run-overrides/node-list-clamps-numnodes-down/expected.json
@@ -1,0 +1,11 @@
+{
+  "name": "wr",
+  "numNodes": 2,
+  "target": {
+    "nodeNames": [
+      "node001",
+      "node002"
+    ]
+  },
+  "orchestration": null
+}

--- a/pkg/workloadrun/testdata/apply-run-overrides/node-list-clamps-numnodes-down/input.yaml
+++ b/pkg/workloadrun/testdata/apply-run-overrides/node-list-clamps-numnodes-down/input.yaml
@@ -1,0 +1,13 @@
+# --nodes names fewer nodes than the file asks for. numNodes is clamped down to
+# match, because asking for 4 nodes while naming 2 can never be satisfied and
+# the run would wait rather than fail.
+run:
+  metadata:
+    name: wr
+  spec:
+    image: img:latest
+    numNodes: 4
+    framework:
+      torch:
+        script: /t.py
+nodeList: node001,node002

--- a/pkg/workloadrun/testdata/apply-run-overrides/node-list-never-raises-numnodes/expected.json
+++ b/pkg/workloadrun/testdata/apply-run-overrides/node-list-never-raises-numnodes/expected.json
@@ -1,0 +1,14 @@
+{
+  "name": "wr",
+  "numNodes": 2,
+  "target": {
+    "nodeNames": [
+      "node001",
+      "node002",
+      "node003",
+      "node004",
+      "node005"
+    ]
+  },
+  "orchestration": null
+}

--- a/pkg/workloadrun/testdata/apply-run-overrides/node-list-never-raises-numnodes/input.yaml
+++ b/pkg/workloadrun/testdata/apply-run-overrides/node-list-never-raises-numnodes/input.yaml
@@ -1,0 +1,18 @@
+# The clamp works in one direction only, and this case records that.
+#
+# Naming more nodes than numNodes does not raise numNodes. A run of 2 nodes with
+# five names still runs on 2 nodes, chosen from those five.
+#
+# Someone who reads the clamp as a mistake could change it into a plain
+# assignment. Raising numNodes would run the workload on more nodes than the
+# file asked for.
+run:
+  metadata:
+    name: wr
+  spec:
+    image: img:latest
+    numNodes: 2
+    framework:
+      torch:
+        script: /t.py
+nodeList: node001,node002,node003,node004,node005

--- a/pkg/workloadrun/testdata/apply-run-overrides/topology-domain-without-key-uses-auto/expected.json
+++ b/pkg/workloadrun/testdata/apply-run-overrides/topology-domain-without-key-uses-auto/expected.json
@@ -1,0 +1,16 @@
+{
+  "name": "wr",
+  "numNodes": 2,
+  "target": {
+    "matchExpressions": [
+      {
+        "key": "__auto__",
+        "operator": "In",
+        "values": [
+          "rack-7"
+        ]
+      }
+    ]
+  },
+  "orchestration": null
+}

--- a/pkg/workloadrun/testdata/apply-run-overrides/topology-domain-without-key-uses-auto/input.yaml
+++ b/pkg/workloadrun/testdata/apply-run-overrides/topology-domain-without-key-uses-auto/input.yaml
@@ -1,0 +1,21 @@
+# When a user passes --topology-domain and no --topology-key, the code inserts
+# the placeholder "__auto__" as the key.
+#
+# runWorkloadRunExecute replaces the placeholder later, using
+# cluster.DefaultTopologyKey. No platform override replaces it, because platform
+# overrides set orchestration.topology.topologyKey, which is a different field
+# from target.matchExpressions[].key.
+#
+# The replacement is skipped when node discovery returns no nodes, and the
+# placeholder then reaches the cluster as written, where it matches nothing. No
+# case covers that path yet.
+run:
+  metadata:
+    name: wr
+  spec:
+    image: img:latest
+    numNodes: 2
+    framework:
+      torch:
+        script: /t.py
+topologyDomain: rack-7

--- a/pkg/workloadrun/testdata/build-workflow-spec/inline-config-adds-volume-and-configmap/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/inline-config-adds-volume-and-configmap/expected.json
@@ -1,0 +1,39 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "/bin/bash",
+      "/config/run.sh"
+    ],
+    "numNodes": 1,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime",
+    "ConfigMap"
+  ],
+  "validation": null,
+  "workerEnv": [
+    "NCCL_DEBUG=INFO",
+    "NCCL_DEBUG_SUBSYS=NET,INIT",
+    "NCCL_NVLS_ENABLE=1",
+    "NCCL_CUMEM_ENABLE=1",
+    "NCCL_NET_GDR_C2C=1",
+    "NCCL_NET_GDR_LEVEL=PHB",
+    "NCCL_P2P_NET_CHUNKSIZE=2097152",
+    "NCCL_SHM_DISABLE=1",
+    "NCCL_MNNVL_ENABLE=0",
+    "NCCL_SOCKET_IFNAME=eth0"
+  ],
+  "workerVolumeMounts": [
+    "dshm at /dev/shm",
+    "config-volume at /config"
+  ],
+  "runtimeVolumes": [
+    "dshm",
+    "config-volume"
+  ],
+  "overrideCount": 15
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/inline-config-adds-volume-and-configmap/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/inline-config-adds-volume-and-configmap/input.yaml
@@ -1,0 +1,27 @@
+# An inline config has two effects that someone can change one at a time. It
+# adds a volume and a mount at /config, and it adds a second dependency that
+# carries the ConfigMap. If either half goes missing, the run either mounts
+# nothing or mounts a ConfigMap that was never created, and both failures happen
+# when the pod starts rather than when the spec is rendered.
+#
+# Three fields in the expected file cover the two halves. runtimeVolumes holds
+# the config volume, workerVolumeMounts holds the mount at /config, and
+# dependencyKinds holds the ConfigMap.
+run:
+  metadata:
+    name: wr-config
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 1
+    framework:
+      exec:
+        command: ["/bin/bash", "/config/run.sh"]
+    config:
+      inline:
+        run.sh: |
+          echo hello
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: exec

--- a/pkg/workloadrun/testdata/build-workflow-spec/intra-node-runs-one-node-per-job/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/intra-node-runs-one-node-per-job/expected.json
@@ -1,0 +1,38 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "torchrun"
+    ],
+    "args": [
+      "/workspace/train.py"
+    ],
+    "numNodes": 1,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime"
+  ],
+  "validation": null,
+  "workerEnv": [
+    "NCCL_DEBUG=INFO",
+    "NCCL_DEBUG_SUBSYS=NET,INIT",
+    "NCCL_NVLS_ENABLE=1",
+    "NCCL_CUMEM_ENABLE=1",
+    "NCCL_NET_GDR_C2C=1",
+    "NCCL_NET_GDR_LEVEL=PHB",
+    "NCCL_P2P_NET_CHUNKSIZE=2097152",
+    "NCCL_SHM_DISABLE=1",
+    "NCCL_MNNVL_ENABLE=0",
+    "NCCL_SOCKET_IFNAME=eth0"
+  ],
+  "workerVolumeMounts": [
+    "dshm at /dev/shm"
+  ],
+  "runtimeVolumes": [
+    "dshm"
+  ],
+  "overrideCount": 15
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/intra-node-runs-one-node-per-job/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/intra-node-runs-one-node-per-job/input.yaml
@@ -1,0 +1,35 @@
+# B6, fixed by PR #61 on this path only.
+#
+# A testScale of intra-node means that each node is tested on its own.
+# Partitioning reads the numNodes of the workload rather than any orchestration
+# field, so the setting did nothing, and a run over 4 nodes stayed one job of 4
+# nodes. PR #61 added nodesPerJobForScale to the command line render path, and
+# this case records the result. The trainer asks for 1 node even though the run
+# asks for 4.
+#
+# The controller does not do the same thing. It sets NodesPerJob to
+# spec.NumNodes at line 257 and line 300 of
+# pkg/controller/workloadrun_controller.go. Its only mention of
+# nodesPerJobForScale is a comment at line 515 that says the case is "Handled by
+# nodesPerJobForScale when the workload is built", and the controller never
+# calls that function. A WorkloadRun that runs on a real cluster therefore still
+# gets one job of 4 nodes.
+#
+# So this case covers the preview and not the behaviour that B6 was about. Do
+# not read a passing run here as proof that B6 is fixed.
+run:
+  metadata:
+    name: wr-intra-node
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 4
+    framework:
+      torch:
+        script: /workspace/train.py
+    orchestration:
+      testScale: intra-node
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: torch

--- a/pkg/workloadrun/testdata/build-workflow-spec/mpi-ignores-spec-env/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/mpi-ignores-spec-env/expected.json
@@ -1,0 +1,38 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "timeout",
+      "3600",
+      "/usr/local/mpi/bin/mpirun"
+    ],
+    "args": [
+      "-N",
+      "8",
+      "--allow-run-as-root",
+      "--mca",
+      "plm_rsh_args",
+      "-o StrictHostKeyChecking=no -o ConnectionAttempts=10",
+      "-x",
+      "NCCL_DEBUG=INFO",
+      "/workspace/all_reduce_perf"
+    ],
+    "numNodes": 2,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime"
+  ],
+  "validation": null,
+  "workerEnv": null,
+  "workerVolumeMounts": [
+    "mpi-ssh-auth at /tmp/mpi-ssh-raw",
+    "dshm at /dev/shm"
+  ],
+  "runtimeVolumes": [
+    "dshm"
+  ],
+  "overrideCount": 14
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/mpi-ignores-spec-env/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/mpi-ignores-spec-env/input.yaml
@@ -1,0 +1,40 @@
+# B7, filed as issue #68 and still open.
+#
+# A torch run receives spec.env, and an MPI run does not, because
+# BuildMPIRuntime never reads the field. The behaviour may be deliberate,
+# because mpirun needs "-x VAR" to pass a variable to each worker process.
+#
+# The workerEnv field in the expected file is what to read. It lists
+# "NAME=value" for the worker container of the runtime dependency, which is the
+# container the workload runs in.
+#
+#   torch-run-renders...  workerEnv holds the 10 defaults from BaseNCCLEnvVars
+#   mpi-ignores-spec-env  workerEnv is empty
+#
+# The variable below is named CRE_TEST_MARKER on purpose. No default sets that
+# name, so the expected file can show whether the user's variable arrived. An
+# earlier version of this case used NCCL_DEBUG, which BaseNCCLEnvVars also sets,
+# so a fix that emitted the defaults and still dropped the user's variable would
+# have looked correct.
+#
+# The expected file records what the code does today, not what it should do.
+# When someone fixes issue #68, workerEnv here holds CRE_TEST_MARKER=present.
+# That change is the fix, not a regression.
+run:
+  metadata:
+    name: wr-mpi
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 2
+    framework:
+      mpi:
+        binary: /workspace/all_reduce_perf
+        mpirunPath: /usr/local/mpi/bin/mpirun
+    env:
+      - name: CRE_TEST_MARKER
+        value: present
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: mpi

--- a/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/expected.json
@@ -1,0 +1,48 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "torchrun"
+    ],
+    "args": [
+      "/workspace/train.py"
+    ],
+    "numNodes": 2,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime"
+  ],
+  "validation": {
+    "performance": {
+      "enabled": true,
+      "tracking": {},
+      "thresholds": {
+        "thresholds": {
+          "busBandwidthGBps": "value \u003e= 100"
+        }
+      }
+    }
+  },
+  "workerEnv": [
+    "NCCL_DEBUG=INFO",
+    "NCCL_DEBUG_SUBSYS=NET,INIT",
+    "NCCL_NVLS_ENABLE=1",
+    "NCCL_CUMEM_ENABLE=1",
+    "NCCL_NET_GDR_C2C=1",
+    "NCCL_NET_GDR_LEVEL=PHB",
+    "NCCL_P2P_NET_CHUNKSIZE=2097152",
+    "NCCL_SHM_DISABLE=1",
+    "NCCL_MNNVL_ENABLE=0",
+    "NCCL_SOCKET_IFNAME=eth0"
+  ],
+  "workerVolumeMounts": [
+    "dshm at /dev/shm"
+  ],
+  "runtimeVolumes": [
+    "dshm"
+  ],
+  "overrideCount": 15
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/input.yaml
@@ -1,0 +1,25 @@
+# Thresholds are the only thing that turns on the Validation block, and T1
+# showed why the block is needed. When no thresholds are set,
+# checkPerformanceThresholds returns early, so nothing checks that any data was
+# collected. The presence of the block decides whether a run is measured or only
+# watched.
+#
+# Note the spelling of the key. Issue #52 is open because one unknown threshold
+# key turns off all threshold checks without saying so, which makes the exact
+# string here important.
+run:
+  metadata:
+    name: wr-thresholds
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 2
+    framework:
+      torch:
+        script: /workspace/train.py
+    thresholds:
+      busBandwidthGBps: "value >= 100"
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: torch

--- a/pkg/workloadrun/testdata/build-workflow-spec/torch-keeps-spec-env/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/torch-keeps-spec-env/expected.json
@@ -1,0 +1,39 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "torchrun"
+    ],
+    "args": [
+      "/workspace/train.py"
+    ],
+    "numNodes": 2,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime"
+  ],
+  "validation": null,
+  "workerEnv": [
+    "NCCL_DEBUG=INFO",
+    "NCCL_DEBUG_SUBSYS=NET,INIT",
+    "NCCL_NVLS_ENABLE=1",
+    "NCCL_CUMEM_ENABLE=1",
+    "NCCL_NET_GDR_C2C=1",
+    "NCCL_NET_GDR_LEVEL=PHB",
+    "NCCL_P2P_NET_CHUNKSIZE=2097152",
+    "NCCL_SHM_DISABLE=1",
+    "NCCL_MNNVL_ENABLE=0",
+    "NCCL_SOCKET_IFNAME=eth0",
+    "CRE_TEST_MARKER=present"
+  ],
+  "workerVolumeMounts": [
+    "dshm at /dev/shm"
+  ],
+  "runtimeVolumes": [
+    "dshm"
+  ],
+  "overrideCount": 15
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/torch-keeps-spec-env/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/torch-keeps-spec-env/input.yaml
@@ -1,0 +1,26 @@
+# The other half of issue #68, and the case that makes mpi-ignores-spec-env
+# mean something. A torch run passes spec.env to the worker container.
+#
+# The variable is named CRE_TEST_MARKER because no default sets that name, so
+# workerEnv in the expected file shows the user's variable next to the 10
+# defaults from BaseNCCLEnvVars.
+#
+# Without this case, a change that dropped spec.env for torch as well as MPI
+# would fail nothing, because no other case sets spec.env on a torch run.
+run:
+  metadata:
+    name: wr-torch-env
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 2
+    framework:
+      torch:
+        script: /workspace/train.py
+    env:
+      - name: CRE_TEST_MARKER
+        value: present
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: torch

--- a/pkg/workloadrun/testdata/build-workflow-spec/torch-run-renders-the-default-workflow/expected.json
+++ b/pkg/workloadrun/testdata/build-workflow-spec/torch-run-renders-the-default-workflow/expected.json
@@ -1,0 +1,38 @@
+{
+  "trainer": {
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "command": [
+      "torchrun"
+    ],
+    "args": [
+      "/workspace/train.py"
+    ],
+    "numNodes": 2,
+    "numProcPerNode": 8
+  },
+  "timeoutPerJob": "24h0m0s",
+  "iterations": 1,
+  "dependencyKinds": [
+    "TrainingRuntime"
+  ],
+  "validation": null,
+  "workerEnv": [
+    "NCCL_DEBUG=INFO",
+    "NCCL_DEBUG_SUBSYS=NET,INIT",
+    "NCCL_NVLS_ENABLE=1",
+    "NCCL_CUMEM_ENABLE=1",
+    "NCCL_NET_GDR_C2C=1",
+    "NCCL_NET_GDR_LEVEL=PHB",
+    "NCCL_P2P_NET_CHUNKSIZE=2097152",
+    "NCCL_SHM_DISABLE=1",
+    "NCCL_MNNVL_ENABLE=0",
+    "NCCL_SOCKET_IFNAME=eth0"
+  ],
+  "workerVolumeMounts": [
+    "dshm at /dev/shm"
+  ],
+  "runtimeVolumes": [
+    "dshm"
+  ],
+  "overrideCount": 15
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/torch-run-renders-the-default-workflow/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/torch-run-renders-the-default-workflow/input.yaml
@@ -1,0 +1,16 @@
+# The ordinary case, and the one to read the others against. A torch run over 2
+# nodes with nothing unusual set.
+run:
+  metadata:
+    name: wr-torch
+    namespace: default
+  spec:
+    image: nvcr.io/nvidia/pytorch:24.01-py3
+    numNodes: 2
+    framework:
+      torch:
+        script: /workspace/train.py
+gpusPerNode: 8
+mlnxPerNode: 0
+enableMNNVL: false
+frameworkType: torch


### PR DESCRIPTION
`pkg/workloadrun` is 1171 lines in one file with no test files. It has produced
five findings and three merged pull requests, which makes it the package that
produces the bugs and the package with no tests at the same time. This adds
tests for the parts of it that turned out to be wrong before.

## What the tests cover

`BuildWorkflowSpec` gets six cases. Each one covers a bug that shipped, or a
path that nothing else covers.

| Case | Covers |
|---|---|
| `intra-node-runs-one-node-per-job` | B6, fixed by #61 on this path only, see below |
| `mpi-ignores-spec-env` | B7, issue #68, still open |
| `torch-keeps-spec-env` | the other half of issue #68 |
| `inline-config-adds-volume-and-configmap` | the config volume, the mount at /config, and the ConfigMap dependency |
| `thresholds-enable-validation` | T1, the Validation block and its threshold key |
| `torch-run-renders-the-default-workflow` | the ordinary case, to read the others against |

`applyRunOverrides` gets four cases, and `resolveWRTimeout` gets three
assertions. Ten cases run in total.

Coverage of the package goes from 0% to 21%.

## Each case records only the fields it is about

A record of the whole rendered spec is about 1040 lines, and about 85% of it is
the platform override block, which
`cmd/integration/testdata/reconcile/workloadrun-torch` already records line for
line. If these cases recorded the block again, then every edit to
`pkg/platform/overrides/workloadrun.yaml` or to the catalog `_lib` files it
reads would fail all of them, and a reviewer would have to read a diff of
several thousand lines to find the few lines that matter. The project guide
warns against regenerating expected files without reading them, and a diff that
size is how that starts.

The six cases hold 287 lines in total. The shape follows
`pkg/certification/certification_test.go` and
`pkg/controller/workloadrun_timeout_test.go`, which both project to a small
struct.

## The recorded fields are chosen so a case fails when its behaviour is removed

The Validation block is recorded in full, including the threshold key, rather
than as a flag saying the block exists. Issue #52 is open about one unknown key
turning off every threshold check without saying so, so the key is part of what
the case covers.

The config case records the pod volumes and the worker container's volume mounts
as well as the dependency kinds, because a person can remove either half on its
own and the case should fail for either.

Environment variables are recorded as name and value, and the two environment
cases use `CRE_TEST_MARKER`, which no default sets. An earlier version used
`NCCL_DEBUG`, which `BaseNCCLEnvVars` also sets, so a change that emitted the
defaults and still dropped the user's variable would have looked correct.

The variables come from the worker container of the runtime dependency, and the
code picks the replicated job named `node` rather than the first one. An MPI
runtime holds two jobs, `node` and `launcher`, and only `node` runs the worker
processes. A search of the whole document would also find init containers and
the launcher, where a variable does not reach the workers.

## Two problems the tests found, which this pull request does not fix

The first has its own issue, #85. PR #61 fixed B6 on the render path only. The
controller passes `spec.NumNodes` to `platform.RuntimeConfig` at line 257, to
`platform.OverrideConfig` at line 300, and to the trainer at line 409, and
neither override hook changes a node count. Its only mention of
`nodesPerJobForScale` is a comment at line 515 saying the case is "Handled by
nodesPerJobForScale when the workload is built", and the controller never calls
that function. So `testScale: intra-node` still produces one job across every
node on a cluster, while `ncrectl workloadrun render` shows it working.

The comment in `intra-node-runs-one-node-per-job/input.yaml` says so, so that
nobody reads a passing run as proof that B6 is fixed.

The second is `resolveWRTimeout`, which exists in this package and again in
`pkg/controller/workloadrun_controller.go`. PR #64 changed both copies and added
a test for the controller copy only. Each test calls one copy, so neither test
detects drift between them. `pkg/workloadrun` already imports `pkg/controller`
and `pkg/controller` does not import `pkg/workloadrun`, so the copy in this
package can be deleted in a later change. The comment on the test says this.

## How the tests were checked

Every case was run with the matching behaviour removed, and each one fails
without it:

- removing the intra-node collapse fails `intra-node-runs-one-node-per-job`
- removing the ConfigMap dependency fails `inline-config-adds-volume-and-configmap`
- removing the `/config` mount fails the same case
- emptying the `Performance` block fails `thresholds-enable-validation`
- passing only the base environment fails `torch-keeps-spec-env`

The expected files were generated three times and run under `-shuffle=on` to
check that nothing depends on map ordering.

`make lint` reports 0 issues, and `make test` passes.

## Note for a reviewer

The struct tags on the test input are `json` and not `yaml` on purpose.
`sigs.k8s.io/yaml` converts the YAML to JSON and then calls `encoding/json`,
which ignores a `yaml` tag and leaves an unmatched field at its zero value
without reporting an error. With `yaml` tags, a typo in a key would write
`gpusPerNode: 0` into an expected file and nothing would fail.

No production code changes.
