### PR TITLE
fix(installer): verify SHA256 checksum before installing ncrectl binary

### DIFF
--- a/installer
+++ b/installer
@@ -236,6 +236,59 @@ fi
 chmod +x "${TEMP_DIR}/${BINARY_NAME}"
 
 # ---------------------------------------------------------------------------
+# Verify checksum
+# ---------------------------------------------------------------------------
+
+msg "Verifying checksum..."
+
+CHECKSUMS_FILE="${TEMP_DIR}/checksums.txt"
+
+# Download checksums.txt from the same release, mirroring the binary download path.
+if [[ "${GH_AVAILABLE}" == "true" ]]; then
+  gh release download "${VERSION}" \
+    --repo "${GH_REPO}" \
+    --pattern "checksums.txt" \
+    --output "${CHECKSUMS_FILE}" \
+    --clobber 2>/dev/null || true
+elif [[ -n "${GH_TOKEN}" ]]; then
+  CHECKSUM_ASSET_URL=$(echo "${RELEASE_JSON}" | tr -d '\n' | tr '{' '\n' \
+    | grep '"name" *: *"checksums\.txt"' \
+    | grep -o '"url" *: *"https://api\.github\.com[^"]*releases/assets/[0-9]*"' \
+    | head -1 \
+    | sed 's/.*"\(https[^"]*\)".*/\1/')
+  if [[ -n "${CHECKSUM_ASSET_URL}" ]]; then
+    curl -fsSL \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/octet-stream" \
+      -o "${CHECKSUMS_FILE}" \
+      "${CHECKSUM_ASSET_URL}" 2>/dev/null || true
+  fi
+else
+  CHECKSUM_URL="${GH_RELEASE_URL}/${VERSION}/checksums.txt"
+  curl -fsSL -o "${CHECKSUMS_FILE}" "${CHECKSUM_URL}" 2>/dev/null || true
+fi
+
+if [[ ! -f "${CHECKSUMS_FILE}" ]] || [[ ! -s "${CHECKSUMS_FILE}" ]]; then
+  err "checksums.txt not found for release ${VERSION} — cannot verify download"
+fi
+
+# Select SHA-256 tool: sha256sum (Linux/GNU) or shasum -a 256 (macOS/Darwin).
+if command -v sha256sum &>/dev/null; then
+  SHA256_CHECK=(sha256sum --check --ignore-missing)
+elif command -v shasum &>/dev/null; then
+  SHA256_CHECK=(shasum -a 256 --check --ignore-missing)
+else
+  err "No SHA-256 tool found (sha256sum or shasum) — cannot verify checksum"
+fi
+
+# Run from TEMP_DIR so the relative filenames in checksums.txt resolve correctly.
+if ! (cd "${TEMP_DIR}" && "${SHA256_CHECK[@]}" checksums.txt); then
+  err "SHA-256 checksum verification failed for ${BINARY_NAME} — aborting install"
+fi
+
+ok "Checksum verified."
+
+# ---------------------------------------------------------------------------
 # Install / upgrade binary + kubectl plugin symlink
 #
 # kubectl discovers plugins by looking for executables named "kubectl-<name>"


### PR DESCRIPTION
## Summary

The installer downloaded the `ncrectl` binary via `curl` and immediately installed it to `/usr/local/bin` with no integrity check. The release pipeline publishes a `checksums.txt` file alongside every binary, but the installer never fetched or verified it. A MITM or compromised CDN could serve a backdoored binary to any user running the documented one-liner install.

This adds checksum verification after the binary download. It handles all three download paths the installer already uses: `gh` CLI, authenticated `curl` with `GH_TOKEN`, and unauthenticated public download. If verification fails the installer prints a clear error and exits without installing.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] CLI (ncrectl)

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed — checksum path should be tested against a real release
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review

Closes #91