### PR TITLE
fix(api,controller): prevent panics from empty or mutated spec.categories

### DIFF
--- a/api/v1alpha1/certification_types.go
+++ b/api/v1alpha1/certification_types.go
@@ -272,6 +272,8 @@ type CertificationSpec struct {
 
 	// Categories are the list of certificate categories required for the Target
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="categories is immutable after creation"
 	Categories []CertificateCategory `json:"categories,omitempty"`
 
 	// Global defaults for all categories. Per-category options override these.

--- a/helm/cluster-readiness-engine/crds/cre.nvidia.com_certifications.yaml
+++ b/helm/cluster-readiness-engine/crds/cre.nvidia.com_certifications.yaml
@@ -269,7 +269,11 @@ spec:
                   - domain
                   - variant
                   type: object
+                minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: categories is immutable after creation
+                  rule: self == oldSelf
               enableCheckpoint:
                 description: |-
                   enableCheckpoint enables checkpointing for training workloads.

--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -165,6 +165,9 @@ func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context
 	}
 
 	// Create Workflow for the first category
+	if len(certification.Spec.Categories) == 0 {
+		return ctrl.Result{}, fmt.Errorf("certification has no categories")
+	}
 	firstCategory := certification.Spec.Categories[0]
 	workflowName, err := r.createWorkflowForCategory(ctx, certification, firstCategory)
 	if err != nil {
@@ -226,6 +229,9 @@ func (r *CertificationReconciler) processNextCategory(ctx context.Context, certi
 	}
 
 	// Category is Pending — create its Workflow
+	if activeIdx >= len(certification.Spec.Categories) {
+		return ctrl.Result{}, fmt.Errorf("category index %d out of range (spec has %d categories)", activeIdx, len(certification.Spec.Categories))
+	}
 	category := certification.Spec.Categories[activeIdx]
 	workflowName, err := r.createWorkflowForCategory(ctx, certification, category)
 	if err != nil {


### PR DESCRIPTION
## Summary

Two related issues in `CertificationSpec.Categories`:

**Empty list causes controller panic (#92):** `categories: []` passed CRD validation because the field had `+kubebuilder:validation:Required` but no `MinItems=1`. On the next reconcile, `initializeCategoryStatuses` indexed `Spec.Categories[0]` without a length check, panicking and taking down all six reconcilers in the shared binary.

**Mid-run mutation causes wrong Workflow or panic (#93):** `processNextCategory` uses the position of the first non-terminal entry in `Status.CategoryStatuses` as an index into `Spec.Categories`. If a user patched `spec.categories` mid-run (inserting, reordering, or removing entries), `activeIdx` could exceed the slice length, again causing a panic.

Changes:
- Add `+kubebuilder:validation:MinItems=1` to reject empty lists at admission
- Add `+kubebuilder:validation:XValidation` immutability rule to prevent spec mutations after creation
- Add a defensive `len()` guard in `initializeCategoryStatuses` before accessing index 0
- Add a bounds check in `processNextCategory` before `Categories[activeIdx]`
- Regenerate CRD with `make manifests`

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] API / CRDs
- [x] Controller / Reconcilers

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review

Closes #92, #93