### PR TITLE
fix(ci): implement cosign image signing and SBOM generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for keyless cosign signing via OIDC
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,6 +63,35 @@ jobs:
           fi
 
       - name: Build and push
-        run: make docker-buildx
+        id: push
+        run: |
+          make docker-buildx
+          # Capture the image digest for signing
+          DIGEST=$(docker buildx imagetools inspect \
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }} \
+            --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         env:
           IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Sign container image
+        run: |
+          cosign sign --yes \
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.17.9
+        with:
+          image: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+
+      - name: Attest SBOM
+        run: |
+          cosign attest --yes \
+            --predicate sbom.cyclonedx.json \
+            --type cyclonedx \
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
 ## Supply Chain
 
 - CRE is licensed under Apache-2.0. Dependencies are reviewed for license compatibility with Apache-2.0; attributions are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
-- Release artifacts (container images, `ncrectl` binaries, Helm chart) will be signed with Sigstore cosign and ship with SBOMs and build provenance as part of the CI release pipeline. Verification commands will be documented here when the first signed release is published.
+- Container images are signed with Sigstore cosign (keyless OIDC) and ship with CycloneDX SBOMs attested via `cosign attest`. To verify: `cosign verify ghcr.io/nvidia/cluster-readiness-engine/manager:<tag> --certificate-identity-regexp='https://github.com/NVIDIA/cluster-readiness-engine' --certificate-oidc-issuer='https://token.actions.githubusercontent.com'`. CLI binaries include SHA256 checksums in each release.
 
 ## Product Security Resources
 


### PR DESCRIPTION
## Summary

`SECURITY.md` promised that release artifacts would be signed with Sigstore cosign and ship with SBOMs, but `publish.yml` had no signing step, no SBOM tooling, and no `id-token: write` permission (required for OIDC keyless signing). Users had no way to verify the integrity of published images.

Changes:
- Add `id-token: write` to the publish job permissions for OIDC keyless signing
- Capture the image digest after push (needed to pin signing to the exact digest, not just the tag)
- Add `sigstore/cosign-installer` and `cosign sign` to sign the image against the GitHub Actions OIDC identity
- Add `anchore/sbom-action` to generate a CycloneDX SBOM
- Add `cosign attest` to attach the SBOM to the image as a verifiable attestation
- Update `SECURITY.md` to reflect what is now implemented and include the `cosign verify` command for consumers

To verify a signed image after this lands:
```bash
cosign verify ghcr.io/nvidia/cluster-readiness-engine/manager:<tag> \
  --certificate-identity-regexp='https://github.com/NVIDIA/cluster-readiness-engine' \
  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation / CI

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed — signing steps will only run in CI with a valid OIDC token
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [x] Documentation updated (`SECURITY.md` updated)
- [x] Ready for review

Closes #90