### PR TITLE
fix(catalog): keep Forge GB200/GB300 NCCL MPI bootstrap off InfiniBand

### DIFF
--- a/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/expected.json
@@ -1,0 +1,493 @@
+{
+  "Certification/forge-gb200-nc": {
+    "kind": "Certification",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "forge-gb200-nc",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/certification-finalizer"
+      ]
+    },
+    "spec": {
+      "target": {
+        "nodeSelector": {
+          "nvidia.com/gpu.present": "true",
+          "nvidia.com/gpu.product": "NVIDIA-GB200-NVL72"
+        }
+      },
+      "categories": [
+        {
+          "domain": "communication",
+          "variant": "nccl-all-reduce"
+        }
+      ],
+      "nodesPerJob": 2,
+      "enableMNNVL": true
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "WorkflowRunning",
+          "message": "Certification in progress"
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        }
+      ],
+      "categoryStatuses": [
+        {
+          "domain": "communication",
+          "variant": "nccl-all-reduce",
+          "workflowRef": {
+            "name": "forge-gb200-nc-communicat-56cdb",
+            "namespace": "default"
+          },
+          "status": "InProgress"
+        }
+      ]
+    }
+  },
+  "Workflow/forge-gb200-nc-communicat-56cdb": {
+    "kind": "Workflow",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "forge-gb200-nc-communicat-56cdb",
+      "namespace": "default",
+      "labels": {
+        "app.kubernetes.io/managed-by": "cluster-readiness-engine",
+        "cre.nvidia.com/category-domain": "communication",
+        "cre.nvidia.com/category-variant": "nccl-all-reduce",
+        "cre.nvidia.com/certification": "forge-gb200-nc"
+      },
+      "ownerReferences": [
+        {
+          "apiVersion": "cre.nvidia.com/v1alpha1",
+          "kind": "Certification",
+          "name": "forge-gb200-nc",
+          "uid": "",
+          "controller": true,
+          "blockOwnerDeletion": true
+        }
+      ],
+      "finalizers": [
+        "cre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "nccl-all-reduce-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "nvcr.io/nvidia/pytorch:26.01-py3",
+                "command": [
+                  "timeout",
+                  "3600",
+                  "/usr/local/mpi/bin/mpirun"
+                ],
+                "args": [
+                  "-N",
+                  "4",
+                  "--allow-run-as-root",
+                  "--mca",
+                  "plm_rsh_args",
+                  "-o StrictHostKeyChecking=no",
+                  "--mca",
+                  "coll_ucc_enable",
+                  "0",
+                  "--mca",
+                  "coll_hcoll_enable",
+                  "0",
+                  "--mca",
+                  "pml",
+                  "ob1",
+                  "--mca",
+                  "btl",
+                  "tcp,self",
+                  "--mca",
+                  "btl_tcp_if_include",
+                  "eth0",
+                  "--mca",
+                  "oob",
+                  "tcp",
+                  "--mca",
+                  "oob_tcp_if_include",
+                  "eth0",
+                  "-x",
+                  "NCCL_DEBUG=INFO",
+                  "-x",
+                  "NCCL_NVLS_ENABLE=1",
+                  "-x",
+                  "NCCL_CUMEM_ENABLE=1",
+                  "-x",
+                  "NCCL_P2P_NET_CHUNKSIZE=2097152",
+                  "-x",
+                  "NCCL_MNNVL_ENABLE=1",
+                  "-x",
+                  "UCX_TLS=tcp",
+                  "-x",
+                  "UCX_NET_DEVICES=eth0",
+                  "/usr/local/bin/all_reduce_perf_mpi",
+                  "-b",
+                  "8",
+                  "-e",
+                  "16G",
+                  "-f",
+                  "2",
+                  "-n",
+                  "100",
+                  "-N",
+                  "10"
+                ],
+                "numNodes": 2,
+                "numProcPerNode": 4
+              },
+              "runtimePatches": [
+                {
+                  "manager": "cre.nvidia.com/catalog",
+                  "trainingRuntimeSpec": {
+                    "template": {
+                      "spec": {
+                        "replicatedJobs": [
+                          {
+                            "name": "node",
+                            "template": {
+                              "spec": {
+                                "template": {
+                                  "spec": {
+                                    "volumes": [
+                                      {
+                                        "name": "dshm",
+                                        "emptyDir": {
+                                          "medium": "Memory"
+                                        }
+                                      }
+                                    ],
+                                    "containers": [
+                                      {
+                                        "name": "node",
+                                        "volumeMounts": [
+                                          {
+                                            "name": "dshm",
+                                            "mountPath": "/dev/shm"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "launcher"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          },
+          "nodeHealthMonitor": {
+            "cel": {
+              "expression": "node.spec.unschedulable == true"
+            }
+          },
+          "bandwidthMeasurement": {
+            "logProfileRef": "nccl-bandwidth",
+            "sampleInterval": "30s",
+            "testType": "all_reduce"
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true",
+            "nvidia.com/gpu.product": "NVIDIA-GB200-NVL72"
+          }
+        },
+        "execution": {
+          "timeoutPerJob": "1h0m0s"
+        },
+        "iterations": 1
+      },
+      "dependencies": [
+        {
+          "apiVersion": "trainer.kubeflow.org/v1alpha1",
+          "kind": "TrainingRuntime",
+          "metadata": {
+            "labels": {
+              "app": "nccl-all-reduce",
+              "trainer.kubeflow.org/framework": "mpi"
+            },
+            "name": "nccl-all-reduce-runtime"
+          },
+          "spec": {
+            "mlPolicy": {
+              "mpi": {
+                "mpiImplementation": "OpenMPI",
+                "numProcPerNode": 4,
+                "sshAuthMountPath": "/tmp/mpi-ssh-raw"
+              },
+              "numNodes": 1
+            },
+            "template": {
+              "spec": {
+                "network": {
+                  "publishNotReadyAddresses": true
+                },
+                "replicatedJobs": [
+                  {
+                    "name": "node",
+                    "template": {
+                      "spec": {
+                        "template": {
+                          "spec": {
+                            "containers": [
+                              {
+                                "args": [
+                                  "set -x \u0026\u0026\napt-get update \u0026\u0026\napt-get install -y --no-install-recommends openssh-server  \u0026\u0026\nmkdir -p /var/run/sshd  \u0026\u0026\nchmod 0755 /var/run/sshd  \u0026\u0026\nmkdir -p /root/.ssh \u0026\u0026\nchmod 700 /root/.ssh \u0026\u0026\ncp /tmp/mpi-ssh-raw/* /root/.ssh/ \u0026\u0026\nchmod 600 /root/.ssh/id_rsa \u0026\u0026\nchmod 644 /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \u0026\u0026\n/usr/sbin/sshd -De"
+                                ],
+                                "command": [
+                                  "sh",
+                                  "-c"
+                                ],
+                                "env": [
+                                  {
+                                    "name": "NCCL_MNNVL_ENABLE",
+                                    "value": "1"
+                                  }
+                                ],
+                                "image": "nvcr.io/nvidia/pytorch:26.01-py3",
+                                "name": "node",
+                                "readinessProbe": {
+                                  "initialDelaySeconds": 5,
+                                  "tcpSocket": {
+                                    "port": 22
+                                  }
+                                },
+                                "resources": {
+                                  "claims": [
+                                    {
+                                      "name": "compute-domain-channel"
+                                    }
+                                  ],
+                                  "limits": {
+                                    "nvidia.com/gpu": "4"
+                                  },
+                                  "requests": {
+                                    "nvidia.com/gpu": "4"
+                                  }
+                                },
+                                "securityContext": {
+                                  "capabilities": {
+                                    "add": [
+                                      "IPC_LOCK"
+                                    ]
+                                  }
+                                },
+                                "volumeMounts": [
+                                  {
+                                    "mountPath": "/tmp/mpi-ssh-raw",
+                                    "name": "mpi-ssh-auth",
+                                    "readOnly": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "resourceClaims": [
+                              {
+                                "name": "compute-domain-channel",
+                                "resourceClaimTemplateName": "nccl-all-reduce-channel"
+                              }
+                            ],
+                            "restartPolicy": "OnFailure"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "dependsOn": [
+                      {
+                        "name": "node",
+                        "status": "Ready"
+                      }
+                    ],
+                    "name": "launcher",
+                    "template": {
+                      "metadata": {
+                        "labels": {
+                          "trainer.kubeflow.org/trainjob-ancestor-step": "trainer"
+                        }
+                      },
+                      "spec": {
+                        "template": {
+                          "spec": {
+                            "containers": [
+                              {
+                                "image": "nvcr.io/nvidia/pytorch:26.01-py3",
+                                "name": "node",
+                                "resources": {
+                                  "limits": {
+                                    "cpu": "2",
+                                    "memory": "1Gi"
+                                  }
+                                },
+                                "volumeMounts": [
+                                  {
+                                    "mountPath": "/tmp/mpi-ssh-raw",
+                                    "name": "mpi-ssh-auth",
+                                    "readOnly": true
+                                  },
+                                  {
+                                    "mountPath": "/root/.ssh",
+                                    "name": "ssh-keys"
+                                  }
+                                ]
+                              }
+                            ],
+                            "initContainers": [
+                              {
+                                "args": [
+                                  "set -x \u0026\u0026\ncp /tmp/mpi-ssh-raw/* /root/.ssh/ \u0026\u0026\nchmod 600 /root/.ssh/id_rsa \u0026\u0026\nchmod 644 /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys"
+                                ],
+                                "command": [
+                                  "sh",
+                                  "-c"
+                                ],
+                                "image": "nvcr.io/nvidia/pytorch:26.01-py3",
+                                "name": "fix-ssh-permissions",
+                                "volumeMounts": [
+                                  {
+                                    "mountPath": "/tmp/mpi-ssh-raw",
+                                    "name": "mpi-ssh-auth",
+                                    "readOnly": true
+                                  },
+                                  {
+                                    "mountPath": "/root/.ssh",
+                                    "name": "ssh-keys"
+                                  }
+                                ]
+                              }
+                            ],
+                            "restartPolicy": "OnFailure",
+                            "volumes": [
+                              {
+                                "emptyDir": {},
+                                "name": "ssh-keys"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "successPolicy": {
+                  "operator": "All",
+                  "targetReplicatedJobs": [
+                    "launcher"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "resource.nvidia.com/v1beta1",
+          "kind": "ComputeDomain",
+          "metadata": {
+            "labels": {
+              "app": "nccl-all-reduce"
+            },
+            "name": "nccl-all-reduce-compute-domain"
+          },
+          "spec": {
+            "channel": {
+              "allocationMode": "Single",
+              "resourceClaimTemplate": {
+                "name": "nccl-all-reduce-channel"
+              }
+            },
+            "numNodes": 2
+          }
+        }
+      ]
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "GroupsPartitioned",
+          "message": "Discovered 2 nodes, partitioned into 1 groups (2 nodes/job)"
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        }
+      ],
+      "orchestration": {
+        "totalNodes": 2,
+        "nodesPerJob": 2,
+        "totalGroups": 1,
+        "currentIteration": 1,
+        "detectedPlatform": "forge",
+        "detectedGPUArchitecture": "gb200",
+        "groups": [
+          {
+            "name": "group-0",
+            "nodes": [
+              "ytl-gb200-node-01",
+              "ytl-gb200-node-02"
+            ],
+            "phase": "Pending"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/input_client_objects.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Forge GB200 nodes: empty providerID and hostnames without "forge" in the name,
+# so platform detection falls back to the nke.nvidia.com/site-name label.
+# Nodes share a gpu.clique label (GB200 topology-aware scheduling).
+apiVersion: v1
+kind: Node
+metadata:
+  name: ytl-gb200-node-01
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: NVIDIA-GB200-NVL72
+    nvidia.com/gpu.clique: "clique-0"
+    kubernetes.io/hostname: ytl-gb200-node-01
+    nke.nvidia.com/site-name: ytl
+spec:
+  providerID: ""
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: ytl-gb200-node-02
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: NVIDIA-GB200-NVL72
+    nvidia.com/gpu.clique: "clique-0"
+    kubernetes.io/hostname: ytl-gb200-node-02
+    nke.nvidia.com/site-name: ytl
+spec:
+  providerID: ""
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Certification
+metadata:
+  name: forge-gb200-nc
+  namespace: default
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+      nvidia.com/gpu.product: NVIDIA-GB200-NVL72
+  nodesPerJob: 2
+  enableMNNVL: true
+  categories:
+    - domain: communication
+      variant: nccl-all-reduce

--- a/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/certification-forge-gb200-nccl/input_config.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: Certification
+  name: forge-gb200-nc
+  namespace: default
+  condition: InProgress
+collect:
+  - kind: Certification
+    name: forge-gb200-nc
+    namespace: default
+  - kind: Workflow
+    name: forge-gb200-nc-communicat-56cdb
+    namespace: default

--- a/pkg/catalog/entries/_lib/nccl/forge-mpi-tcp-args.yaml
+++ b/pkg/catalog/entries/_lib/nccl/forge-mpi-tcp-args.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MPI bootstrap MCA flags for Forge GB200/GB300 (RoCE / MNNVL, no InfiniBand).
+#
+# Forge exposes IB HCAs to pods that never requested an RDMA resource. Without
+# these flags Open MPI's UCC collective component binds an IB device and aborts
+# in MPI_Init (ucc_core_addr_exchange → UD endpoint timeout). Disabling UCC
+# alone is insufficient: the UCX PML then binds IB and aborts in the first
+# MPI_Allgather. Both collective and point-to-point / out-of-band transports
+# must be pinned to TCP. This affects only MPI bootstrap — NCCL carries
+# collectives over NVLink/MNNVL via the ComputeDomain dependency as usual.
+- --mca
+- coll_ucc_enable
+- "0"
+- --mca
+- coll_hcoll_enable
+- "0"
+- --mca
+- pml
+- ob1
+- --mca
+- btl
+- tcp,self
+- --mca
+- btl_tcp_if_include
+- eth0
+- --mca
+- oob
+- tcp
+- --mca
+- oob_tcp_if_include
+- eth0

--- a/pkg/catalog/entries/_lib/nccl/forge-mpi-tcp-env.yaml
+++ b/pkg/catalog/entries/_lib/nccl/forge-mpi-tcp-env.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Belt-and-braces UCX env vars passed via mpirun -x for Forge GB200/GB300.
+# Prevents UCX from selecting an IB device even when pml=ob1 is set, ensuring
+# MPI out-of-band and point-to-point communication stays on TCP/eth0.
+- name: UCX_TLS
+  value: tcp
+- name: UCX_NET_DEVICES
+  value: eth0

--- a/pkg/catalog/entries/communication/nccl-all-gather.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-gather.yaml
@@ -495,3 +495,26 @@ overrides:
 {{ lib "nccl/forge-ib-env.yaml" . | toMpiArgs | indent 12 }}
             - /usr/local/bin/all_gather_perf_mpi
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- Forge + GB200/GB300 (MNNVL over NVLink; MPI bootstrap must not use IB) ---
+# Must come AFTER the GB200/GB300 ComputeDomain block so these args win, and after
+# Forge + L40 so the L40 IB baseline is not applied to Blackwell.
+# Forge exposes IB HCAs to pods that never requested an RDMA resource; UCC/UCX then
+# bind one and abort in MPI_Init. Pin the MPI bootstrap to TCP. The ComputeDomain
+# dependency from the GB200/GB300 block still applies, so NCCL keeps MNNVL.
+- when:
+    platform:
+      equals: forge
+    gpuArchitecture:
+      in: [gb200, gb300]
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            args:
+{{ lib "nccl/mpi-leading-args.yaml" . | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-args.yaml" . | indent 12 }}
+{{ lib "nccl/gb200-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/all_gather_perf_mpi
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}

--- a/pkg/catalog/entries/communication/nccl-all-reduce.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-reduce.yaml
@@ -498,3 +498,26 @@ overrides:
 {{ lib "nccl/forge-ib-env.yaml" . | toMpiArgs | indent 12 }}
             - /usr/local/bin/all_reduce_perf_mpi
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- Forge + GB200/GB300 (MNNVL over NVLink; MPI bootstrap must not use IB) ---
+# Must come AFTER the GB200/GB300 ComputeDomain block so these args win, and after
+# Forge + L40 so the L40 IB baseline is not applied to Blackwell.
+# Forge exposes IB HCAs to pods that never requested an RDMA resource; UCC/UCX then
+# bind one and abort in MPI_Init. Pin the MPI bootstrap to TCP. The ComputeDomain
+# dependency from the GB200/GB300 block still applies, so NCCL keeps MNNVL.
+- when:
+    platform:
+      equals: forge
+    gpuArchitecture:
+      in: [gb200, gb300]
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            args:
+{{ lib "nccl/mpi-leading-args.yaml" . | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-args.yaml" . | indent 12 }}
+{{ lib "nccl/gb200-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/all_reduce_perf_mpi
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}

--- a/pkg/catalog/entries/communication/nccl-alltoall.yaml
+++ b/pkg/catalog/entries/communication/nccl-alltoall.yaml
@@ -531,3 +531,26 @@ overrides:
             - -d
             - uint8
 {{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}
+# --- Forge + GB200/GB300 (MNNVL over NVLink; MPI bootstrap must not use IB) ---
+# Must come AFTER the GB200/GB300 ComputeDomain block so these args win, and after
+# Forge + L40 so the L40 IB baseline is not applied to Blackwell.
+# Forge exposes IB HCAs to pods that never requested an RDMA resource; UCC/UCX then
+# bind one and abort in MPI_Init. Pin the MPI bootstrap to TCP. The ComputeDomain
+# dependency from the GB200/GB300 block still applies, so NCCL keeps MNNVL.
+- when:
+    platform:
+      equals: forge
+    gpuArchitecture:
+      in: [gb200, gb300]
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          trainer:
+            args:
+{{ lib "nccl/mpi-leading-args.yaml" . | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-args.yaml" . | indent 12 }}
+{{ lib "nccl/gb200-env.yaml" . | toMpiArgs | indent 12 }}
+{{ lib "nccl/forge-mpi-tcp-env.yaml" . | toMpiArgs | indent 12 }}
+            - /usr/local/bin/alltoall_perf_mpi
+{{ lib "nccl/nccl-perf-args.yaml" . | indent 12 }}


### PR DESCRIPTION
## Summary

On Forge bare metal with GB200/GB300, NCCL tests aborted during MPI startup. Forge exposes InfiniBand HCAs to pods that never requested an RDMA resource. Open MPI's UCC collective component binds an IB device and aborts in `MPI_Init` (`ucc_core_addr_exchange` → UD endpoint timeout). Disabling UCC alone is insufficient: the UCX PML then binds IB and aborts in the first `MPI_Allgather`. Both collective components and point-to-point / out-of-band transports must be pinned to TCP.

This fix affects only MPI bootstrap — NCCL still carries collectives over NVLink/MNNVL via the ComputeDomain dependency as usual.

**New lib fragments:**
- `forge-mpi-tcp-args.yaml` — `--mca` flags: `coll_ucc_enable=0`, `coll_hcoll_enable=0`, `pml=ob1`, `btl=tcp,self`, `btl_tcp_if_include=eth0`, `oob=tcp`, `oob_tcp_if_include=eth0`
- `forge-mpi-tcp-env.yaml` — belt-and-braces UCX env passed via `-x`: `UCX_TLS=tcp`, `UCX_NET_DEVICES=eth0`

**New override block** appended to `nccl-all-reduce`, `nccl-all-gather`, and `nccl-alltoall`. Ordering is load-bearing: the block must come after the GB200/GB300 ComputeDomain block (so these args win via array replacement) and after the Forge+L40 block (so the L40 IB baseline is not applied to Blackwell). The ComputeDomain dependency from the GB200/GB300 block still applies, preserving MNNVL.

`nccl-loopback` and `nccl-loopback-nvswitch` are intentionally unchanged — single-node, no cross-node MPI bootstrap.

**Integration test** (`certification-forge-gb200-nccl`): two GB200 nodes with `nke.nvidia.com/site-name: ytl` and empty `spec.providerID` to exercise label-based Forge platform detection. Golden file asserts `detectedPlatform: forge`, `detectedGPUArchitecture: gb200`, and the full TCP-pinned MCA arg sequence with `NCCL_MNNVL_ENABLE=1`.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Catalog / Workloads

## Testing
- [x] Tests pass locally (`make test`)
- [ ] Manual testing completed — verified against a real Forge GB200 cluster
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review