### PR TITLE
fix(catalog): pin AWS+GB300 NCCL image tag to explicit version

### DIFF
--- a/pkg/catalog/entries/_lib/deps/aws-gb300-roce-runtime-patch-comm.yaml
+++ b/pkg/catalog/entries/_lib/deps/aws-gb300-roce-runtime-patch-comm.yaml
@@ -19,7 +19,7 @@
                 spec:
                   containers:
                   - name: node
-                    image: public.ecr.aws/hpc-cloud/nccl-tests:latest
+                    image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
                     resources:
                       limits:
                         nvidia.com/gpu: "{{ .GpusPerNode }}"
@@ -46,7 +46,7 @@
                 spec:
                   containers:
                   - name: node
-                    image: public.ecr.aws/hpc-cloud/nccl-tests:latest
+                    image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
             metadata:
               labels:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer

--- a/pkg/catalog/entries/communication/nccl-all-gather.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-gather.yaml
@@ -422,7 +422,7 @@ overrides:
       workload:
         trainJob:
           trainer:
-            image: public.ecr.aws/hpc-cloud/nccl-tests:latest
+            image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
             command:
 {{ lib "nccl/aws-gb300-roce-command.yaml" . | indent 12 }}
             args:

--- a/pkg/catalog/entries/communication/nccl-all-reduce.yaml
+++ b/pkg/catalog/entries/communication/nccl-all-reduce.yaml
@@ -425,7 +425,7 @@ overrides:
       workload:
         trainJob:
           trainer:
-            image: public.ecr.aws/hpc-cloud/nccl-tests:latest
+            image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
             command:
 {{ lib "nccl/aws-gb300-roce-command.yaml" . | indent 12 }}
             args:

--- a/pkg/catalog/entries/communication/nccl-alltoall.yaml
+++ b/pkg/catalog/entries/communication/nccl-alltoall.yaml
@@ -450,7 +450,7 @@ overrides:
       workload:
         trainJob:
           trainer:
-            image: public.ecr.aws/hpc-cloud/nccl-tests:latest
+            image: public.ecr.aws/hpc-cloud/nccl-tests:cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9
             command:
 {{ lib "nccl/aws-gb300-roce-command.yaml" . | indent 12 }}
             args:


### PR DESCRIPTION
## Summary
- Replaces the unpinned `:latest` NCCL image tag with an explicit version (`cuda12.8.1-efa1.43.2-ofiv1.16.3-ncclv2.27.7-1-testsv2.16.9`) across all AWS+GB300 catalog entries
- Affects `aws-gb300-roce-runtime-patch-comm.yaml` and the `nccl-all-reduce`, `nccl-all-gather`, and `nccl-alltoall` communication entries
- Aligns GB300 image pinning with the already-pinned tags used on other AWS paths

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] Catalog entries (`pkg/catalog/entries/`)

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] make manifests generate run (only if *_types.go changed)
- [ ] Golden files updated
- [ ] Documentation updated
- [x] Ready for review