### PR TITLE
fix(catalog): replace DCGM privileged:true with SYS_ADMIN, remove hostNetwork

### DIFF
--- a/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
+++ b/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
@@ -74,6 +74,3 @@ orchestration:
   iterations: 1
 overrides:
 {{ lib "overrides/gb200-topology-key.yaml" . }}
-- when:
-    gpuArchitecture:
-      in: [a100]

--- a/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
+++ b/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
@@ -34,9 +34,8 @@ dependencies:
                       requests:
                         nvidia.com/gpu: "{{ .GpusPerNode }}"
                     securityContext:
-                      privileged: true
-                  dnsPolicy: ClusterFirstWithHostNet
-                  hostNetwork: true
+                      capabilities:
+                        add: [SYS_ADMIN]
                   restartPolicy: Never
                   tolerations:
                   - operator: Exists
@@ -78,27 +77,3 @@ overrides:
 - when:
     gpuArchitecture:
       in: [a100]
-# --- OCI (DGXC / CRI-O) ---
-# CRI-O rejects privileged containers with device plugin GPU injection
-# (device paths already exist on host). Replace privileged with SYS_ADMIN.
-- when:
-    platform:
-      equals: oci
-  dependencies:
-  - apiVersion: trainer.kubeflow.org/v1alpha1
-    kind: TrainingRuntime
-    metadata:
-      name: dcgm-level4-runtime
-    spec:
-      template:
-        spec:
-          replicatedJobs:
-          - name: node
-            template:
-              spec:
-                template:
-                  spec:
-                    containers:
-                    - name: node
-                      securityContext:
-                        privileged: false


### PR DESCRIPTION
## Summary
Replaces the overly broad `privileged: true` security context on DCGM exporter containers with the minimum required capability (`SYS_ADMIN`) and removes `hostNetwork: true`, reducing the attack surface for GPU workload pods.

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] Catalog / workload definitions (`pkg/catalog/`)

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] make manifests generate run (only if *_types.go changed)
- [ ] Golden files updated
- [ ] Documentation updated
- [x] Ready for review