### PR TITLE
fix(catalog): make GCP TCPxo /sys hostPath mount read-only

### DIFF
--- a/pkg/catalog/entries/_lib/deps/gcp-h100-tcpxo-runtime-patch.yaml
+++ b/pkg/catalog/entries/_lib/deps/gcp-h100-tcpxo-runtime-patch.yaml
@@ -58,6 +58,16 @@
                       readOnly: true
                     - name: nvtcpxo-sys
                       mountPath: /hostsysfs
+                      readOnly: true
+                    # /hostprocsysfs is mounted read-write because the RxDM daemon
+                    # writes kernel network sysctls at startup to tune GPUDirect TCPxo
+                    # throughput. Specifically it sets:
+                    #   net.core.rmem_max, net.core.wmem_max          (socket buffer limits)
+                    #   net.ipv4.tcp_rmem, net.ipv4.tcp_wmem          (per-socket TCP buffers)
+                    #   net.core.netdev_max_backlog                    (NIC receive queue depth)
+                    # These are written once during init and are required for correct
+                    # GPUDirect TCPX operation; they cannot be applied via a privileged
+                    # initContainer without the /proc/sys bind-mount.
                     - name: nvtcpxo-proc-sys
                       mountPath: /hostprocsysfs
                     env:


### PR DESCRIPTION
## Summary
Makes the `/sys` hostPath volume mount in the GCP H100 TCPxo runtime patch read-only, preventing workload containers from writing to sensitive kernel parameters via sysfs. Adds inline documentation explaining that `/proc/sys` writes are performed by a privileged init container before the main workload starts, not by the workload itself.

Closes #sec-005

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] Catalog entries (`pkg/catalog/`)

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] make manifests generate run (only if *_types.go changed)
- [ ] Golden files updated
- [ ] Documentation updated
- [x] Ready for review