### PR TITLE
perf: cache CEL ToUnstructured by resource version, use field index

### DIFF
--- a/pkg/controller/failure_log_test.go
+++ b/pkg/controller/failure_log_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
@@ -102,7 +103,18 @@ func TestFailureLogCapture(t *testing.T) {
 		}
 
 		job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+			WithIndex(&corev1.Pod{}, nodemonitor.PodCREJobIndexField, func(obj client.Object) []string {
+				pod, ok := obj.(*corev1.Pod)
+				if !ok {
+					return nil
+				}
+				if jn, found := pod.Labels[nodemonitor.CREJobLabel]; found {
+					return []string{jn}
+				}
+				return nil
+			}).
+			Build()
 		// Clientset is only dereferenced once a failed pod is found, which is
 		// the path these cases do not take.
 		r := &JobReconciler{Client: c, Scheme: scheme, Clientset: &kubernetes.Clientset{}}

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -834,11 +834,11 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 		return
 	}
 
-	// List pods for this Job.
+	// List pods for this Job using the field index for O(1) lookup.
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList,
 		client.InNamespace(job.Namespace),
-		client.MatchingLabels{"cre.nvidia.com/job": job.Name},
+		client.MatchingFields{nodemonitor.PodCREJobIndexField: job.Name},
 	); err != nil {
 		log.V(1).Info("Failed to list pods for failure log capture", "error", err)
 		return

--- a/pkg/nodemonitor/cel/detector.go
+++ b/pkg/nodemonitor/cel/detector.go
@@ -24,11 +24,20 @@ const (
 	reasonCELMatch = "CELExpressionMatched"
 )
 
+// nodeCacheEntry holds a previously converted node map keyed by resource version.
+type nodeCacheEntry struct {
+	resourceVersion string
+	nodeMap         map[string]any
+}
+
 // Detector evaluates CEL expressions against Kubernetes Node objects.
 type Detector struct {
 	expression string
 	program    cel.Program
 	mu         sync.RWMutex
+
+	nodeMapMu    sync.RWMutex
+	nodeMapCache map[string]nodeCacheEntry
 }
 
 // Detector is the reference implementation of NodeFailureDetector. The Job
@@ -137,15 +146,34 @@ func (d *Detector) createCELEnvironment() (*cel.Env, error) {
 // This provides access to the full Node object in CEL expressions.
 // It ensures commonly accessed fields always exist with default values to prevent
 // "no such key" errors in CEL expressions.
+//
+// Results are cached by node UID and resource version so that repeated calls
+// for the same (unchanged) node skip the expensive ToUnstructured conversion.
 func (d *Detector) nodeToMap(node *corev1.Node) (map[string]any, error) {
-	// Use the Kubernetes unstructured converter to get the full object
+	uid := string(node.UID)
+	rv := node.ResourceVersion
+
+	// Fast path: return cached map if the resource version matches.
+	d.nodeMapMu.RLock()
+	entry, ok := d.nodeMapCache[uid]
+	d.nodeMapMu.RUnlock()
+	if ok && entry.resourceVersion == rv {
+		return entry.nodeMap, nil
+	}
+
+	// Slow path: convert and cache.
 	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert node to unstructured: %w", err)
 	}
-
-	// Ensure commonly accessed nested structures exist with defaults
 	d.ensureDefaults(unstructured)
+
+	d.nodeMapMu.Lock()
+	if d.nodeMapCache == nil {
+		d.nodeMapCache = make(map[string]nodeCacheEntry)
+	}
+	d.nodeMapCache[uid] = nodeCacheEntry{resourceVersion: rv, nodeMap: unstructured}
+	d.nodeMapMu.Unlock()
 
 	return unstructured, nil
 }


### PR DESCRIPTION
## Summary

- Cache the CEL detector's `ToUnstructured` conversion keyed by node UID + ResourceVersion so the expensive conversion only runs when a node actually changes, not on every reconcile call
- Switch `captureFailureLog` pod listing from `MatchingLabels` to `MatchingFields` to use the existing informer field index instead of scanning all cached pods

## Type of Change
- [x] Bug fix

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review

Fixes #135
Fixes #136