### PR TITLE
fix(controller): remove annotation branch from nodeHealthChangePredicate

### DIFF
--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -1438,11 +1438,6 @@ func (r *JobReconciler) nodeHealthChangePredicate() predicate.Predicate {
 				return true
 			}
 
-			// Trigger on annotation changes
-			if !mapsEqual(oldNode.Annotations, newNode.Annotations) {
-				return true
-			}
-
 			// Trigger on cordon/uncordon
 			if oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable {
 				return true

--- a/pkg/controller/node_health_predicate_test.go
+++ b/pkg/controller/node_health_predicate_test.go
@@ -4,129 +4,45 @@
 package controller
 
 import (
+	"encoding/json"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
-// makeBaseNode returns a minimal healthy node for predicate tests.
-func makeBaseNode(name string) *corev1.Node {
-	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
-			},
-			Annotations: map[string]string{
-				"node.alpha.kubernetes.io/ttl": "0",
-			},
-		},
-		Spec: corev1.NodeSpec{Unschedulable: false},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{
-				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
-			},
-		},
+// TestNodeHealthChangePredicate verifies that nodeHealthChangePredicate triggers
+// (or suppresses) reconciliation for the correct categories of node changes.
+// Annotation-only updates (e.g. kubelet heartbeats) must NOT trigger reconciles
+// because on large clusters they caused constant reconcile storms (issue #119).
+func TestNodeHealthChangePredicate(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "node-health-predicate",
+		ExpectedSuffix: ".json",
 	}
-}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var oldNode, newNode corev1.Node
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input_old_node.yaml"]), &oldNode); err != nil {
+			return err
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input_new_node.yaml"]), &newNode); err != nil {
+			return err
+		}
 
-// callUpdatePredicate invokes the UpdateFunc of nodeHealthChangePredicate.
-func callUpdatePredicate(t *testing.T, oldNode, newNode *corev1.Node) bool {
-	t.Helper()
-	r := &JobReconciler{}
-	pred := r.nodeHealthChangePredicate()
-	return pred.Update(event.UpdateEvent{
-		ObjectOld: oldNode,
-		ObjectNew: newNode,
+		r := &JobReconciler{}
+		result := r.nodeHealthChangePredicate().Update(event.UpdateEvent{
+			ObjectOld: &oldNode,
+			ObjectNew: &newNode,
+		})
+
+		b, err := json.MarshalIndent(map[string]any{"result": result}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
 	})
-}
-
-// TestNodeHealthPredicateAnnotationOnlyChange asserts that a node update
-// differing only in annotations does NOT trigger a reconcile.
-// Kubelet heartbeat annotations change every ~10 s per node; on large clusters
-// this caused constant reconcile storms on the Job controller (issue #119).
-func TestNodeHealthPredicateAnnotationOnlyChange(t *testing.T) {
-	t.Parallel()
-
-	oldNode := makeBaseNode("node-1")
-	newNode := makeBaseNode("node-1")
-	newNode.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"heartbeat":"updated"}`
-
-	if callUpdatePredicate(t, oldNode, newNode) {
-		t.Fatal("annotation-only node update should NOT trigger reconcile but predicate returned true")
-	}
-}
-
-// TestNodeHealthPredicateConditionChange asserts that a Ready→NotReady
-// status change DOES trigger a reconcile.
-func TestNodeHealthPredicateConditionChange(t *testing.T) {
-	t.Parallel()
-
-	oldNode := makeBaseNode("node-1")
-	newNode := makeBaseNode("node-1")
-	newNode.Status.Conditions[0].Status = corev1.ConditionFalse
-
-	if !callUpdatePredicate(t, oldNode, newNode) {
-		t.Fatal("condition change should trigger reconcile but predicate returned false")
-	}
-}
-
-// TestNodeHealthPredicateTaintChange asserts that adding a taint DOES trigger
-// a reconcile.
-func TestNodeHealthPredicateTaintChange(t *testing.T) {
-	t.Parallel()
-
-	oldNode := makeBaseNode("node-1")
-	newNode := makeBaseNode("node-1")
-	newNode.Spec.Taints = append(newNode.Spec.Taints, corev1.Taint{
-		Key:    "nvidia.com/gpu",
-		Value:  "unhealthy",
-		Effect: corev1.TaintEffectNoSchedule,
-	})
-
-	if !callUpdatePredicate(t, oldNode, newNode) {
-		t.Fatal("taint change should trigger reconcile but predicate returned false")
-	}
-}
-
-// TestNodeHealthPredicateLabelChange asserts that a label change DOES trigger
-// a reconcile (GPUd-style health labels).
-func TestNodeHealthPredicateLabelChange(t *testing.T) {
-	t.Parallel()
-
-	oldNode := makeBaseNode("node-1")
-	newNode := makeBaseNode("node-1")
-	newNode.Labels["nvidia.com/gpu.health"] = "not-ready"
-
-	if !callUpdatePredicate(t, oldNode, newNode) {
-		t.Fatal("label change should trigger reconcile but predicate returned false")
-	}
-}
-
-// TestNodeHealthPredicateCordonChange asserts that cordoning a node DOES
-// trigger a reconcile.
-func TestNodeHealthPredicateCordonChange(t *testing.T) {
-	t.Parallel()
-
-	oldNode := makeBaseNode("node-1")
-	newNode := makeBaseNode("node-1")
-	newNode.Spec.Unschedulable = true
-
-	if !callUpdatePredicate(t, oldNode, newNode) {
-		t.Fatal("cordon change should trigger reconcile but predicate returned false")
-	}
-}
-
-// TestNodeHealthPredicateNoChange asserts that an identical node update does
-// NOT trigger a reconcile.
-func TestNodeHealthPredicateNoChange(t *testing.T) {
-	t.Parallel()
-
-	node := makeBaseNode("node-1")
-
-	if callUpdatePredicate(t, node, node) {
-		t.Fatal("identical node update should NOT trigger reconcile but predicate returned true")
-	}
 }

--- a/pkg/controller/node_health_predicate_test.go
+++ b/pkg/controller/node_health_predicate_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// makeBaseNode returns a minimal healthy node for predicate tests.
+func makeBaseNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
+			},
+			Annotations: map[string]string{
+				"node.alpha.kubernetes.io/ttl": "0",
+			},
+		},
+		Spec: corev1.NodeSpec{Unschedulable: false},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// callUpdatePredicate invokes the UpdateFunc of nodeHealthChangePredicate.
+func callUpdatePredicate(t *testing.T, oldNode, newNode *corev1.Node) bool {
+	t.Helper()
+	r := &JobReconciler{}
+	pred := r.nodeHealthChangePredicate()
+	return pred.Update(event.UpdateEvent{
+		ObjectOld: oldNode,
+		ObjectNew: newNode,
+	})
+}
+
+// TestNodeHealthPredicateAnnotationOnlyChange asserts that a node update
+// differing only in annotations does NOT trigger a reconcile.
+// Kubelet heartbeat annotations change every ~10 s per node; on large clusters
+// this caused constant reconcile storms on the Job controller (issue #119).
+func TestNodeHealthPredicateAnnotationOnlyChange(t *testing.T) {
+	t.Parallel()
+
+	oldNode := makeBaseNode("node-1")
+	newNode := makeBaseNode("node-1")
+	newNode.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"heartbeat":"updated"}`
+
+	if callUpdatePredicate(t, oldNode, newNode) {
+		t.Fatal("annotation-only node update should NOT trigger reconcile but predicate returned true")
+	}
+}
+
+// TestNodeHealthPredicateConditionChange asserts that a Ready→NotReady
+// status change DOES trigger a reconcile.
+func TestNodeHealthPredicateConditionChange(t *testing.T) {
+	t.Parallel()
+
+	oldNode := makeBaseNode("node-1")
+	newNode := makeBaseNode("node-1")
+	newNode.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	if !callUpdatePredicate(t, oldNode, newNode) {
+		t.Fatal("condition change should trigger reconcile but predicate returned false")
+	}
+}
+
+// TestNodeHealthPredicateTaintChange asserts that adding a taint DOES trigger
+// a reconcile.
+func TestNodeHealthPredicateTaintChange(t *testing.T) {
+	t.Parallel()
+
+	oldNode := makeBaseNode("node-1")
+	newNode := makeBaseNode("node-1")
+	newNode.Spec.Taints = append(newNode.Spec.Taints, corev1.Taint{
+		Key:    "nvidia.com/gpu",
+		Value:  "unhealthy",
+		Effect: corev1.TaintEffectNoSchedule,
+	})
+
+	if !callUpdatePredicate(t, oldNode, newNode) {
+		t.Fatal("taint change should trigger reconcile but predicate returned false")
+	}
+}
+
+// TestNodeHealthPredicateLabelChange asserts that a label change DOES trigger
+// a reconcile (GPUd-style health labels).
+func TestNodeHealthPredicateLabelChange(t *testing.T) {
+	t.Parallel()
+
+	oldNode := makeBaseNode("node-1")
+	newNode := makeBaseNode("node-1")
+	newNode.Labels["nvidia.com/gpu.health"] = "not-ready"
+
+	if !callUpdatePredicate(t, oldNode, newNode) {
+		t.Fatal("label change should trigger reconcile but predicate returned false")
+	}
+}
+
+// TestNodeHealthPredicateCordonChange asserts that cordoning a node DOES
+// trigger a reconcile.
+func TestNodeHealthPredicateCordonChange(t *testing.T) {
+	t.Parallel()
+
+	oldNode := makeBaseNode("node-1")
+	newNode := makeBaseNode("node-1")
+	newNode.Spec.Unschedulable = true
+
+	if !callUpdatePredicate(t, oldNode, newNode) {
+		t.Fatal("cordon change should trigger reconcile but predicate returned false")
+	}
+}
+
+// TestNodeHealthPredicateNoChange asserts that an identical node update does
+// NOT trigger a reconcile.
+func TestNodeHealthPredicateNoChange(t *testing.T) {
+	t.Parallel()
+
+	node := makeBaseNode("node-1")
+
+	if callUpdatePredicate(t, node, node) {
+		t.Fatal("identical node update should NOT trigger reconcile but predicate returned true")
+	}
+}

--- a/pkg/controller/testdata/node-health-predicate/annotation-only-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/annotation-only-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": false
+}

--- a/pkg/controller/testdata/node-health-predicate/annotation-only-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/annotation-only-change/input_new_node.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kubectl.kubernetes.io/last-applied-configuration: '{"heartbeat":"updated"}'
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/annotation-only-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/annotation-only-change/input_old_node.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/condition-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/condition-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": true
+}

--- a/pkg/controller/testdata/node-health-predicate/condition-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/condition-change/input_new_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "False"

--- a/pkg/controller/testdata/node-health-predicate/condition-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/condition-change/input_old_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/cordon-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/cordon-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": true
+}

--- a/pkg/controller/testdata/node-health-predicate/cordon-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/cordon-change/input_new_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: true
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/cordon-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/cordon-change/input_old_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/label-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/label-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": true
+}

--- a/pkg/controller/testdata/node-health-predicate/label-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/label-change/input_new_node.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+    nvidia.com/gpu.health: not-ready
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/label-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/label-change/input_old_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/no-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/no-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": false
+}

--- a/pkg/controller/testdata/node-health-predicate/no-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/no-change/input_new_node.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/no-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/no-change/input_old_node.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/taint-change/expected.json
+++ b/pkg/controller/testdata/node-health-predicate/taint-change/expected.json
@@ -1,0 +1,3 @@
+{
+  "result": true
+}

--- a/pkg/controller/testdata/node-health-predicate/taint-change/input_new_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/taint-change/input_new_node.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+  taints:
+    - key: nvidia.com/gpu
+      value: unhealthy
+      effect: NoSchedule
+status:
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/controller/testdata/node-health-predicate/taint-change/input_old_node.yaml
+++ b/pkg/controller/testdata/node-health-predicate/taint-change/input_old_node.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+spec:
+  unschedulable: false
+status:
+  conditions:
+    - type: Ready
+      status: "True"


### PR DESCRIPTION
## Summary

Kubelet heartbeat annotations update every ~10s per node. On large clusters this caused constant reconcile storms on the Job controller. This PR removes the annotation branch from `nodeHealthChangePredicate` so that annotation-only node updates no longer trigger unnecessary reconciles.

## Type of Change
- [x] Bug fix

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review

Fixes #119