### PR TITLE
fix(catalog): H200 gpu-defaults, nemotron5-56b alloc, dcgm timeouts

### DIFF
--- a/cmd/integration/testdata/reconcile/certification-aws-a100-dcgm/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-aws-a100-dcgm/expected.json
@@ -138,7 +138,9 @@
             "nvidia.com/gpu.product": "NVIDIA-A100-SXM4-40GB"
           }
         },
-        "execution": {},
+        "execution": {
+          "timeoutPerJob": "1h0m0s"
+        },
         "iterations": 1
       },
       "dependencies": [

--- a/cmd/integration/testdata/reconcile/certification-aws-gb200-n5/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-aws-gb200-n5/expected.json
@@ -391,6 +391,10 @@
                                     "value": "1"
                                   },
                                   {
+                                    "name": "PYTORCH_CUDA_ALLOC_CONF",
+                                    "value": "expandable_segments:True"
+                                  },
+                                  {
                                     "name": "UCX_MEM_MMAP_HOOK_MODE",
                                     "value": "none"
                                   },

--- a/cmd/integration/testdata/reconcile/certification-aws-h100-n5/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-aws-h100-n5/expected.json
@@ -388,6 +388,10 @@
                                     "value": "1"
                                   },
                                   {
+                                    "name": "PYTORCH_CUDA_ALLOC_CONF",
+                                    "value": "expandable_segments:True"
+                                  },
+                                  {
                                     "name": "UCX_MEM_MMAP_HOOK_MODE",
                                     "value": "none"
                                   },

--- a/cmd/integration/testdata/reconcile/certification-gcp-gb200-n5/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-gcp-gb200-n5/expected.json
@@ -393,6 +393,10 @@
                                     "value": "1"
                                   },
                                   {
+                                    "name": "PYTORCH_CUDA_ALLOC_CONF",
+                                    "value": "expandable_segments:True"
+                                  },
+                                  {
                                     "name": "UCX_MEM_MMAP_HOOK_MODE",
                                     "value": "none"
                                   },

--- a/cmd/integration/testdata/reconcile/certification-gcp-h100-n5/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-gcp-h100-n5/expected.json
@@ -629,6 +629,10 @@
                                     "value": "1"
                                   },
                                   {
+                                    "name": "PYTORCH_CUDA_ALLOC_CONF",
+                                    "value": "expandable_segments:True"
+                                  },
+                                  {
                                     "name": "UCX_MEM_MMAP_HOOK_MODE",
                                     "value": "none"
                                   },

--- a/cmd/integration/testdata/reconcile/certification-oci-dcgm/expected.json
+++ b/cmd/integration/testdata/reconcile/certification-oci-dcgm/expected.json
@@ -138,7 +138,9 @@
             "nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"
           }
         },
-        "execution": {},
+        "execution": {
+          "timeoutPerJob": "1h0m0s"
+        },
         "iterations": 1
       },
       "dependencies": [

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -207,12 +206,11 @@ func newRootCommand() *cobra.Command {
 				return fmt.Errorf("unable to create controller GoodputMeasurement: %w", err)
 			}
 			if err := (&controller.BandwidthMeasurementReconciler{
-				Client:          mgr.GetClient(),
-				APIReader:       mgr.GetAPIReader(),
-				Scheme:          mgr.GetScheme(),
-				Clientset:       clientset,
-				LogFetcher:      podlogs.NewKubernetesLogFetcher(clientset),
-				RequeueInterval: time.Second,
+				Client:     mgr.GetClient(),
+				APIReader:  mgr.GetAPIReader(),
+				Scheme:     mgr.GetScheme(),
+				Clientset:  clientset,
+				LogFetcher: podlogs.NewKubernetesLogFetcher(clientset),
 			}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("unable to create controller BandwidthMeasurement: %w", err)
 			}

--- a/pkg/catalog/entries/_lib/gpu-defaults.yaml
+++ b/pkg/catalog/entries/_lib/gpu-defaults.yaml
@@ -32,6 +32,9 @@ defaults:
   b200:
     gpusPerNode: 8
     mlnxPerNode: 8
+  h200:
+    gpusPerNode: 8
+    mlnxPerNode: 8
   gb200:
     gpusPerNode: 4
     mlnxPerNode: 8

--- a/pkg/catalog/entries/communication/nccl-loopback-nvswitch.yaml
+++ b/pkg/catalog/entries/communication/nccl-loopback-nvswitch.yaml
@@ -98,7 +98,14 @@ jobTemplate:
           numNodes: 1
           numProcPerNode: 1
 orchestration:
-  execution: {}
+{{- if gt .MaxConcurrent 0 }}
+  execution:
+    maxConcurrent: {{ .MaxConcurrent }}
+    timeoutPerJob: {{ .TimeoutPerJob }}
+{{- else }}
+  execution:
+    timeoutPerJob: {{ .TimeoutPerJob }}
+{{- end }}
   iterations: 1
 {{- if .Thresholds }}
 validation:

--- a/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
+++ b/pkg/catalog/entries/diagnostics/dcgm-level4.yaml
@@ -71,7 +71,14 @@ jobTemplate:
           numNodes: 1
           numProcPerNode: 1
 orchestration:
-  execution: {}
+{{- if gt .MaxConcurrent 0 }}
+  execution:
+    maxConcurrent: {{ .MaxConcurrent }}
+    timeoutPerJob: {{ .TimeoutPerJob }}
+{{- else }}
+  execution:
+    timeoutPerJob: {{ .TimeoutPerJob }}
+{{- end }}
   iterations: 1
 overrides:
 {{ lib "overrides/gb200-topology-key.yaml" . }}

--- a/pkg/catalog/entries/training/nemotron5-56b.yaml
+++ b/pkg/catalog/entries/training/nemotron5-56b.yaml
@@ -127,6 +127,8 @@ dependencies:
                       value: "1"
                     - name: TORCH_NCCL_HIGH_PRIORITY
                       value: "1"
+                    - name: PYTORCH_CUDA_ALLOC_CONF
+                      value: "expandable_segments:True"
 {{ lib "nccl/gb200-training-ucx-env.yaml" . | indent 20 }}
                     - name: EXIT_DURATION_MINS
                       value: "{{ .ExitDurationMins }}"

--- a/pkg/controller/bandwidthmeasurement_controller.go
+++ b/pkg/controller/bandwidthmeasurement_controller.go
@@ -29,6 +29,8 @@ import (
 )
 
 const (
+	defaultBandwidthMeasurementRequeueInterval = 15 * time.Second
+
 	bandwidthMeasurementFinalizer = "cre.nvidia.com/bandwidthmeasurement-finalizer"
 
 	reasonBandwidthJobRunning   = "JobRunning"
@@ -99,6 +101,14 @@ func (r *BandwidthMeasurementReconciler) getSampleInterval(m *burninv1alpha1.Ban
 	return defaultSampleInterval
 }
 
+// getRequeueInterval returns the configured requeue interval or the default.
+func (r *BandwidthMeasurementReconciler) getRequeueInterval() time.Duration {
+	if r.RequeueInterval > 0 {
+		return r.RequeueInterval
+	}
+	return defaultBandwidthMeasurementRequeueInterval
+}
+
 // +kubebuilder:rbac:groups=cre.nvidia.com,resources=bandwidthmeasurements,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cre.nvidia.com,resources=bandwidthmeasurements/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cre.nvidia.com,resources=bandwidthmeasurements/finalizers,verbs=update
@@ -149,7 +159,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 	if err := r.Get(ctx, jobKey, job); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Referenced Job not found, requeueing", "job", jobKey)
-			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get referenced Job: %w", err)
 	}
@@ -178,7 +188,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 	}
 
 	// Job hasn't started yet.
-	return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+	return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 }
 
 func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement, job *burninv1alpha1.Job) (ctrl.Result, error) {
@@ -217,19 +227,19 @@ func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, meas
 	}
 	if workloadName == "" {
 		log.Info("Job has no workloadRef yet, requeueing")
-		return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+		return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 	}
 
 	discoverer := podutil.NewWorkerDiscoverer(r.podReader())
 	pod, err := discoverer.GetReplicatedJobPod(ctx, measurement.Namespace, workloadName, replicatedJobName)
 	if err != nil {
 		log.Info("Pod not found yet, requeueing", "replicatedJob", replicatedJobName, "error", err)
-		return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+		return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 	}
 
 	if !podutil.IsPodRunning(pod) && pod.Status.Phase != corev1.PodSucceeded {
 		log.Info("Pod not running yet, requeueing", "pod", pod.Name, "phase", pod.Status.Phase)
-		return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+		return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 	}
 
 	// Skip reading logs if the container is currently in a waiting state


### PR DESCRIPTION
## Summary

- Add H200 GPU entry to `gpu-defaults.yaml` (8 GPUs/node, MNNVL disabled)
- Add `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` to `nemotron5-56b` training env to reduce OOM risk on memory-constrained nodes
- Add `timeoutPerJob` to `dcgm-level4` and `nccl-loopback-nvswitch` catalog entries so stuck tests cannot hold GPUs indefinitely
- Fix `BandwidthMeasurementReconciler` `RequeueInterval` from `time.Second` to the standard 15s used by all other reconcilers

## Type of Change
- [x] Bug fix

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [x] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review

Fixes #131
Fixes #132
Fixes #134
Fixes #139