### PR TITLE
build: upgrade Go 1.26.5 → 1.26.6 (GO-2026-5026)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Base images are pinned by digest so a rebuild uses the same bits every time.
 # The tag is kept for readability; the digest is what resolves. Dependabot
 # raises the digest on its weekly docker run.
-FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
+FROM golang:1.26.6@sha256:640a234f4bea3e399c056b7b8f9c667c4939befae8db2f14e9785e16eccd4205 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/cluster-readiness-engine
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11


### PR DESCRIPTION
## Summary

- Bump Go toolchain from 1.26.5 to 1.26.6 in `go.mod` and pin the builder image digest in `Dockerfile`
- Fixes govulncheck CI failure caused by GO-2026-5026 (`net/http` vulnerability)
- All CI workflows already use `go-version-file: go.mod` so no workflow changes needed

## Type of Change
- [ ] Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI

## Testing
- [x] Tests pass locally
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review