### PR TITLE
docs: clarify certification prerequisites and update rc.8 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ A Certification creates one Workflow per catalog category. Each Workflow creates
 
 ## Quickstart
 
+For complete prerequisites, installation, a first run, and cleanup, see
+[Your first certification](docs/getting-started/first-certification.md).
+
 **0. Check the cluster**
 
-CRE needs the NVIDIA GPU Operator. The `diagnostics/dcgm-level4` category also
-needs the standalone DCGM service, which the GPU Operator creates only when
-`spec.dcgm.enabled` is true. That setting is off by default when the operator
-runs its own embedded DCGM for metrics. Your cluster administrator can turn it
-on:
+CRE requires the NVIDIA GPU Operator and, with the default metrics settings,
+the Prometheus Operator CRDs that serve `monitoring.coreos.com/v1`; GB200 and
+GB300 catalog entries also require the NVIDIA DRA driver for `ComputeDomain`
+resources. The `diagnostics/dcgm-level4` category additionally requires the
+standalone DCGM service, which the GPU Operator creates only when
+`spec.dcgm.enabled` is true. Because the operator normally uses embedded DCGM
+for metrics, standalone DCGM is off by default; enable it with:
 
 ```bash
 kubectl patch clusterpolicy cluster-policy --type=merge \
@@ -59,7 +64,7 @@ Every release so far is a pre-release, and `releases/latest` resolves only to th
 newest **stable** release. Until `v0.1.0` is tagged, name the version explicitly:
 
 ```bash
-CRE_VERSION=v0.1.0-rc.7
+CRE_VERSION=v0.1.0-rc.8
 curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
   | bash -s -- -v "${CRE_VERSION}"
 ```
@@ -139,7 +144,7 @@ Helm, or need to pin the controller image in your own manifests, both are
 published to the GitHub Container Registry on every release.
 
 ```bash
-CRE_VERSION=v0.1.0-rc.7
+CRE_VERSION=v0.1.0-rc.8
 
 # Inspect the chart before installing it
 helm show chart oci://ghcr.io/nvidia/cluster-readiness-engine --version "$CRE_VERSION"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ check that you received what we published.
 ## Versioning
 
 CRE follows [Semantic Versioning](https://semver.org/). Tags are `vMAJOR.MINOR.PATCH`,
-optionally with a pre-release suffix, for example `v0.1.0` or `v0.1.0-rc.7`.
+optionally with a pre-release suffix, for example `v0.1.0` or `v0.1.0-rc.8`.
 
 The project is at `v0.x`. Under SemVer that means the public surface can still change in
 a minor release. Treat CRD schemas, the `ncrectl` command line, and Helm values as

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -30,7 +30,7 @@ Cordoned nodes are skipped. If a node is cordoned, CRE does not select it, and i
 Every release so far is a pre-release, and `releases/latest` resolves only to the newest **stable** release, so that URL cannot be fetched yet. Name the version explicitly instead:
 
 ```bash
-CRE_VERSION=v0.1.0-rc.7
+CRE_VERSION=v0.1.0-rc.8
 curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
   | bash -s -- -v "${CRE_VERSION}"
 ```

--- a/installer
+++ b/installer
@@ -40,7 +40,7 @@ Usage: $0 [-d install_dir] [-p] [-v version]
 Options:
   -d DIR    Installation directory (default: /usr/local/bin)
   -p        Include pre-release versions
-  -v TAG    Install this exact release tag (e.g. v0.1.0-rc.7)
+  -v TAG    Install this exact release tag (e.g. v0.1.0-rc.8)
 EOF
   exit 1
 }


### PR DESCRIPTION
## Summary

- Link the first-certification guide from the README quickstart.
- Document the GPU Operator, Prometheus Operator CRDs, NVIDIA DRA driver, and standalone DCGM prerequisites.
- Update current installation examples from `v0.1.0-rc.7` to `v0.1.0-rc.8`.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected

- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [x] CLI (ncrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing

- [x] `git diff --check`
- [x] Documentation and installer usage changes manually reviewed
- [x] No breaking changes

Full runtime tests were not run because this PR changes documentation and installer help text only.

## Risk Assessment

Low. Runtime behavior is unchanged, and the changes are limited to prerequisite guidance, links, and release-version examples.

## Checklist

- [x] Self-review completed
- [x] `make manifests generate` not required; no API types changed
- [x] Golden files not required; integration output is unchanged
- [x] Documentation updated
- [x] Ready for review