### PR TITLE
fix(podlogs): bound pod log stream duration

### DIFF
--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor/cel"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
 )
@@ -920,7 +921,8 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 		Container: failedContainer.Name,
 		TailLines: &tailLines,
 	}
-	stream, err := r.Clientset.CoreV1().Pods(failedPod.Namespace).GetLogs(failedPod.Name, logOpts).Stream(ctx)
+	req := r.Clientset.CoreV1().Pods(failedPod.Namespace).GetLogs(failedPod.Name, logOpts)
+	stream, err := podlogs.OpenStream(ctx, req)
 	if err != nil {
 		log.V(1).Info("Failed to stream pod logs for failure capture", "pod", failedPod.Name, "error", err)
 		job.Status.FailureLog = fl

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/orchestration"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
 )
@@ -2118,7 +2119,8 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 		Container: containerName,
 		TailLines: &tailLines,
 	}
-	stream, err := r.Clientset.CoreV1().Pods(targetPod.Namespace).GetLogs(targetPod.Name, logOpts).Stream(ctx)
+	req := r.Clientset.CoreV1().Pods(targetPod.Namespace).GetLogs(targetPod.Name, logOpts)
+	stream, err := podlogs.OpenStream(ctx, req)
 	if err != nil {
 		log.V(1).Info("Failed to stream pod logs for timeout capture", "pod", targetPod.Name, "error", err)
 		job.Status.FailureLog = &burninv1alpha1.FailureLog{

--- a/pkg/podlogs/fetcher.go
+++ b/pkg/podlogs/fetcher.go
@@ -69,9 +69,10 @@ func (f *kubernetesLogFetcher) FetchLogs(ctx context.Context, namespace, podName
 	return ScanLines(io.LimitReader(stream, limit))
 }
 
-// OpenStream opens a pod log request with DefaultStreamTimeout. The returned
-// stream keeps the timeout active until it is closed, so stalled response-body
-// reads are bounded as well as the initial request.
+// OpenStream opens a pod log request bounded by DefaultStreamTimeout or the
+// parent context's deadline, whichever is earlier. The returned stream keeps
+// that deadline active until it is closed, so stalled response-body reads are
+// bounded as well as the initial request.
 func OpenStream(ctx context.Context, req *rest.Request) (io.ReadCloser, error) {
 	return openStreamWithTimeout(ctx, req, DefaultStreamTimeout)
 }

--- a/pkg/podlogs/fetcher.go
+++ b/pkg/podlogs/fetcher.go
@@ -9,11 +9,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
+
+// DefaultStreamTimeout bounds the complete lifecycle of a pod log request,
+// including opening the stream and consuming its response body.
+const DefaultStreamTimeout = 2 * time.Minute
 
 // PodLogFetcher abstracts fetching raw log lines from a pod.
 type PodLogFetcher interface {
@@ -52,7 +58,7 @@ func (f *kubernetesLogFetcher) FetchLogs(ctx context.Context, namespace, podName
 	podLogOpts.LimitBytes = &limit
 
 	req := f.clientset.CoreV1().Pods(namespace).GetLogs(podName, podLogOpts)
-	stream, err := req.Stream(ctx)
+	stream, err := OpenStream(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("opening log stream: %w", err)
 	}
@@ -61,6 +67,37 @@ func (f *kubernetesLogFetcher) FetchLogs(ctx context.Context, namespace, podName
 	// LimitBytes is enforced by the API server, but a misbehaving or proxied
 	// endpoint could ignore it — bound the client side too.
 	return ScanLines(io.LimitReader(stream, limit))
+}
+
+// OpenStream opens a pod log request with DefaultStreamTimeout. The returned
+// stream keeps the timeout active until it is closed, so stalled response-body
+// reads are bounded as well as the initial request.
+func OpenStream(ctx context.Context, req *rest.Request) (io.ReadCloser, error) {
+	return openStreamWithTimeout(ctx, req, DefaultStreamTimeout)
+}
+
+func openStreamWithTimeout(ctx context.Context, req *rest.Request, timeout time.Duration) (io.ReadCloser, error) {
+	streamCtx, cancel := context.WithTimeout(ctx, timeout)
+	stream, err := req.Stream(streamCtx)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &cancelReadCloser{
+		ReadCloser: stream,
+		cancel:     cancel,
+	}, nil
+}
+
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (r *cancelReadCloser) Close() error {
+	r.cancel()
+	return r.ReadCloser.Close()
 }
 
 // DefaultMaxLogBytes caps a single log fetch at 8 MB. Sized well above a normal

--- a/pkg/podlogs/fetcher_test.go
+++ b/pkg/podlogs/fetcher_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podlogs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenStreamTimesOutBeforeResponseHeaders(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+
+	req := newPodLogRequest(t, transport)
+	stream, err := openStreamWithTimeout(context.Background(), req, 50*time.Millisecond)
+
+	require.Nil(t, stream)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestOpenStreamTimesOutWhileReadingResponseBody(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: &contextBlockingBody{
+				ctx:    req.Context(),
+				reader: strings.NewReader("complete line\n"),
+			},
+			Request: req,
+		}, nil
+	})
+
+	req := newPodLogRequest(t, transport)
+	stream, err := openStreamWithTimeout(context.Background(), req, 50*time.Millisecond)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+	lines, err := ScanLines(stream)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, []string{"complete line"}, lines)
+}
+
+func TestOpenStreamHonorsEarlierParentDeadline(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+
+	req := newPodLogRequest(t, transport)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	t.Cleanup(cancel)
+
+	stream, err := openStreamWithTimeout(ctx, req, time.Minute)
+
+	require.Nil(t, stream)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestOpenStreamUsesDefaultTimeoutAndCancelsOnClose(t *testing.T) {
+	requestContexts := make(chan context.Context, 1)
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requestContexts <- req.Context()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	})
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host:      "http://pod-logs.test",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+
+	started := time.Now()
+	stream, err := OpenStream(context.Background(), clientset.CoreV1().Pods("default").GetLogs("worker-0", &corev1.PodLogOptions{}))
+	require.NoError(t, err)
+
+	requestCtx := <-requestContexts
+	deadline, ok := requestCtx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, started.Add(DefaultStreamTimeout), deadline, time.Second)
+
+	require.NoError(t, stream.Close())
+	select {
+	case <-requestCtx.Done():
+		assert.ErrorIs(t, requestCtx.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("request context was not cancelled when the stream closed")
+	}
+}
+
+func newPodLogRequest(t *testing.T, transport http.RoundTripper) *rest.Request {
+	t.Helper()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host:      "http://pod-logs.test",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	return clientset.CoreV1().Pods("default").GetLogs("worker-0", &corev1.PodLogOptions{})
+}
+
+type contextBlockingBody struct {
+	ctx    context.Context
+	reader *strings.Reader
+}
+
+func (b *contextBlockingBody) Read(buffer []byte) (int, error) {
+	n, err := b.reader.Read(buffer)
+	if n > 0 || err != io.EOF {
+		return n, err
+	}
+
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (*contextBlockingBody) Close() error {
+	return nil
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/podlogs/fetcher_test.go
+++ b/pkg/podlogs/fetcher_test.go
@@ -5,77 +5,150 @@ package podlogs
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
-func TestOpenStreamTimesOutBeforeResponseHeaders(t *testing.T) {
-	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		<-req.Context().Done()
-		return nil, req.Context().Err()
-	})
-
-	req := newPodLogRequest(t, transport)
-	stream, err := openStreamWithTimeout(context.Background(), req, 50*time.Millisecond)
-
-	require.Nil(t, stream)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
+type openStreamInput struct {
+	Stall         string `yaml:"stall"`
+	StreamTimeout string `yaml:"streamTimeout"`
+	ParentTimeout any    `yaml:"parentTimeout"`
+	Body          string `yaml:"body"`
 }
 
-func TestOpenStreamTimesOutWhileReadingResponseBody(t *testing.T) {
-	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     make(http.Header),
-			Body: &contextBlockingBody{
-				ctx:    req.Context(),
-				reader: strings.NewReader("complete line\n"),
-			},
-			Request: req,
-		}, nil
-	})
-
-	req := newPodLogRequest(t, transport)
-	stream, err := openStreamWithTimeout(context.Background(), req, 50*time.Millisecond)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stream.Close()) })
-
-	lines, err := ScanLines(stream)
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, []string{"complete line"}, lines)
+type openStreamResult struct {
+	Lines               *[]string `json:"lines,omitempty"`
+	ErrorKind           string    `json:"errorKind,omitempty"`
+	StreamOpened        *bool     `json:"streamOpened,omitempty"`
+	ElapsedUnder        string    `json:"elapsedUnder,omitempty"`
+	DeadlineFromDefault *bool     `json:"deadlineFromDefault,omitempty"`
+	CancelledOnClose    *bool     `json:"cancelledOnClose,omitempty"`
 }
 
-func TestOpenStreamHonorsEarlierParentDeadline(t *testing.T) {
-	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		<-req.Context().Done()
-		return nil, req.Context().Err()
+func TestOpenStream(t *testing.T) {
+	p := &testutil.TestCaseParser{
+		Subdir:         "open-stream",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in openStreamInput
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		var got openStreamResult
+		var err error
+		switch in.Stall {
+		case "none":
+			got, err = runDefaultTimeoutCase(in)
+		case "headers", "body":
+			got, err = runStallCase(tc.T, in)
+		default:
+			return fmt.Errorf("unknown stall %q", in.Stall)
+		}
+		if err != nil {
+			return err
+		}
+
+		b, marshalErr := json.MarshalIndent(got, "", "  ")
+		if marshalErr != nil {
+			return marshalErr
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
 	})
-
-	req := newPodLogRequest(t, transport)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	t.Cleanup(cancel)
-
-	stream, err := openStreamWithTimeout(ctx, req, time.Minute)
-
-	require.Nil(t, stream)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
-func TestOpenStreamUsesDefaultTimeoutAndCancelsOnClose(t *testing.T) {
+func runStallCase(t testing.TB, in openStreamInput) (openStreamResult, error) {
+	streamTimeout, err := time.ParseDuration(in.StreamTimeout)
+	if err != nil {
+		return openStreamResult{}, fmt.Errorf("streamTimeout: %w", err)
+	}
+
+	ctx := context.Background()
+	parentTimeout, hasParent, err := parseParentTimeout(in.ParentTimeout)
+	if err != nil {
+		return openStreamResult{}, err
+	}
+	if hasParent {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, parentTimeout)
+		defer cancel()
+	}
+
+	body := in.Body
+	if body == "" {
+		body = "complete line\n"
+	}
+
+	var transport http.RoundTripper
+	switch in.Stall {
+	case "headers":
+		transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+	case "body":
+		transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: &contextBlockingBody{
+					ctx:    req.Context(),
+					reader: strings.NewReader(body),
+				},
+				Request: req,
+			}, nil
+		})
+	}
+
+	started := time.Now()
+	stream, err := openStreamWithTimeout(ctx, newPodLogRequest(t, transport), streamTimeout)
+	elapsed := time.Since(started)
+
+	lines := []string{}
+	opened := false
+	got := openStreamResult{
+		Lines:        &lines,
+		StreamOpened: &opened,
+	}
+	if err != nil {
+		got.ErrorKind = errorKind(err)
+	} else {
+		opened = true
+		defer stream.Close() //nolint:errcheck
+		scanned, scanErr := ScanLines(stream)
+		if scanned != nil {
+			lines = scanned
+			got.Lines = &lines
+		}
+		got.ErrorKind = errorKind(scanErr)
+	}
+	if hasParent && elapsed < time.Second {
+		got.ElapsedUnder = "1s"
+	}
+	return got, nil
+}
+
+func runDefaultTimeoutCase(in openStreamInput) (openStreamResult, error) {
+	if in.StreamTimeout != "default" {
+		return openStreamResult{}, fmt.Errorf("streamTimeout: want default, got %q", in.StreamTimeout)
+	}
+
 	requestContexts := make(chan context.Context, 1)
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		requestContexts <- req.Context()
@@ -90,27 +163,90 @@ func TestOpenStreamUsesDefaultTimeoutAndCancelsOnClose(t *testing.T) {
 		Host:      "http://pod-logs.test",
 		Transport: transport,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return openStreamResult{}, err
+	}
 
 	started := time.Now()
 	stream, err := OpenStream(context.Background(), clientset.CoreV1().Pods("default").GetLogs("worker-0", &corev1.PodLogOptions{}))
-	require.NoError(t, err)
+	if err != nil {
+		return openStreamResult{}, err
+	}
 
 	requestCtx := <-requestContexts
 	deadline, ok := requestCtx.Deadline()
-	require.True(t, ok)
-	assert.WithinDuration(t, started.Add(DefaultStreamTimeout), deadline, time.Second)
+	fromDefault := ok && deadline.Sub(started).Abs() <= DefaultStreamTimeout+time.Second &&
+		started.Add(DefaultStreamTimeout).Sub(deadline).Abs() <= time.Second
 
-	require.NoError(t, stream.Close())
+	closeErr := stream.Close()
+	if closeErr != nil {
+		return openStreamResult{}, closeErr
+	}
+
+	cancelled := false
 	select {
 	case <-requestCtx.Done():
-		assert.ErrorIs(t, requestCtx.Err(), context.Canceled)
+		cancelled = errors.Is(requestCtx.Err(), context.Canceled)
 	case <-time.After(time.Second):
-		t.Fatal("request context was not cancelled when the stream closed")
+	}
+
+	return openStreamResult{
+		DeadlineFromDefault: &fromDefault,
+		CancelledOnClose:    &cancelled,
+	}, nil
+}
+
+func parseParentTimeout(v any) (time.Duration, bool, error) {
+	if v == nil {
+		return 0, false, nil
+	}
+	switch x := v.(type) {
+	case string:
+		if x == "" || x == "0" {
+			return 0, false, nil
+		}
+		d, err := time.ParseDuration(x)
+		if err != nil {
+			return 0, false, fmt.Errorf("parentTimeout: %w", err)
+		}
+		if d == 0 {
+			return 0, false, nil
+		}
+		return d, true, nil
+	case int:
+		if x == 0 {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("parentTimeout: unsupported int %d", x)
+	case int64:
+		if x == 0 {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("parentTimeout: unsupported int %d", x)
+	case float64:
+		if x == 0 {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("parentTimeout: unsupported number %v", x)
+	default:
+		return 0, false, fmt.Errorf("parentTimeout: unsupported type %T", v)
 	}
 }
 
-func newPodLogRequest(t *testing.T, transport http.RoundTripper) *rest.Request {
+func errorKind(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.DeadlineExceeded):
+		return "DeadlineExceeded"
+	case errors.Is(err, context.Canceled):
+		return "Canceled"
+	default:
+		return err.Error()
+	}
+}
+
+func newPodLogRequest(t testing.TB, transport http.RoundTripper) *rest.Request {
 	t.Helper()
 
 	clientset, err := kubernetes.NewForConfig(&rest.Config{

--- a/pkg/podlogs/testdata/open-stream/default-timeout-cancel-on-close/expected.json
+++ b/pkg/podlogs/testdata/open-stream/default-timeout-cancel-on-close/expected.json
@@ -1,0 +1,4 @@
+{
+  "deadlineFromDefault": true,
+  "cancelledOnClose": true
+}

--- a/pkg/podlogs/testdata/open-stream/default-timeout-cancel-on-close/input.yaml
+++ b/pkg/podlogs/testdata/open-stream/default-timeout-cancel-on-close/input.yaml
@@ -1,0 +1,4 @@
+# Successful empty body. Pins DefaultStreamTimeout on the request context and
+# that Close cancels it.
+stall: none
+streamTimeout: default

--- a/pkg/podlogs/testdata/open-stream/parent-deadline-earlier/expected.json
+++ b/pkg/podlogs/testdata/open-stream/parent-deadline-earlier/expected.json
@@ -1,0 +1,6 @@
+{
+  "lines": [],
+  "errorKind": "DeadlineExceeded",
+  "streamOpened": false,
+  "elapsedUnder": "1s"
+}

--- a/pkg/podlogs/testdata/open-stream/parent-deadline-earlier/input.yaml
+++ b/pkg/podlogs/testdata/open-stream/parent-deadline-earlier/input.yaml
@@ -1,0 +1,5 @@
+# Parent context expires first. elapsedUnder asserts the 50ms parent deadline
+# fired rather than the 1m stream timeout — both errors are DeadlineExceeded.
+stall: headers
+parentTimeout: 50ms
+streamTimeout: 1m

--- a/pkg/podlogs/testdata/open-stream/stall-before-headers/expected.json
+++ b/pkg/podlogs/testdata/open-stream/stall-before-headers/expected.json
@@ -1,0 +1,5 @@
+{
+  "lines": [],
+  "errorKind": "DeadlineExceeded",
+  "streamOpened": false
+}

--- a/pkg/podlogs/testdata/open-stream/stall-before-headers/input.yaml
+++ b/pkg/podlogs/testdata/open-stream/stall-before-headers/input.yaml
@@ -1,0 +1,5 @@
+# Stall before the response headers arrive. The stream timeout is the deadline
+# that fires.
+stall: headers
+parentTimeout: 0
+streamTimeout: 50ms

--- a/pkg/podlogs/testdata/open-stream/stall-reading-body/expected.json
+++ b/pkg/podlogs/testdata/open-stream/stall-reading-body/expected.json
@@ -1,0 +1,7 @@
+{
+  "lines": [
+    "complete line"
+  ],
+  "errorKind": "DeadlineExceeded",
+  "streamOpened": true
+}

--- a/pkg/podlogs/testdata/open-stream/stall-reading-body/input.yaml
+++ b/pkg/podlogs/testdata/open-stream/stall-reading-body/input.yaml
@@ -1,0 +1,7 @@
+# Headers succeed; the body then blocks until the stream timeout fires.
+# ScanLines keeps the line that arrived before the stall.
+stall: body
+parentTimeout: 0
+streamTimeout: 50ms
+body: |
+  complete line


### PR DESCRIPTION
## Summary

- Bound the complete lifecycle of pod log requests to two minutes, covering both stream creation and response-body reads.
- Reuse the bounded stream helper for measurement collection, Job failure-log capture, and Workflow timeout-log capture.
- Add regression tests for header stalls, body-read stalls, earlier parent deadlines, the default timeout, and cancellation on close.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected

- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI
- [x] Other: Pod log fetching

## Testing

- [x] `make manifests generate`
- [x] `make lint-fix`
- [x] `make build`
- [x] `make test`
- [x] Post-rebase `go test ./pkg/podlogs ./pkg/controller`
- [x] No breaking changes

## Risk Assessment

Low. A stalled log request can still occupy a reconcile worker for up to two minutes, but it can no longer block indefinitely. Measurement fetch errors skip the current sample without advancing the log-fetch anchor, so the next sample retries the window subject to the existing maximum-lookback clamp.

## Checklist

- [x] Self-review completed
- [x] `make manifests generate` run
- [x] Golden files not required; integration output is unchanged
- [x] Documentation updates not required; no API or user-facing configuration changed
- [x] Ready for review

Fixes #137
