### PR TITLE
fix: remove affinity so that controller deploys on GPU only clusters

### DIFF
--- a/helm/cluster-readiness-engine/values.yaml
+++ b/helm/cluster-readiness-engine/values.yaml
@@ -19,13 +19,7 @@ manager:
     requests:
       cpu: 10m
       memory: 1Gi
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: nvidia.com/gpu.present
-                operator: DoesNotExist
+  affinity: {}
   tolerations:
     - operator: Exists
   terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Summary

Remove affinity to allow deploying on controller on GPU only clusters like in the case of edge deployments.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [X] Helm / Deployment
- [ ] Documentation / CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] `make manifests generate` run (if `*_types.go` was modified)
- [X] Golden files updated (if integration test output changed)
- [X] Documentation updated (if needed)
- [X] Ready for review
