### PR TITLE
docs: fix TMF-reported doc/code drift, add WorkloadRun quickstarts, operations section, and gangScheduler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ kubectl ncre certification report <name> -n <namespace>
 Helm, or need to pin the controller image in your own manifests, both are
 published to the GitHub Container Registry on every release.
 
+While this repository is internal, Helm needs to authenticate to the registry
+before it can pull the chart:
+
+```bash
+gh auth token | helm registry login ghcr.io \
+  --username "$(gh api user --jq .login)" --password-stdin
+```
+
 ```bash
 CRE_VERSION=v0.1.0-rc.8
 
@@ -180,12 +188,16 @@ spec:
   framework:
     mpi:
       binary: /usr/local/bin/all_reduce_perf_mpi
-      mpirunPath: /usr/local/bin/mpirun
+      mpirunPath: /usr/local/mpi/bin/mpirun
       args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
   bandwidthMeasurement:
     logProfileRef: nccl-bandwidth
     testType: all_reduce
 ```
+
+`numNodes` is the node count **per job group**, not the total: CRE partitions all
+eligible nodes into groups of this size and runs one job per group, so
+`numNodes: 4` on a 16-node cluster produces four 4-node jobs.
 
 ```bash
 kubectl ncre workloadrun run nccl-all-reduce.yaml --wait

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ Pin an explicit version rather than installing whatever is newest. Chart and
 image versions move together, so the two commands above and your own manifests
 should all name the same tag.
 
-## Run a training workload
+## Run a workload
 
-WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Write a YAML file with an image, a framework, and a node count. CRE detects the platform and GPU architecture.
+WorkloadRun is a simplified API for running training, NCCL, or custom workloads. Write a YAML file with an image, a framework, and a node count. CRE detects the platform and GPU architecture. The quickest example is an NCCL bandwidth check:
 
 ```yaml
 # nccl-all-reduce.yaml
@@ -202,6 +202,10 @@ eligible nodes into groups of this size and runs one job per group, so
 ```bash
 kubectl ncre workloadrun run nccl-all-reduce.yaml --wait
 ```
+
+For the full NCCL benchmark suite, see [Run NCCL Benchmarks](docs/how-to-guides/nccl-benchmarks.md).
+For training workloads, see the [Nemotron 5](docs/how-to-guides/workloadrun-nemotron5.md) and
+[DeepSeek-V3](docs/how-to-guides/workloadrun-deepseek-v3.md) quickstarts.
 
 ## Scope and non-goals
 

--- a/docs/api-reference/validation-results.md
+++ b/docs/api-reference/validation-results.md
@@ -1,0 +1,642 @@
+---
+title: Validation Results
+description: Cluster certification results across validated platform and GPU combinations, and the machine-readable results format.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+The Cluster Readiness Engine (CRE) has been validated on the following platform and GPU combinations. Each certification ran NCCL communication tests (all-reduce, all-gather, alltoall) and NeMo training. GB200/GB300 configurations include both MNNVL-enabled and MNNVL-disabled variants.
+
+## Summary
+
+| Platform | GPU   | Nodes | Interconnect | Categories | Result   |
+|----------|-------|-------|--------------|------------|----------|
+| AWS      | H100  | 2     | EFA          | 4/4        | PASSED   |
+| AWS      | GB200 | 4     | EFA          | 8/8        | PASSED   |
+| AWS      | GB300 | 8     | RoCE         | 8/8        | PASSED   |
+| GCP      | H100  | 2     | TCPXO        | 4/4        | PASSED   |
+| GCP      | GB200 | 2     | RoCE         | 8/8        | PASSED   |
+
+Catalog variant names evolve between releases. The training entry used during these validation runs (`training/nemotron4-15b`) has since been superseded — the current catalog offers `training/nemotron5-8b` and `training/nemotron5-56b`. List the categories available in your installed version with `ncrectl certification list-categories`.
+
+## Detailed Reports
+
+### AWS H100
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      Certification Report                      ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      gpu-cluster-cert
+  Platform:  aws
+  GPU:       h100
+  Nodes:     2
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  11m 0s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      260.20 GB/s  487.87 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  7m 5s                                              │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      361.14 GB/s  338.57 GB/s  67                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  22m 10s                                            │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      84.40 GB/s   79.11 GB/s   66                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  4m 49s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Avg Runtime Goodput:  0.90 (90%)                              │
+│  Avg TFLOPs/GPU:  539.8                                        │
+│  Avg Train Time:  3m 40s                                       │
+│  Avg Step Time:  2.85s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   4/4 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### AWS GB200
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      Certification Report                      ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      gpu-cluster-cert
+  Platform:  aws
+  GPU:       gb200
+  Nodes:     4
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  6m 47s                                             │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      470.68 GB/s  882.51 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  4m 3s                                              │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      649.90 GB/s  609.28 GB/s  67                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  5m 12s                                             │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      606.58 GB/s  568.66 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  20m 20s                                            │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      102.08 GB/s  191.40 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  10m 23s                                            │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      204.01 GB/s  191.26 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  28m 31s                                            │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      62.02 GB/s   58.15 GB/s   63                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 43s                                             │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Avg Runtime Goodput:  0.68 (68%)                              │
+│  Avg TFLOPs/GPU:  1186.5                                       │
+│  Avg Train Time:  2m 38s                                       │
+│  Avg Step Time:  1.30s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 49s                                             │
+│  Nodes/Job: 4                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Avg Runtime Goodput:  0.66 (66%)                              │
+│  Avg TFLOPs/GPU:  1118.5                                       │
+│  Avg Train Time:  3m 10s                                       │
+│  Avg Step Time:  1.38s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   8/8 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### AWS GB300
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      Certification Report                      ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      gpu-cluster-cert
+  Platform:  aws
+  GPU:       gb300
+  Nodes:     8
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  7m 32s                                             │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      476.55 GB/s  923.32 GB/s  67                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  5m 3s                                              │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      721.28 GB/s  698.74 GB/s  69                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  6m 40s                                             │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      700.45 GB/s  678.57 GB/s  68                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  13m 39s                                            │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      194.07 GB/s  376.01 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  6m 19s                                             │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      377.48 GB/s  365.68 GB/s  63                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  24m 26s                                            │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      88.38 GB/s   85.62 GB/s   68                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 49s                                             │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Avg Runtime Goodput:  0.57 (57%)                              │
+│  Avg TFLOPs/GPU:  1388.5                                       │
+│  Avg Train Time:  3m 26s                                       │
+│  Avg Step Time:  1.11s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 54s                                             │
+│  Nodes/Job: 8                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Avg Runtime Goodput:  0.57 (57%)                              │
+│  Avg TFLOPs/GPU:  1136.9                                       │
+│  Avg Train Time:  3m 26s                                       │
+│  Avg Step Time:  1.40s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   8/8 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### GCP H100
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      Certification Report                      ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      gpu-cluster-cert
+  Platform:  gcp
+  GPU:       h100
+  Nodes:     2
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  13m 38s                                            │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      179.78 GB/s  337.09 GB/s  67                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  11m 19s                                            │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      201.88 GB/s  189.27 GB/s  66                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  40m 40s                                            │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      42.84 GB/s   40.16 GB/s   66                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  4m 37s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│                                                                │
+│  Avg Runtime Goodput:  0.92 (92%)                              │
+│  Avg TFLOPs/GPU:  511.7                                        │
+│  Avg Train Time:  3m 33s                                       │
+│  Avg Step Time:  3.01s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   4/4 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### GCP GB200
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      Certification Report                      ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      gpu-cluster-cert
+  Platform:  gcp
+  GPU:       gb200
+  Nodes:     2
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  6m 25s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      478.90 GB/s  838.07 GB/s  64                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  2m 56s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      777.35 GB/s  680.18 GB/s  58                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 7s                                              │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      781.51 GB/s  683.82 GB/s  67                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-reduce                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  6m 50s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      478.72 GB/s  837.76 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-all-gather                                 │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 24s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      777.33 GB/s  680.16 GB/s  58                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  communication/nccl-alltoall                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  3m 8s                                              │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Bandwidth:                                                    │
+│    Size       AlgBW        BusBW        Samples                │
+│    16 GB      781.54 GB/s  683.84 GB/s  65                     │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  5m 40s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Enabled                                            │
+│                                                                │
+│  Avg Runtime Goodput:  0.68 (68%)                              │
+│  Avg TFLOPs/GPU:  1175.0                                       │
+│  Avg Train Time:  2m 16s                                       │
+│  Avg Step Time:  1.31s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  training/nemotron4-15b                                        │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Duration:  2m 44s                                             │
+│  Nodes/Job: 2                                                  │
+│  Jobs:      1                                                  │
+│  MNNVL:     Disabled                                           │
+│                                                                │
+│  Avg Runtime Goodput:  0.69 (69%)                              │
+│  Avg TFLOPs/GPU:  1122.0                                       │
+│  Avg Train Time:  2m 21s                                       │
+│  Avg Step Time:  1.37s                                         │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   8/8 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Machine-readable results
+
+`ncrectl certification run --wait --results-file <path>` and `ncrectl certification report <name> --results-file <path>` write the same report as JSON. The file contains a single report object (or an array when multiple certifications are combined into one report):
+
+```json
+{
+  "name": "gpu-cluster-cert",
+  "platform": "aws",
+  "gpu": "gb200",
+  "totalNodes": 4,
+  "categories": [
+    {
+      "domain": "communication",
+      "variant": "nccl-all-reduce",
+      "status": "Succeeded",
+      "runtime": "6m 47s",
+      "nodesPerJob": 4,
+      "jobs": 1,
+      "mnnvl": "Enabled",
+      "bandwidth": [
+        { "size": "16 GB", "algBW": "470.68 GB/s", "busBW": "882.51 GB/s", "samples": 65 }
+      ]
+    }
+  ],
+  "failedNodes": [],
+  "result": "PASSED"
+}
+```
+
+Top-level fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Certification name |
+| `platform` | string | Detected platform (`aws`, `gcp`, `azure`, `oci`, `onprem`, ...) |
+| `gpu` | string | Detected GPU architecture |
+| `totalNodes` | int | Number of nodes targeted by the certification |
+| `excludedNodes` | []string | Nodes that matched the target but were left untested (omitted when empty) |
+| `exclusionReason` | string | Why nodes were excluded (omitted when empty) |
+| `categories` | []object | Per-category results (see below) |
+| `failedNodes` | []string | Deduped union of failed node names across all categories |
+| `result` | string | `PASSED`, `INCOMPLETE`, `FAILED`, or `RUNNING` |
+| `nodeResults` | []object | Per-node pass/fail entries: `name`, `group`, `rack` (optional), `status` (`Passed` or `Failed`) |
+
+Each entry in `categories`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `domain` / `variant` | string | Catalog category, e.g. `communication` / `nccl-all-reduce` |
+| `status` | string | Category status (`Succeeded`, `Failed`, ...) |
+| `failureReason` | string | Populated from the Workflow `Failed` condition message (omitted when empty) |
+| `runtime` | string | Total runtime across all iterations |
+| `testScale` | string | Test scale, when set |
+| `nodesPerJob` | int | Nodes per job group |
+| `jobs` | int | Number of jobs run |
+| `mnnvl` | string | `Enabled`, `Disabled`, or omitted when unknown |
+| `bandwidth` | []object | NCCL results per message size: `size`, `algBW`, `busBW`, `samples` |
+| `domains` | []object | Training results per topology domain: `name`, `nodeCount`, `goodput`, `tflops`, `stepTime` |
+| `failedGroups` | []object | Failed orchestration groups: `name`, `nodeCount`, `nodes`, `reason` |
+| `iterations` | []object | Per-iteration results: `number`, `status`, `duration` |
+
+## See also
+
+- [Certification API](./certification.md) — the resource these reports are generated from
+- [Interpret Results](../how-to-guides/interpret-results.md) — how to read a certification report

--- a/docs/api-reference/workloadrun.md
+++ b/docs/api-reference/workloadrun.md
@@ -21,8 +21,11 @@ spec:
     mpi:
       binary: /usr/local/bin/all_reduce_perf_mpi
       args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
-      mpirunPath: /usr/local/bin/mpirun
-  numNodes: 4
+      mpirunPath: /usr/local/mpi/bin/mpirun
+  numNodes: 4   # nodes per job group; all eligible nodes are partitioned into 4-node jobs
+  gangScheduler:
+    schedulerName: kai-scheduler
+    queue: high-priority
   target:
     nodeSelector:
       nvidia.com/gpu.present: "true"
@@ -35,7 +38,15 @@ spec:
 
 ## Spec fields
 
-_Generated from CRD schema — coming soon._
+_Generated from CRD schema — coming soon. Fields documented so far:_
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gangScheduler` | GangSchedulerSpec | Optional. Opts workload pods into a gang-aware scheduler such as KAI Scheduler. When set, the scheduler name is injected as `schedulerName` into every workload pod template (for MPI, both launcher and worker pods) and the queue is applied as the `kai.scheduler/queue` label on the pod template metadata, so the scheduler holds all pods until the entire gang can be placed |
+| `gangScheduler.schedulerName` | string | Required; minimum length 1. Name of the gang-aware scheduler to use (e.g., `kai-scheduler`). Injected as `schedulerName` in each workload pod spec |
+| `gangScheduler.queue` | string | Optional. Scheduler queue to submit the workload to; defaults to `default-queue` when unset. When non-empty, must be a valid Kubernetes label value: at most 63 characters, beginning and ending with an alphanumeric character, and containing only alphanumerics, hyphens, underscores, or dots (pattern `^$\|^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`) |
+
+`numNodes` (shown in the example above) is the number of nodes **per job group**, not a total: the orchestrator partitions all eligible nodes into groups of that size.
 
 ## Status fields
 

--- a/docs/designs/034-inferred-dependency-lifecycle.md
+++ b/docs/designs/034-inferred-dependency-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-034: Eliminate LifecycleSpec — Infer Dependency Scope and Ordering from References
 
-> **Supersedes:** [ADR-011](011-workflow-dependency-lifecycle.md) (Workflow Dependency Lifecycle Management)
+> **Supersedes:** ADR-011 (internal; predates the public repository) (Workflow Dependency Lifecycle Management)
 
 ## Context
 
@@ -105,6 +105,6 @@ Remove all `lifecycle` blocks from catalog YAML entries. The inference engine de
 
 ## References
 
-- [ADR-011](011-workflow-dependency-lifecycle.md) — original dependency lifecycle design (superseded)
+- ADR-011 (internal; predates the public repository) — original dependency lifecycle design (superseded)
 - `api/v1alpha1/workflow_types.go` — DependencySpec type changes
 - `pkg/controller/workflow_deps.go` — classification, ordering, and cross-ref detection

--- a/docs/designs/053-ordered-dependency-deletion.md
+++ b/docs/designs/053-ordered-dependency-deletion.md
@@ -100,7 +100,7 @@ Remove `cleanupDependencies()` from `setFinalStatus()` entirely. **Rejected:** D
 ## References
 
 - [ADR-034](034-inferred-dependency-lifecycle.md) — Inferred dependency scope and topological ordering
-- [ADR-011](011-workflow-dependency-lifecycle.md) — Original dependency lifecycle design (superseded by ADR-034)
+- ADR-011 (internal; predates the public repository) — Original dependency lifecycle design (superseded by ADR-034)
 - `pkg/controller/workflow_deps.go` — `orderDependencies()`, `classifyDependencies()`, `cleanupScopedDependencies()`
 - `pkg/controller/workflow_controller.go` — `handleDeletion()`, `setFinalStatus()`, `cleanupDependencies()`
 - `pkg/controller/job_controller.go` — `handleDeletion()` (Job-level workload cleanup)

--- a/docs/designs/058-mistral-gb300-ib-support.md
+++ b/docs/designs/058-mistral-gb300-ib-support.md
@@ -59,7 +59,7 @@ No existing platform override targets Mistral, and no catalog path emits `rdma/i
 
 ## Notes
 
-- Per-pod `rdma/ib` count, Nemotron6 dep parity with [`gb300-roce-nemo6.yaml`](../../pkg/catalog/entries/_lib/deps/gb300-roce-nemo6.yaml), and whether the `dcgm-level4` diagnostics entry needs a mistral-specific override are finalized during implementation; the plan enumerates them as open sub-questions.
+- Per-pod `rdma/ib` count, Nemotron6 dep parity with [`gb300-roce-torch.yaml`](../../pkg/catalog/entries/_lib/deps/gb300-roce-torch.yaml), and whether the `dcgm-level4` diagnostics entry needs a mistral-specific override are finalized during implementation; the plan enumerates them as open sub-questions.
 - `GpusPerNode` default for GB300 is handled by [`pkg/gpu/`](../../pkg/gpu/) defaults. The example node reports `nvidia.com/gpu.count: 4`; we confirm this matches the catalog default before committing.
 
 ## References

--- a/docs/designs/060-azure-h100-nccl-support.md
+++ b/docs/designs/060-azure-h100-nccl-support.md
@@ -43,7 +43,7 @@ The same gap exists across all three multi-node NCCL variants (`nccl-all-reduce`
 
 - **Override ordering becomes load-bearing for Azure H100.** A future edit that reorders the Azure (non-A100) block after the H100 block would zero out the H100 args (because the non-A100 block carries a shorter args list). Mitigation: integration golden file `certification-azure-h100-nccl/expected.json` will fail on regression.
 - **Other Azure non-A100, non-H100 GPUs (H200, B200) keep the four-var minimum.** Acceptable — adding tuning for those SKUs is a future ADR with its own field validation.
-- **Same args duplicated across the catalog files.** Could be hoisted into a shared `_lib/nccl/azure-h100-mpiargs.yaml` later (matches the [`nccl/togetherai-ib-mpiargs.yaml`](../../pkg/catalog/entries/_lib/nccl/togetherai-ib-mpiargs.yaml) precedent), but doing so now would entangle ADR-060 with the unrelated decision of when to extract a lib. Leave inline for now; promote to lib in a follow-up if another variant lands.
+- **Same args duplicated across the catalog files.** Could be hoisted into a shared `_lib/nccl/azure-h100-mpiargs.yaml` later (matches the [`nccl/togetherai-ib-env.yaml`](../../pkg/catalog/entries/_lib/nccl/togetherai-ib-env.yaml) precedent), but doing so now would entangle ADR-060 with the unrelated decision of when to extract a lib. Leave inline for now; promote to lib in a follow-up if another variant lands.
 
 ## Alternatives Considered
 

--- a/docs/designs/061-cre-nvsentinel-remediation-decoupling.md
+++ b/docs/designs/061-cre-nvsentinel-remediation-decoupling.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-CRE historically created a Remediation CR when a Certification failed, and a Remediation controller applied taints, cordons, and node conditions to failed nodes ([ADR-006](006-remediation-lifecycle.md)).
+CRE historically created a Remediation CR when a Certification failed, and a Remediation controller applied taints, cordons, and node conditions to failed nodes (ADR-006 (internal; predates the public repository)).
 
 This approach has several problems:
 
@@ -263,4 +263,4 @@ A terminal failed Certification (`conditions` has `type=Failed, status=True`) wi
 
 ## References
 
-- [ADR-006: Remediation Lifecycle](006-remediation-lifecycle.md) — original design (superseded by this ADR)
+- ADR-006: Remediation Lifecycle (internal; predates the public repository) — original design (superseded by this ADR)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -68,7 +68,7 @@ Read the relevant record before you change the behaviour it describes. `CLAUDE.m
 | 058 | [Mistral GB300 SKU Support (InfiniBand)](058-mistral-gb300-ib-support.md) |
 | 059 | [WorkloadRun — Simplified Workload Execution API](059-workloadrun-simplified-api.md) |
 | 060 | [Azure H100 Multi-Node NCCL Support](060-azure-h100-nccl-support.md) |
-| 061 | [Remove Remediation Controller — Failed Node Attribution via Certification CR](061-excalibur-nvsentinel-remediation-decoupling.md) |
+| 061 | [Remove Remediation Controller — Failed Node Attribution via Certification CR](061-cre-nvsentinel-remediation-decoupling.md) |
 | 062 | [Succeeded Node Attribution via a Compressed ConfigMap](062-node-detail-propagation.md) |
 | 063 | [Auto-Inject Tolerations from `target.taintSelectors`](063-taint-selector-tolerations.md) |
 | 064 | [Helm Chart Distribution](064-helm-chart-distribution.md) |

--- a/docs/getting-started/workloadrun-quick-start.md
+++ b/docs/getting-started/workloadrun-quick-start.md
@@ -27,7 +27,7 @@ spec:
     mpi:
       binary: /usr/local/bin/all_reduce_perf_mpi
       args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
-      mpirunPath: /usr/local/bin/mpirun
+      mpirunPath: /usr/local/mpi/bin/mpirun
   numNodes: 4
   bandwidthMeasurement:
     logProfileRef: nccl-bandwidth

--- a/docs/how-to-guides/nccl-benchmarks.md
+++ b/docs/how-to-guides/nccl-benchmarks.md
@@ -34,7 +34,7 @@ spec:
     mpi:
       binary: /usr/local/bin/all_reduce_perf_mpi
       args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
-      mpirunPath: /usr/local/bin/mpirun
+      mpirunPath: /usr/local/mpi/bin/mpirun
   numNodes: 4
   bandwidthMeasurement:
     logProfileRef: nccl-bandwidth

--- a/docs/how-to-guides/run-workloadrun.md
+++ b/docs/how-to-guides/run-workloadrun.md
@@ -25,6 +25,8 @@ spec:
   numNodes: 4
 ```
 
+`numNodes` is the number of nodes **per job group**, not a total: the orchestrator partitions all eligible nodes into groups of that size. For example, `numNodes: 4` on 16 eligible nodes produces four 4-node jobs.
+
 ```bash
 ncrectl workloadrun run \
   --workload-registry nvcr.io \
@@ -58,6 +60,37 @@ spec:
   goodputMeasurement:
     logProfileRef: megatron-training
 ```
+
+## Gang scheduling
+
+Distributed workloads can deadlock under the default scheduler when only some of their pods fit on the cluster: the placed pods hold GPUs while waiting for peers that never arrive. Set `spec.gangScheduler` to opt every workload pod into a gang-aware scheduler, such as KAI Scheduler, which holds all pods until the entire gang can be placed at once.
+
+```yaml
+apiVersion: cre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: gang-scheduled-workload
+spec:
+  image: nvcr.io/nvidia/pytorch:26.01-py3
+  framework:
+    mpi:
+      mpirunPath: /usr/local/mpi/bin/mpirun
+      binary: /usr/local/bin/all_reduce_perf_mpi
+      args: ["-b", "8", "-e", "32G", "-f", "2", "-n", "100"]
+  numNodes: 4          # nodes per job group; all eligible nodes are partitioned into 4-node jobs
+  gangScheduler:
+    schedulerName: kai-scheduler   # required
+    queue: high-priority           # optional; defaults to "default-queue"
+```
+
+`schedulerName` is required. `queue` is optional and defaults to `default-queue`; when set, it must be a valid Kubernetes label value (at most 63 characters, beginning and ending with an alphanumeric character, containing only alphanumerics, hyphens, underscores, or dots).
+
+When `gangScheduler` is set, CRE modifies every pod template generated for the workload — for MPI frameworks that includes both the launcher and the worker pods:
+
+- The configured scheduler name is injected as `schedulerName` in each pod spec, so the pods bypass the default scheduler.
+- The queue is applied as the `kai.scheduler/queue` label on the pod template metadata, so a gang-aware scheduler can hold all pods in the gang until they can be placed together.
+
+See [API Reference: WorkloadRun](../api-reference/workloadrun.md) for validation details.
 
 ## View results
 

--- a/docs/how-to-guides/workloadrun-deepseek-v3.md
+++ b/docs/how-to-guides/workloadrun-deepseek-v3.md
@@ -1,0 +1,333 @@
+---
+title: Run DeepSeek-V3 Training with WorkloadRun
+description: End-to-end guide to running DeepSeek-V3 BF16 training with Megatron-Bridge and WorkloadRun, including a developer-overridable branch checkout.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+This guide walks through running DeepSeek-V3 BF16 training on a GPU cluster with Cluster Readiness Engine (CRE), using Megatron-Bridge and WorkloadRun. Unlike the [Nemotron 5 guide](./workloadrun-nemotron5.md), which uses raw Megatron-LM, this example uses Megatron-Bridge's recipe system *and* demonstrates the developer-friendly pattern of overriding the container's `scripts/performance/` with a cloned branch checkout — so developers can iterate on their own `run_script.py` / `utils/overrides.py` without rebuilding the image.
+
+For an introduction to WorkloadRun and when to use it instead of a full Certification, see the [WorkloadRun Quick Start](../getting-started/workloadrun-quick-start.md). For generic WorkloadRun options (targeting nodes, measurements, framework types), see [Run a WorkloadRun](./run-workloadrun.md).
+
+## Prerequisites
+
+- A Kubernetes cluster with GPU nodes (`nvidia.com/gpu.present=true`) and `kubectl` access
+- `ncrectl` installed and the CRE controller running on the cluster — see [Installation](../getting-started/install.md)
+- An NGC API key for pulling the NeMo container image from `nvcr.io`
+- The DeepSeek-V3 recipe fetches the model configuration from Hugging Face Hub at startup, so worker pods need outbound access to `huggingface.co` (or a pre-populated Hugging Face cache mounted into the pods — see the env var comments below)
+
+No dataset or checkpoint download is required: the recipe trains on synthetic data, and this guide runs a proxy-size model.
+
+## Megatron-LM vs Megatron-Bridge
+
+| | Megatron-LM ([Nemotron 5 guide](./workloadrun-nemotron5.md)) | Megatron-Bridge (this guide) |
+|---|---|---|
+| **Config style** | All args spelled out in `train.sh` | Recipe name + Hydra overrides |
+| **Container** | `pytorch:25.08-py3` + clone Megatron-LM | `nemo:26.02.00` (Megatron-Bridge pre-installed at `/opt/Megatron-Bridge`) |
+| **Entry point** | `torchrun pretrain_gpt.py --num-layers 79 ...` | `torchrun run_script.py -m deepseek -s v3 ...` |
+| **Init container** | Clone Megatron-LM from GitHub | Clone Megatron-Bridge from GitHub (`llmb-r0.2.0` branch) |
+| **What gets overridden** | The whole `megatron-lm` package | Only `scripts/performance/` — bridge package + megatron-core come from the container |
+| **Log profile** | `megatron-training` | `megatron-bridge` |
+
+## Create the WorkloadRun manifest
+
+Save the following as `deepseek-v3-bf16.yaml`:
+
+```yaml
+apiVersion: cre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: deepseek-v3-bf16
+  namespace: default
+spec:
+  # The NeMo 26.02.00 image has Megatron-Bridge + Megatron-Core +
+  # DeepEP + matching transformers/flashinfer/etc. all pre-installed at
+  # /opt/Megatron-Bridge. Nothing needs pip install at runtime.
+  image: nvcr.io/nvidia/nemo:26.02.00
+  framework:
+    exec:
+      command: ["/bin/bash", "/config/train.sh"]
+  numNodes: 16
+  config:
+    inline:
+      train.sh: |
+        #!/bin/bash
+        set -e
+
+        BRIDGE_PATH=/mnt/workspace/megatron-bridge
+        # Prepend the cloned scripts/performance/ to PYTHONPATH so a
+        # developer's branch overrides win for runner code, while the
+        # bridge package + megatron-core continue to come from the
+        # container's /opt/Megatron-Bridge.
+        export PYTHONPATH=${BRIDGE_PATH}/scripts/performance:$PYTHONPATH
+
+        exec torchrun \
+          --nnodes $PET_NNODES \
+          --nproc-per-node $PET_NPROC_PER_NODE \
+          ${BRIDGE_PATH}/scripts/performance/run_script.py \
+          -a dummy -p dummy \
+          -m deepseek -s v3 \
+          -c bf16 \
+          -g gb300 \
+          -ng $((PET_NNODES * PET_NPROC_PER_NODE)) \
+          -gn $PET_NPROC_PER_NODE \
+          -ms 50 \
+          -mb 1 -pp 1 -ep 64 \
+          --no-detach \
+          model.hidden_size=1024 \
+          model.kv_channels=64 \
+          model.pipeline_model_parallel_layout=null \
+          model.virtual_pipeline_model_parallel_size=null \
+          logger.log_throughput=true \
+          train.manual_gc=true \
+          train.manual_gc_interval=100
+  initContainers:
+    - name: megatron-bridge-clone
+      image: nvcr.io/nvidia/nemo:26.02.00
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -ex
+          git clone --depth 1 -b llmb-r0.2.0 \
+            https://github.com/NVIDIA-NeMo/Megatron-Bridge.git \
+            /mnt/workspace/megatron-bridge
+      volumeMounts:
+        - name: workspace
+          mountPath: /mnt/workspace
+  volumes:
+    - name: workspace
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - name: workspace
+      mountPath: /mnt/workspace
+  env:
+    # NCCL / torch.distributed tuning recommended for this model.
+    - name: TORCH_NCCL_AVOID_RECORD_STREAMS
+      value: "1"
+    - name: TORCH_NCCL_HIGH_PRIORITY
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    - name: NCCL_NET_GDR_LEVEL
+      value: PHB
+    - name: NCCL_NET_GDR_C2C
+      value: "1"
+    # MNNVL / NVLink topology hints
+    - name: NVLINK_DOMAIN_SIZE
+      value: "72"
+    - name: USE_MNNVL
+      value: "1"
+    - name: NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN
+      value: "64"
+    # CUDA + transformer-engine tuning
+    - name: CUDA_DEVICE_MAX_CONNECTIONS
+      value: "32"
+    - name: NVTE_FWD_LAYERNORM_SM_MARGIN
+      value: "20"
+    - name: NVTE_BWD_LAYERNORM_SM_MARGIN
+      value: "20"
+    # HuggingFace: the DeepSeek-V3 recipe needs to fetch the model
+    # config to introspect architecture. Leave these at "0" so HF Hub
+    # downloads succeed (mount an HF cache instead if your cluster is
+    # air-gapped).
+    - name: TRANSFORMERS_OFFLINE
+      value: "0"
+    - name: HF_HUB_OFFLINE
+      value: "0"
+    - name: TOKENIZERS_PARALLELISM
+      value: "False"
+    # UCX env vars to avoid memory hook conflicts in the container
+    - name: UCX_MEM_MMAP_HOOK_MODE
+      value: none
+    - name: UCX_MEM_CUDA_HOOK_MODE
+      value: none
+    - name: UCX_MEM_MALLOC_HOOKS
+      value: "n"
+    - name: UCX_ERROR_SIGNALS
+      value: ""
+  resources:
+    limits:
+      nvidia.com/gpu: "4"
+      memory: 800Gi
+      cpu: "128"
+    requests:
+      nvidia.com/gpu: "4"
+      memory: 500Gi
+      cpu: "64"
+  goodputMeasurement:
+    logProfileRef: megatron-bridge
+    sampleInterval: 10s
+```
+
+### How the branch override works
+
+The pattern in this YAML is the developer-iteration pattern for Megatron-Bridge:
+
+1. **Container ships everything heavy.** `nvcr.io/nvidia/nemo:26.02.00` already has `megatron-bridge`, `megatron-core` (with FSDP), `transformers`, `flashinfer`, `DeepEP`, and matching CUDA/NCCL — all version-pinned to work together. No `pip install` at runtime.
+2. **Init container clones a branch** of `https://github.com/NVIDIA-NeMo/Megatron-Bridge` into a shared `emptyDir` volume. Only `scripts/performance/` matters here — it's where `run_script.py`, `utils/overrides.py`, and the recipe configs live.
+3. **`train.sh` prepends the cloned `scripts/performance/` to `PYTHONPATH`** and invokes the cloned `run_script.py` by absolute path. Result:
+   - `from utils.overrides import …` resolves to the developer's branch (override wins).
+   - `from megatron.bridge import …` and `from megatron.core import …` resolve to the container's pre-installed packages (stable, version-matched).
+4. **No image rebuild required.** A developer commits to their branch on GitHub, points the init container's `git clone -b ...` at it, and re-submits the WorkloadRun. Iteration takes seconds (small clone) instead of minutes (image build/push).
+
+Branch choice matters: pick a branch whose script + bridge API expectations match what the container ships. `llmb-r0.2.0` works against `nemo:26.02.00`. A branch that depends on a newer bridge API will fail at import time — pick a different branch or use a newer NeMo image.
+
+### Key configuration
+
+- **`numNodes: 16`** — the number of nodes **per job group**, not a total. The orchestrator partitions **all** eligible GPU nodes into groups of this size and creates one job per group: `numNodes: 16` on a 16-node cluster creates a single 16-node job, while `numNodes: 4` on the same cluster would create four 4-node jobs that run in parallel. Set it to your full cluster size for a single full-scale run.
+- **`-m deepseek -s v3`** — selects the DeepSeek-V3 architecture.
+- **`-c bf16`** — BF16 precision (FP8 paths in this branch require a newer bridge than `nemo:26.02.00` ships).
+- **`-g gb300`** — GPU-specific tuning hints. Also accepts `gb200`, `b200`, or `h100` — match your cluster.
+- **`-a dummy -p dummy --no-detach`** — `run_script.py` in this branch was written as a SLURM job submitter; `--no-detach` makes it run in-process under `torchrun`. The `-a`/`-p` flags are required by argparse but unused when not actually submitting via SLURM.
+- **`-ng / -gn`** — `-ng` is `numNodes × gpusPerNode`; `-gn` matches `gpusPerNode`. The `PET_NNODES` and `PET_NPROC_PER_NODE` environment variables are injected into worker pods automatically.
+- **`-pp 1 -ep 64`** — pipeline parallelism off, 64-way expert parallelism. Works for the proxy-size model below; for the full model use `-pp 4 -ep 64 -vp 4` at 256+ GPUs. The product `ep × tp × pp` must divide the world size; with `-pp 1` and no tensor parallelism, `-ep` can equal the world size.
+- **`model.hidden_size=1024 model.kv_channels=64`** — proxy model dimensions so the workload fits on a 64-GPU cluster. The full DeepSeek-V3 (671B) needs 256+ GPUs; drop these overrides when you have enough GPUs.
+- **`model.pipeline_model_parallel_layout=null model.virtual_pipeline_model_parallel_size=null`** — clears the recipe's layout/VPP defaults so they don't conflict with the `-pp 1` we're forcing.
+- **`logger.log_throughput=true`** — emits TFLOPS per iteration into the training log; the built-in `megatron-bridge` LogProfile parses these for goodput.
+- **`train.manual_gc=true train.manual_gc_interval=100`** — explicit garbage-collection pacing recommended for this recipe.
+- **`resources`** — optional. When omitted, CRE auto-sets only `nvidia.com/gpu: <gpusPerNode>` (both limits and requests); it does not guess memory or CPU. Set the block explicitly, as here, if you need CPU pinning or memory sizing.
+
+CRE auto-handles NCCL environment variables, ComputeDomain and DRA setup, EFA/RoCE networking, and topology-aware orchestration based on the detected platform and GPU architecture.
+
+## Submit the WorkloadRun
+
+```bash
+export NGC_API_KEY=<your-ngc-api-key>
+
+ncrectl workloadrun run \
+  --workload-registry nvcr.io \
+  --workload-registry-username '$oauthtoken' \
+  --workload-registry-password "$NGC_API_KEY" \
+  deepseek-v3-bf16.yaml
+```
+
+The `--workload-registry*` flags create an `nvcr.io` image pull secret in the target namespace and inject it into the WorkloadRun automatically.
+
+## Monitor progress
+
+Watch pods come up:
+
+```bash
+kubectl get pods -w
+```
+
+Lightweight status check:
+
+```bash
+ncrectl workloadrun status deepseek-v3-bf16
+```
+
+Check goodput measurement in real time:
+
+```bash
+kubectl get goodputmeasurement -w
+```
+
+The training-loop log lines (in `kubectl logs <pod> -c node -f`) will look like:
+
+```
+[2026-06-11 15:19:14] iteration   2/  50 | consumed samples: 1024 |
+  elapsed time per iteration (ms): 11184.3 |
+  learning rate: 6.000000E-05 | global batch size: 512 |
+  lm loss: 1.178900E+01 | ... | grad norm: 1.837 | ...
+```
+
+…with a `throughput per GPU (TFLOP/s/GPU): ...` field appended on each iteration thanks to `logger.log_throughput=true`.
+
+## Generate a report
+
+```bash
+ncrectl workloadrun report deepseek-v3-bf16
+```
+
+Example output (16 nodes × 4 GPUs, BF16 proxy model):
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                       WorkloadRun Report                       ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      deepseek-v3-bf16
+  Platform:  aws
+  GPU:       gb300
+  Nodes:     16
+
+┌────────────────────────────────────────────────────────────────┐
+│  workloadrun/deepseek-v3-bf16                                   │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Runtime:   7m 52s                                             │
+│  Scale:     full-scale                                         │
+│  Nodes/Job: 16                                                 │
+│  Jobs:      1                                                  │
+│                                                                │
+│  ┌ clique-0 (16 nodes) ──────────────────────────────────────┐ │
+│  │  Avg Runtime Goodput:  1.00 (100%)                        │ │
+│  │  Avg TFLOPs/GPU:  556.5                                   │ │
+│  │  Avg Step Time:  4.78s                                    │ │
+│  └───────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   1/1 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+If a node fails, CRE records it in the WorkloadRun status with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`); it never taints, cordons, or otherwise modifies the node.
+
+To save as JSON:
+
+```bash
+ncrectl workloadrun report deepseek-v3-bf16 --results-file report.json
+```
+
+## Gang scheduling
+
+If the cluster runs a gang-aware scheduler such as KAI Scheduler, add `spec.gangScheduler` so all pods in a job group are held until the entire gang can be placed:
+
+```yaml
+spec:
+  gangScheduler:
+    schedulerName: kai-scheduler   # required; injected as schedulerName into every workload pod
+    queue: high-priority           # optional; defaults to "default-queue"
+```
+
+The `queue` value is applied as the `kai.scheduler/queue` label on the pod template metadata. It must be a valid Kubernetes label value (at most 63 characters). See [Run a WorkloadRun](./run-workloadrun.md) for details.
+
+## Clean up
+
+Cancel the WorkloadRun (cascades to its Workflow, Jobs, and pods):
+
+```bash
+ncrectl workloadrun cancel deepseek-v3-bf16 -n default
+```
+
+## Changing precision
+
+The `-c` flag in `train.sh` controls numerical precision. This example uses `-c bf16`. The `llmb-r0.2.0` `run_script.py` also accepts `bf16`, `fp8_cs`, `fp8_mx`, `fp8_sc`, and `nvfp4`, but some FP8 variants require recipe code that's only on newer (incompatible) branches against `nemo:26.02.00` — stick with `bf16` unless you've verified the branch supports your chosen FP8 mode. If you switch, also update `metadata.name` to keep the resource name aligned with what it's actually doing.
+
+## Available models
+
+The `llmb-r0.2.0` `run_script.py` accepts model family + size via `-m / -s`:
+
+```bash
+# List available recipes from inside any running pod
+kubectl exec -it <pod> -c node -- bash -c '
+  python /opt/Megatron-Bridge/scripts/performance/run_script.py --help
+' 2>&1 | grep -A 1 -E "(-m|-s|--task)" | head -20
+```
+
+Compatible models include DeepSeek-V3, GPT-OSS, LLaMA 3.1, and Qwen3. All use the same WorkloadRun pattern — swap `-m deepseek -s v3` for the desired family/size, adjust parallelism (`-pp`, `-ep`, `-vp`) for your GPU count, and (optionally) drop the `model.hidden_size=... model.kv_channels=...` proxy overrides if you have enough GPUs for the full model.
+
+## Next steps
+
+- [How-to: Run a WorkloadRun](./run-workloadrun.md) — targeting nodes, measurements, framework options
+- [How-to: Run Nemotron 5 Training](./workloadrun-nemotron5.md) — the raw Megatron-LM equivalent of this guide
+- [CLI Reference: workloadrun](../cli-reference/workloadrun.md)
+- [API Reference: WorkloadRun](../api-reference/workloadrun.md)

--- a/docs/how-to-guides/workloadrun-nemotron5.md
+++ b/docs/how-to-guides/workloadrun-nemotron5.md
@@ -1,0 +1,375 @@
+---
+title: Run Nemotron 5 Training with WorkloadRun
+description: End-to-end guide to running a Nemotron 5 (56B) Megatron-LM training workload with WorkloadRun and generating a report.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+This guide walks through running a Nemotron 5 (56B) training workload on a GPU cluster using Cluster Readiness Engine (CRE) and `ncrectl`, from manifest to report. It uses the `exec` framework to launch a Megatron-LM training script with mock data, so no dataset or checkpoint download is required.
+
+For an introduction to WorkloadRun and when to use it instead of a full Certification, see the [WorkloadRun Quick Start](../getting-started/workloadrun-quick-start.md). For generic WorkloadRun options (targeting nodes, measurements, framework types), see [Run a WorkloadRun](./run-workloadrun.md).
+
+## Prerequisites
+
+- A Kubernetes cluster with GPU nodes (`nvidia.com/gpu.present=true`) and `kubectl` access
+- `ncrectl` installed and the CRE controller running on the cluster — see [Installation](../getting-started/install.md)
+- An NGC API key for pulling the `nvcr.io/nvidia/pytorch` workload image
+
+If a cluster administrator has already installed the controller, you only need the NGC API key for the workload image — skip straight to creating the manifest below.
+
+## Create the WorkloadRun manifest
+
+Save the following as `nemotron5.yaml`. It runs Nemotron 5 (56B) using Megatron-LM with the `exec` framework:
+
+```yaml
+apiVersion: cre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: nemotron5-56b
+  namespace: default
+spec:
+  image: nvcr.io/nvidia/pytorch:25.08-py3
+  framework:
+    exec:
+      command: ["/bin/bash", "/config/train.sh"]
+  numNodes: 16
+  config:
+    inline:
+      train.sh: |
+        #!/bin/bash
+        set -e
+
+        WORKSPACE_DIR=${WORKSPACE_DIR:-/mnt/workspace}
+        MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE_DIR}/megatron-lm}
+        CHECKPOINT_DIR=${CHECKPOINT_DIR:-${WORKSPACE_DIR}/checkpoints}
+        TENSORBOARD_DIR=${TENSORBOARD_DIR:-${WORKSPACE_DIR}/tensorboard}
+        mkdir -p ${CHECKPOINT_DIR} ${TENSORBOARD_DIR}
+
+        if ! ls ${MEGATRON_PATH}/megatron/core/datasets/helpers_cpp*.so 1>/dev/null 2>&1; then
+          echo "Building Megatron helpers_cpp..."
+          cd ${MEGATRON_PATH}
+          pip install -e . --no-deps --no-build-isolation 2>&1 | tail -5
+          cd ${WORKSPACE_DIR}
+        fi
+
+        CHECKPOINT_ARGS=""
+        DATA_CACHE_ARGS=""
+        if [ "$ENABLE_CHECKPOINT" = "true" ]; then
+          CHECKPOINT_ARGS="--save ${CHECKPOINT_DIR}"
+          if [ -d "${CHECKPOINT_DIR}" ] && [ "$(ls -A ${CHECKPOINT_DIR} 2>/dev/null)" ]; then
+            CHECKPOINT_ARGS="${CHECKPOINT_ARGS} --load ${CHECKPOINT_DIR}"
+          fi
+          DATA_CACHE_ARGS="--data-cache-path ${WORKSPACE_DIR}/data_cache"
+          mkdir -p ${WORKSPACE_DIR}/data_cache
+        fi
+
+        TOTAL_GPUS=$((PET_NNODES * PET_NPROC_PER_NODE))
+        TP=${TENSOR_PARALLELISM:-4}
+        PP=${PIPELINE_PARALLELISM:-1}
+        MBS=${MICRO_BATCH_SIZE:-1}
+        GBS=${GLOBAL_BATCH_SIZE:-$TOTAL_GPUS}
+
+        echo "TOTAL_GPUS=${TOTAL_GPUS} GBS=${GBS} MBS=${MBS} TP=${TP} PP=${PP}"
+
+        exec torchrun \
+          --nnodes $PET_NNODES \
+          --nproc-per-node $PET_NPROC_PER_NODE \
+          ${MEGATRON_PATH}/pretrain_gpt.py \
+          --attention-backend flash \
+          --distributed-timeout-minutes 230 \
+          --use-mcore-models \
+          --no-mmap-bin-files \
+          --sequence-parallel \
+          --untie-embeddings-and-output-weights \
+          --disable-bias-linear \
+          --init-method-std 0.014 \
+          --position-embedding-type rope \
+          --rotary-base 1000000 \
+          --rotary-percent 1.0 \
+          --squared-relu \
+          --group-query-attention \
+          --kv-channels 128 \
+          --normalization RMSNorm \
+          --attention-dropout 0.0 \
+          --hidden-dropout 0.0 \
+          --exit-duration-in-mins 30 \
+          --train-iters 50 \
+          --lr-decay-iters 1830030 \
+          --lr 6e-4 \
+          --min-lr 6e-6 \
+          --weight-decay 0.1 \
+          --clip-grad 1.0 \
+          --lr-decay-style cosine \
+          --lr-warmup-iters 5 \
+          --eval-iters 1 \
+          --eval-interval 50 \
+          --log-interval 10 \
+          --tokenizer-type NullTokenizer \
+          --vocab-size 131072 \
+          --mock-data \
+          --num-workers 1 \
+          --no-create-attention-mask-in-dataloader \
+          --log-progress \
+          --timing-log-option minmax \
+          --log-params-norm \
+          --log-num-zeros-in-grad \
+          --log-throughput \
+          --bf16 \
+          --adam-beta1 0.9 \
+          --adam-beta2 0.95 \
+          --use-distributed-optimizer \
+          --overlap-grad-reduce \
+          --overlap-param-gather \
+          --manual-gc \
+          --log-straggler \
+          --disable-straggler-on-startup \
+          --straggler-minmax-count 16 \
+          --check-weight-hash-across-dp-replicas-interval 20000 \
+          --ckpt-fully-parallel-save \
+          --ckpt-fully-parallel-load \
+          --async-save \
+          --ckpt-assume-constant-structure \
+          --ckpt-format torch_dist \
+          --num-layers 79 \
+          --hidden-size 8192 \
+          --ffn-hidden-size 32768 \
+          --num-attention-heads 64 \
+          --seq-length 8192 \
+          --max-position-embeddings 8192 \
+          --num-query-groups 8 \
+          --tensor-model-parallel-size $TP \
+          --pipeline-model-parallel-size $PP \
+          --micro-batch-size $MBS \
+          --global-batch-size $GBS \
+          $CHECKPOINT_ARGS \
+          $DATA_CACHE_ARGS \
+          --save-interval ${SAVE_INTERVAL:-250} \
+          --save-retain-interval ${SAVE_RETAIN_INTERVAL:-1000} \
+          --tensorboard-dir ${TENSORBOARD_DIR}
+  initContainers:
+    - name: megatron-clone
+      image: nvcr.io/nvidia/pytorch:25.08-py3
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -ex
+          if [ ! -d "/mnt/workspace/megatron-lm/.git" ]; then
+            git clone --depth 1 -b core_v0.15.2 \
+              https://github.com/NVIDIA/Megatron-LM.git /mnt/workspace/megatron-lm
+          fi
+          echo "Megatron-LM cloned successfully"
+      volumeMounts:
+        - mountPath: /mnt/workspace
+          name: workspace
+  volumes:
+    - name: workspace
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /mnt/workspace
+      name: workspace
+  env:
+    - name: NVTE_FWD_LAYERNORM_SM_MARGIN
+      value: "16"
+    - name: NVTE_BWD_LAYERNORM_SM_MARGIN
+      value: "16"
+    - name: NVTE_FUSED_ATTN
+      value: "0"
+    - name: TORCHINDUCTOR_WORKER_START
+      value: fork
+    - name: CUDA_DEVICE_MAX_CONNECTIONS
+      value: "1"
+    - name: TORCH_NCCL_AVOID_RECORD_STREAMS
+      value: "1"
+    - name: TORCH_NCCL_HIGH_PRIORITY
+      value: "1"
+    - name: UCX_MEM_MMAP_HOOK_MODE
+      value: none
+    - name: UCX_MEM_CUDA_HOOK_MODE
+      value: none
+    - name: UCX_MEM_MALLOC_HOOKS
+      value: "n"
+    - name: UCX_ERROR_SIGNALS
+      value: ""
+    - name: EXIT_DURATION_MINS
+      value: "30"
+    - name: ENABLE_CHECKPOINT
+      value: "false"
+    - name: TRAIN_ITERS
+      value: "50"
+    - name: SAVE_INTERVAL
+      value: "250"
+    - name: SAVE_RETAIN_INTERVAL
+      value: "1000"
+    - name: PYTHONPATH
+      value: /mnt/workspace/megatron-lm
+  resources:
+    limits:
+      nvidia.com/gpu: "4"
+      memory: 800Gi
+      cpu: "128"
+    requests:
+      nvidia.com/gpu: "4"
+      memory: 500Gi
+      cpu: "64"
+  goodputMeasurement:
+    logProfileRef: megatron-training
+    sampleInterval: 10s
+```
+
+Key fields:
+
+- **`numNodes: 16`** — the number of nodes **per job group**, not a total. The orchestrator partitions **all** eligible GPU nodes into groups of this size and creates one job per group: `numNodes: 16` on a 16-node cluster creates a single 16-node job, while `numNodes: 4` on the same cluster would create four 4-node jobs that certify the nodes in parallel. Set it to your full cluster size for a single full-scale run.
+- **`resources`** — optional. When omitted, CRE auto-sets only `nvidia.com/gpu: <gpusPerNode>` (both limits and requests); it does not guess memory or CPU. Set the block explicitly, as here, if you need CPU pinning or memory sizing.
+- **`TP` in `train.sh`** — tensor parallelism: 4 for GB200/GB300, 8 for H100.
+- **No `target` needed** — CRE auto-discovers all GPU nodes. See [Run a WorkloadRun](./run-workloadrun.md) to target specific nodes.
+- **`goodputMeasurement`** — parses training logs with the built-in `megatron-training` LogProfile to compute goodput, TFLOPs/GPU, and step time for the report.
+
+CRE auto-handles NCCL environment variables, ComputeDomain and DRA setup, EFA/RoCE networking, and topology-aware orchestration based on the detected platform and GPU architecture.
+
+## Submit the WorkloadRun
+
+```bash
+export NGC_API_KEY=<your-ngc-api-key>
+
+ncrectl workloadrun run \
+  --workload-registry nvcr.io \
+  --workload-registry-username '$oauthtoken' \
+  --workload-registry-password "$NGC_API_KEY" \
+  nemotron5.yaml
+```
+
+The `--workload-registry*` flags create an `nvcr.io` image pull secret in the target namespace and inject it into the WorkloadRun automatically.
+
+Output:
+
+```
+Discovered 16 GPU nodes with product: NVIDIA-GB300
+WorkloadRun nemotron5-56b created in namespace default.
+
+To check status:
+  kubectl get workloadrun nemotron5-56b -n default
+```
+
+## Monitor progress
+
+Watch pods come up:
+
+```bash
+kubectl get pods -w
+```
+
+Check WorkloadRun status (lightweight):
+
+```bash
+ncrectl workloadrun status nemotron5-56b
+```
+
+For the full resource spec:
+
+```bash
+kubectl get workloadrun nemotron5-56b -o yaml
+```
+
+## Generate a report
+
+After the workload completes (or fails), generate a report:
+
+```bash
+ncrectl workloadrun report nemotron5-56b
+```
+
+Output:
+
+```
+╔════════════════════════════════════════════════════════════════╗
+║                      WorkloadRun Report                        ║
+╚════════════════════════════════════════════════════════════════╝
+
+  Name:      nemotron5-56b
+  Platform:  aws
+  GPU:       gb300
+  Nodes:     16
+
+┌────────────────────────────────────────────────────────────────┐
+│  workloadrun/nemotron5-56b                                     │
+├────────────────────────────────────────────────────────────────┤
+│  Status:    Succeeded                                          │
+│  Runtime:   4m 12s                                             │
+│  Scale:     full-scale                                         │
+│  Nodes/Job: 16                                                 │
+│  Jobs:      1                                                  │
+│                                                                │
+│  ┌ clique-0 (16 nodes) ──────────────────────────────────────┐ │
+│  │  Avg Runtime Goodput:  0.50 (50%)                         │ │
+│  │  Avg TFLOPs/GPU:  852.7                                   │ │
+│  │  Avg Step Time:  1.75s                                    │ │
+│  └───────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│  Summary                                                       │
+├────────────────────────────────────────────────────────────────┤
+│  Categories:   1/1 passed                                      │
+│  Failed Nodes: none                                            │
+│  Result:       PASSED                                          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+If a node fails, CRE records it in the WorkloadRun status with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`); it never taints, cordons, or otherwise modifies the node.
+
+To save the report as JSON:
+
+```bash
+ncrectl workloadrun report nemotron5-56b --results-file report.json
+```
+
+## Gang scheduling
+
+If the cluster runs a gang-aware scheduler such as KAI Scheduler, add `spec.gangScheduler` so all pods in a job group are held until the entire gang can be placed:
+
+```yaml
+spec:
+  gangScheduler:
+    schedulerName: kai-scheduler   # required; injected as schedulerName into every workload pod
+    queue: high-priority           # optional; defaults to "default-queue"
+```
+
+The `queue` value is applied as the `kai.scheduler/queue` label on the pod template metadata. It must be a valid Kubernetes label value (at most 63 characters). See [Run a WorkloadRun](./run-workloadrun.md) for details.
+
+## Clean up
+
+Cancel the WorkloadRun (cascades to its Workflow, Jobs, and pods):
+
+```bash
+ncrectl workloadrun cancel nemotron5-56b -n default
+```
+
+To uninstall CRE entirely:
+
+```bash
+ncrectl setup reset
+```
+
+## Alternative: one-shot run with wait and report
+
+Combine run, wait, and report in a single command:
+
+```bash
+ncrectl workloadrun run \
+  --workload-registry nvcr.io \
+  --workload-registry-username '$oauthtoken' \
+  --workload-registry-password "$NGC_API_KEY" \
+  --wait --results-file report.json \
+  nemotron5.yaml
+```
+
+This blocks until the workload completes and prints the report automatically.
+
+## Next steps
+
+- [How-to: Run a WorkloadRun](./run-workloadrun.md) — targeting nodes, measurements, framework options
+- [CLI Reference: workloadrun](../cli-reference/workloadrun.md)
+- [API Reference: WorkloadRun](../api-reference/workloadrun.md)
+- Nemotron 5 is also available as certification catalog entries (`training/nemotron5-8b`, `training/nemotron5-56b`) — see [Certify a Cluster](./certify-a-cluster.md)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -37,6 +37,10 @@ navigation:
         path: how-to-guides/certify-a-cluster.md
       - page: Run a WorkloadRun
         path: how-to-guides/run-workloadrun.md
+      - page: Run Nemotron 5 Training
+        path: how-to-guides/workloadrun-nemotron5.md
+      - page: Run DeepSeek-V3 Training
+        path: how-to-guides/workloadrun-deepseek-v3.md
       - page: Run NCCL Benchmarks
         path: how-to-guides/nccl-benchmarks.md
       - page: Adaptive Fault Isolation
@@ -79,3 +83,18 @@ navigation:
         path: api-reference/bandwidth-measurement.md
       - page: LogProfile
         path: api-reference/logprofile.md
+      - page: Validation Results
+        path: api-reference/validation-results.md
+
+  - section: Operations
+    contents:
+      - page: Deployment
+        path: operations/deployment.md
+      - page: Monitoring
+        path: operations/monitoring.md
+      - page: Prometheus Metrics
+        path: operations/metrics.md
+      - page: Troubleshooting
+        path: operations/troubleshooting.md
+      - page: FAQ
+        path: operations/faq.md

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,314 @@
+---
+title: Deployment
+description: Resource sizing, high availability, RBAC, install paths, and cleanup for running the controller in production.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+This page covers deploying the Cluster Readiness Engine (CRE) controller in production: install paths, resource sizing, high availability, RBAC, network policies, health probes, and the cleanup steps that are easy to miss.
+
+## Installation methods
+
+CRE supports two install paths. Both pull the same artifacts from the GitHub Container Registry (GHCR).
+
+| Method | Audience | Installs Kubeflow Trainer |
+|--------|----------|---------------------------|
+| `ncrectl setup init` | Operators, quick setup | Yes (skip with `--skip-phases=deps`) |
+| Helm chart (`oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine`) | GitOps / platform teams | No (install separately) |
+
+### ncrectl setup init
+
+Install the CLI first with the installer script (see [Install](../getting-started/install.md) for the full walkthrough):
+
+```bash
+export NCRECTL_VERSION=v0.1.0-rc.8
+curl -sSL "https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${NCRECTL_VERSION}/installer" | bash
+```
+
+Then set up the cluster:
+
+```bash
+ncrectl setup init --image-pull-secret $GITHUB_TOKEN
+```
+
+`setup init` runs two phases:
+
+1. **deps** — Kubeflow Trainer (required for `TrainJob` workloads)
+2. **helm** — the CRE Helm chart: CRDs, controller Deployment, RBAC, metrics Service/ServiceMonitor, and built-in LogProfiles
+
+The Helm chart is pulled from GHCR at the CLI's own version, so a tagged release needs no version flag. **Dev builds (built from `main`) require `--version`** to name the chart version explicitly:
+
+```bash
+ncrectl setup init --version <chart-version> --image-pull-secret $GITHUB_TOKEN
+```
+
+`--image-pull-secret` takes a GitHub token; it creates the `ncrectl-pull-secret` image pull secret in the `cluster-readiness-engine` namespace and authenticates the Helm chart pull. Use `--skip-phases=deps` when Kubeflow Trainer is already installed, and `--auto-approve` to skip the confirmation prompt in CI.
+
+Check the installation at any time:
+
+```bash
+ncrectl setup status
+```
+
+### Helm chart
+
+For GitOps workflows, install the chart directly. **Log in to the GHCR Helm registry first** — the chart pull is authenticated:
+
+```bash
+echo $GITHUB_TOKEN | helm registry login ghcr.io --username <github-username> --password-stdin
+```
+
+Then inspect and install, pinning an explicit version:
+
+```bash
+CRE_VERSION=v0.1.0-rc.8
+
+helm show chart oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine --version "$CRE_VERSION"
+
+helm install cluster-readiness-engine \
+  oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
+  --version "$CRE_VERSION" \
+  --namespace cluster-readiness-engine \
+  --create-namespace
+```
+
+The controller image is `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
+
+Key chart values:
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `manager.replicas` | `1` | Controller Deployment replicas |
+| `manager.image.repository` | `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager` | Controller image |
+| `manager.image.tag` | `""` (uses chart `appVersion`) | Controller image tag |
+| `manager.imagePullSecrets` | `[]` | Pull secrets for the controller image |
+| `manager.resources` | `10m/500m` CPU, `1Gi/1Gi` memory | Controller resource requests/limits |
+| `manager.affinity` | `{}` | Controller pod affinity |
+| `metrics.port` | `8443` | Controller metrics port |
+| `metrics.serviceMonitor.enabled` | `true` | Install a `ServiceMonitor` (requires the Prometheus Operator CRDs; set to `false` on clusters without them) |
+
+## Resource requirements
+
+The controller runs as a single Deployment. The shipped defaults are:
+
+```yaml
+resources:
+  requests:
+    cpu: 10m
+    memory: 1Gi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+```
+
+Size it according to the number of nodes and concurrent workloads in the cluster:
+
+| Cluster size | CPU request / limit | Memory request / limit | Notes |
+|--------------|---------------------|------------------------|-------|
+| Up to ~100 nodes | 10m / 500m | 1Gi / 1Gi | Shipped chart defaults |
+| ~100 – 500 nodes | 200m / 500m | 1Gi / 1Gi | Increase CPU if reconcile latency rises |
+| ~500 – 1000 nodes | 500m / 1000m | 1Gi / 2Gi | Raise both CPU and memory for heavier concurrency |
+
+## High availability
+
+Leader election is enabled by default (the manager runs with `--leader-elect`). To run the controller in HA mode, scale the Deployment to two or more replicas:
+
+```yaml
+manager:
+  replicas: 2
+```
+
+Only one replica holds the leader lease at a time. Standby replicas take over automatically if the leader fails. No additional configuration is required.
+
+## RBAC requirements
+
+The controller's ClusterRole (`cre-manager-role`) is scoped to the resource types CRE actually manages — there are no wildcard rules. Review these before deploying to locked-down clusters:
+
+| Resource | Verbs | Purpose |
+|----------|-------|---------|
+| `cre.nvidia.com/*` (Certifications, Workflows, Jobs, GoodputMeasurements, BandwidthMeasurements, WorkloadRuns) + `/status`, `/finalizers` | full lifecycle | Reconcile the CRD hierarchy |
+| `cre.nvidia.com` LogProfiles | get, list, watch | Read log-parsing profiles |
+| `nodes`, `pods` | get, list, watch | Discover nodes for scheduling and health checks; track workload pod placement |
+| `pods/log` | get | Read training logs for goodput and bandwidth measurement |
+| `configmaps` | full lifecycle | Workflow dependencies and failed-node result records |
+| `persistentvolumeclaims` | create, delete, get, list | Checkpoint storage dependencies |
+| `persistentvolumes` | get, list, patch, watch | Checkpoint storage handling |
+| `events` | create, patch | Emit Kubernetes events |
+| `resource.k8s.io` ResourceClaimTemplates | create, delete, get, list, patch, update | RoCE/DRA network resources |
+| `resource.nvidia.com` ComputeDomains | create, delete, get, list, patch, update | Multi-Node NVLink (MNNVL) domains |
+| `trainer.kubeflow.org` TrainingRuntimes, TrainJobs | create, delete, get, list, patch, update (TrainJobs also watch; `trainjobs/status` get) | Training workloads via Kubeflow Trainer |
+
+The Workflow dependency system creates supporting resources (ConfigMaps, PVCs, ComputeDomains, TrainingRuntimes) before workloads start, so the role includes create/delete on exactly those types. Inspect the full ClusterRole:
+
+```bash
+kubectl get clusterrole cre-manager-role -o yaml
+```
+
+## Cluster scope and tenancy model
+
+The controller operates as a cluster-scoped infrastructure service, the same model used by the GPU Operator, Node Problem Detector, and other Kubernetes-native controllers. Burn-in certification is an infrastructure concern that reads cluster-scoped Node objects to evaluate GPU health.
+
+CRE never modifies nodes — it does not taint, cordon, or patch them. It **records** failed nodes with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`) in the Certification status, and leaves quarantine and repair to your platform's own tooling.
+
+For teams that need per-team access control, the chart ships `admin`, `editor`, and `viewer` ClusterRoles for the Certification, Workflow, Job, and GoodputMeasurement CRDs. Bind these to team-specific groups or service accounts using standard Kubernetes RoleBindings scoped to each team's namespace.
+
+## Network policies
+
+The chart does not ship a NetworkPolicy. If your cluster enforces network policies, allow ingress to the metrics port (`8443`) from your monitoring namespace:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-traffic
+  namespace: cluster-readiness-engine
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: manager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              metrics: enabled
+      ports:
+        - port: 8443   # metrics
+```
+
+If you want to restrict egress to the Kubernetes API server or gate health probes separately, layer additional NetworkPolicies on top of this example.
+
+## Scaling characteristics
+
+The controller uses controller-runtime's work queue model — each reconciler processes events concurrently. A single replica comfortably handles clusters up to 1,000 nodes and hundreds of concurrent burn-in Jobs. Leader election ensures only one replica reconciles at a time, while standby replicas provide automatic failover.
+
+The controller has no external database, no admission webhook, and no sidecar injection. It depends on Kubeflow Trainer for `TrainJob` workloads, and `ncrectl setup init` installs Kubeflow Trainer by default unless you skip the `deps` phase. CRD validation is handled through CEL-based validation rules embedded in the CRD schema, which the API server evaluates natively. Operationally, that reduces the stack to the controller Deployment plus the Kubernetes APIs and Trainer CRDs it uses.
+
+### Tuning for large clusters (200+ nodes)
+
+| Parameter | Default | Large cluster | Notes |
+|-----------|---------|---------------|-------|
+| Controller CPU limit | 500m | 1000m | CEL evaluation scales with node count |
+| Controller memory limit | 1Gi | 2Gi | Status objects grow with group count |
+| GoodputMeasurement `sampleInterval` | 60s | 120s | Reduces API server log fetch load |
+| Certification category concurrency | Unlimited | Partition by node groups | Use multiple Certifications for >500 nodes |
+
+CEL evaluation is lightweight per node, pod-to-node lookups use field indexes, and node watches filter for health-relevant changes only (taints, conditions, schedulability), so unrelated node updates do not trigger reconciliation.
+
+## Air-gapped and disconnected environments
+
+The controller runs without external network access at runtime. All catalog entries are embedded in the binary at compile time, and the controller makes no outbound API calls — it communicates only with the Kubernetes API server. For air-gapped deployment:
+
+1. Mirror the controller image (`ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`) and the Kubeflow Trainer images to your internal registry
+2. Install the Helm chart with `manager.image.repository` pointing at your internal registry
+3. Pre-load any workload images referenced by catalog entries (NeMo, NCCL tests)
+
+No internet access, external telemetry endpoints, or license servers are required at runtime.
+
+## Health checks
+
+The controller exposes two probe endpoints on port `8081`, and the chart configures both probes on the Deployment:
+
+| Endpoint | Probe type | Purpose |
+|----------|-----------|---------|
+| `/healthz` | Liveness | Restart the pod if the process is deadlocked |
+| `/readyz` | Readiness | Remove the pod from service until it is ready to reconcile |
+
+Shipped probe configuration:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 15
+  periodSeconds: 20
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+## Upgrades
+
+1. Review the release notes for breaking changes.
+2. Upgrade the Helm release (log in to `ghcr.io` first, as above):
+   ```bash
+   helm upgrade cluster-readiness-engine \
+     oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
+     --version <new-version> \
+     --namespace cluster-readiness-engine
+   ```
+3. Verify the rollout:
+   ```bash
+   kubectl rollout status -n cluster-readiness-engine deploy/cluster-readiness-engine-manager
+   ```
+
+To roll back:
+
+```bash
+helm rollback cluster-readiness-engine <revision> --namespace cluster-readiness-engine
+```
+
+If you installed with `ncrectl setup init`, upgrade by installing the new CLI version and re-running `ncrectl setup init`.
+
+## Uninstall and cleanup
+
+### ncrectl setup reset
+
+```bash
+ncrectl setup reset
+```
+
+`setup reset` runs three phases: **cr** (deletes all CRE custom resource instances while the controller can still process finalizers), **helm** (removes the CRE Helm release and then explicitly deletes the CRE CRDs), and **deps** (removes Kubeflow Trainer and its CRDs). Use `--skip-phases=deps` to keep Kubeflow Trainer.
+
+**What `setup reset` retains** — clean these up yourself if you want a pristine cluster:
+
+- The `cluster-readiness-engine` and `kubeflow-system` namespaces are not deleted.
+- The `ncrectl-pull-secret` image pull secret created by `setup init --image-pull-secret` remains in the `cluster-readiness-engine` namespace.
+
+```bash
+# Removes both retained namespaces (and the pull secret inside them)
+kubectl delete namespace cluster-readiness-engine kubeflow-system
+```
+
+### helm uninstall leaves the CRDs behind
+
+Helm intentionally never deletes CRDs that live in a chart's `crds/` directory (to avoid accidental data loss), so a manual `helm uninstall cluster-readiness-engine` leaves all seven `cre.nvidia.com` CRDs — and every remaining custom resource instance — in the cluster. Delete them explicitly:
+
+```bash
+kubectl delete crd \
+  bandwidthmeasurements.cre.nvidia.com \
+  certifications.cre.nvidia.com \
+  goodputmeasurements.cre.nvidia.com \
+  jobs.cre.nvidia.com \
+  logprofiles.cre.nvidia.com \
+  workflows.cre.nvidia.com \
+  workloadruns.cre.nvidia.com
+```
+
+**Warning:** deleting a CRD deletes all instances of that resource cluster-wide, including any Certification results you have not exported. Save reports first with `ncrectl certification report <name> --results-file <path>`.
+
+## Production security checklist
+
+Use this checklist before going live. Each item addresses a specific risk surface.
+
+| Item | Status | What to verify |
+|------|--------|----------------|
+| **Network policy** | Required | Restrict egress to the Kubernetes API server and DNS only. No NetworkPolicy ships with the chart — add one for your environment. |
+| **RBAC audit** | Required | Run `kubectl get clusterrole cre-manager-role -o yaml` and verify the permissions match your security requirements. |
+| **TLS for metrics** | Recommended | The default ServiceMonitor uses `insecureSkipVerify: true`. Configure cert-manager to issue a serving certificate for the controller's metrics endpoint. |
+| **Controller node affinity** | Recommended | Schedule the controller on infrastructure nodes, not GPU nodes, using the `manager.affinity` chart value to avoid consuming GPU resources. |
+| **Image provenance** | Recommended | Pin container images by digest rather than tag. Scan images with your vulnerability tooling before deployment. |
+| **Pod Security Standards** | Verify | The controller runs as non-root with `seccompProfile: RuntimeDefault`, a read-only root filesystem, and all capabilities dropped. Verify with `kubectl get pod -n cluster-readiness-engine -o yaml`. |
+| **CRD backup** | Recommended | Include the CRE CRDs in your cluster backup strategy. Certification resources contain node health state that may be needed for audit. |
+
+## Next steps
+
+- [Monitoring](./monitoring.md) — Set up Prometheus metrics and alerting.
+- [Troubleshooting](./troubleshooting.md) — Diagnose common production issues.
+- [Install](../getting-started/install.md) — First-time installation instructions.

--- a/docs/operations/faq.md
+++ b/docs/operations/faq.md
@@ -1,0 +1,58 @@
+---
+title: FAQ
+description: Frequently asked questions — common gotchas, design choices, and tips from real-world usage.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+## General
+
+### How often should I run burn-in?
+
+Recurring cluster-wide burn-in every 3–4 weeks with real ML training workloads is recommended to catch infant mortality failures and hardware degradation over time. Synthetic benchmarks alone are not enough — faults like NVLink bandwidth degradation and NCCL collective hangs only surface under sustained distributed load.
+
+You can declare a Certification once and re-run it on a schedule. The Cluster Readiness Engine (CRE) handles orchestration, measurement, and failure detection each time.
+
+### Can I run CRE on non-NVIDIA GPUs?
+
+No. CRE is built for NVIDIA GPU clusters and depends on NVIDIA-specific health signals (`nvidia.com/gpu.product` labels, DCGM diagnostics, NVLink topology). The catalog entries target NeMo training, NCCL collectives, and DCGM diagnostics — all NVIDIA tooling.
+
+### Can I use my own training workloads instead of the catalog?
+
+Yes. The catalog is a convenience layer that provides pre-configured WorkflowSpecs. You can bypass it entirely by creating Workflow or Job resources directly with any workload spec (`trainJob`), or run a one-off workload with [WorkloadRun](../getting-started/workloadrun-quick-start.md). See [Custom Catalog Entries](../how-to-guides/custom-catalog-entries.md) for adding your own catalog categories.
+
+### What is the difference between a gray failure and a hardware failure?
+
+A **hardware failure** is detected by the node health monitor — the CEL expression evaluates to `true`, indicating a clear signal (for example, a GPU-related taint or node condition set by your cluster's health monitoring stack, or a node marked unschedulable). The controller reports this immediately in the Job's `HardwareFailed` condition and records the node with reason `HardwareFailureDetected`.
+
+A **gray failure** is when hardware is degraded but no health monitor fires. The workload runs but underperforms — reduced NCCL bandwidth, lower goodput, or intermittent hangs. CRE detects these through performance thresholds (goodput ratio, bus bandwidth) and adaptive fault isolation. See [Adaptive Fault Isolation](../how-to-guides/adaptive-fault-isolation.md).
+
+### What happens to failed nodes after repair?
+
+Failed nodes are recorded in the Certification status with a reason (`HardwareFailureDetected`, `ThresholdViolation`, or `WorkloadFailed`). CRE never modifies nodes — it does not taint, cordon, or patch them. Node quarantine and repair are handled by your platform's own tooling. After repairing or replacing the failed hardware, re-run the Certification to verify the fix.
+
+## Development
+
+### Why do I need to run `make manifests generate` after editing types?
+
+CRE uses kubebuilder markers in `*_types.go` files to auto-generate CRD manifests (`helm/cluster-readiness-engine/crds/`) and DeepCopy methods (`zz_generated.deepcopy.go`). If you modify a types file and skip this step, the generated files become stale — the controller binary won't compile because the DeepCopy methods reference the old struct shape, and the CRD YAML won't match the new fields.
+
+Always run `make manifests generate` immediately after any change to `api/v1alpha1/*_types.go`.
+
+### Why doesn't my custom catalog entry appear?
+
+The catalog uses Go `init()` functions for registration. `pkg/catalog` (which loads the entries in `pkg/catalog/entries/`) must be imported by every binary and test suite that resolves catalog lookups — it is blank-imported in `cmd/ncrectl/main.go` and imported by the controller in `cmd/manager/main.go`.
+
+If you created a new catalog entry but the `init()` registration never runs in your binary or test suite, `catalog.Lookup()` returns "not found". See [Custom Catalog Entries](../how-to-guides/custom-catalog-entries.md).
+
+### Why doesn't cascade deletion work in my integration tests?
+
+Kubernetes envtest (used by the integration test suite) does not run a garbage collection controller. This means `OwnerReference`-based cascade deletion does not work — child resources are not automatically deleted when the parent is deleted.
+
+Controllers must explicitly delete child resources in their `handleDeletion()` methods. This is by design in envtest and is documented as a critical pitfall in the project's contributor docs.
+
+## See also
+
+- [Troubleshooting](./troubleshooting.md) — problem-solution pairs for specific issues
+- [Architecture](../concepts/architecture.md) — understand the Certification, Workflow, Job model

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -1,0 +1,269 @@
+---
+title: Prometheus Metrics
+description: Complete reference for all Prometheus metrics exposed by the Cluster Readiness Engine controller.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+This page is the full reference for Prometheus metrics exposed by the Cluster Readiness Engine (CRE) controller. All metrics are registered with the controller-runtime metrics registry and served on the `/metrics` endpoint.
+
+## Scrape configuration
+
+The Helm chart ships a `ServiceMonitor` for the Prometheus Operator (enabled by default via `metrics.serviceMonitor.enabled`):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cluster-readiness-engine-metrics-monitor
+  namespace: cluster-readiness-engine
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true  # Use cert-manager in production
+  selector:
+    matchLabels:
+      control-plane: manager
+```
+
+## Job status metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_job_status` | Gauge | `namespace`, `job`, `workflow`, `status` | Current status of burn-in Jobs. Value is `1` for the current status, `0` for others. Status values: `in_progress`, `succeeded`, `failed`. |
+
+The gauge is set for all three status values on each update, ensuring that a transition from `in_progress` to `succeeded` also zeroes out the `in_progress` series. Metrics are cleaned up when a Job is deleted.
+
+## Hardware failure metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_hardware_failed_jobs_total` | Counter | `namespace`, `job`, `workflow` | Total number of Jobs that detected hardware failures. Incremented once per Job on first detection. |
+| `cre_job_failed_nodes` | Gauge | `namespace`, `job`, `workflow` | Number of nodes with detected hardware failures per Job. |
+| `cre_hardware_failures_detected_total` | Counter | `namespace`, `job`, `workflow`, `node` | Total number of hardware failures detected across all evaluations. Per-node granularity. |
+
+## Node health check metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_node_health_check_duration_seconds` | Histogram | `namespace`, `job`, `workflow` | Duration of node health check operations in seconds. Buckets: 1ms to ~16s (exponential). |
+| `cre_nodes_evaluated_total` | Counter | `namespace`, `job`, `workflow` | Total number of node health evaluations performed. |
+
+## Reconciliation metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_reconcile_total` | Counter | `namespace`, `job`, `workflow`, `result` | Total number of reconciliation attempts. `result` values: `success`, `error`, `requeue`. |
+| `cre_reconcile_duration_seconds` | Histogram | `namespace`, `job`, `workflow` | Duration of reconciliation operations in seconds. Buckets: 10ms to ~20s (exponential). |
+
+## Workload metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_workload_created_total` | Counter | `namespace`, `job`, `workflow` | Total number of workloads created by the Job controller. |
+
+## Goodput metrics
+
+All goodput metrics share the same label set: `namespace`, `measurement`, `job`, `workflow`.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `cre_goodput_ratio` | Gauge | Runtime goodput ratio (0.0 to 1.0) |
+| `cre_goodput_avg_tflops_per_gpu` | Gauge | Average TFLOPS per GPU from goodput measurement |
+| `cre_goodput_training_time_seconds` | Gauge | Total training wall-clock time in seconds |
+| `cre_goodput_reschedule_time_seconds` | Gauge | Cumulative reschedule time in seconds |
+| `cre_goodput_resume_time_seconds` | Gauge | Cumulative resume time in seconds |
+| `cre_goodput_checkpoint_save_time_seconds` | Gauge | Cumulative checkpoint save time in seconds |
+| `cre_goodput_warmup_time_seconds` | Gauge | Total warmup step time in seconds |
+| `cre_goodput_non_warmup_time_seconds` | Gauge | Total non-warmup step time in seconds |
+| `cre_goodput_avg_step_time_seconds` | Gauge | Average time per training step in seconds |
+| `cre_goodput_lost_work_time_seconds` | Gauge | Cumulative lost work time in seconds (work done after last checkpoint, lost on restart) |
+
+Goodput metrics are cleaned up when a GoodputMeasurement is deleted.
+
+### Metric lifecycle
+
+Goodput metrics are cleaned up at specific lifecycle events to prevent stale data in Prometheus:
+
+| Event | What is cleaned up | What is preserved |
+|-------|--------------------|-------------------|
+| Job completes (succeeded or failed) | Operational metrics (every `cre_goodput_*` gauge except the ratio: TFLOPS, step time, training/warmup/non-warmup time, checkpoint, reschedule, resume, lost work) | `cre_goodput_ratio` (the outcome) |
+| Job restarts from checkpoint | Instantaneous metrics (TFLOPS, avg step time) | All cumulative metrics |
+| GoodputMeasurement deleted | All goodput metrics for that measurement | — |
+| BandwidthMeasurement completes or is deleted | All NCCL bandwidth metrics for that measurement | — |
+
+## NCCL bandwidth metrics
+
+All NCCL bandwidth metrics share the same label set: `namespace`, `measurement`, `job`, `workflow`, `nccl_test`, `message_size_bytes`.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `cre_nccl_algbw_gbps` | Gauge | NCCL algorithmic bandwidth in GB/s per message size |
+| `cre_nccl_busbw_gbps` | Gauge | NCCL bus bandwidth in GB/s per message size |
+
+The `nccl_test` label identifies the collective operation (e.g., `all_reduce`, `all_gather`, `alltoall`). The `message_size_bytes` label tracks results per message size tested.
+
+NCCL bandwidth metrics are cleaned up when a BandwidthMeasurement is deleted.
+
+**Cardinality at scale:** NCCL metrics include a `message_size_bytes` label (typically 20-30 values per test). With 3 test types and 10 concurrent measurements, expect ~600-900 NCCL time series. Goodput metrics produce 10 series per measurement. At 100+ concurrent Jobs, monitor your Prometheus memory and consider increasing `sampleInterval` or limiting concurrent Certifications.
+
+## Topology metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cre_topology_validated_nodes` | Gauge | `namespace`, `workflow`, `topology_key`, `domain`, `node` | Set to `1` for each node that passed burn-in validation. Per-node granularity for identifying exactly which nodes are certified in each topology domain. |
+| `cre_topology_failed_nodes` | Gauge | `namespace`, `workflow`, `topology_key`, `domain`, `node` | Set to `1` for each node that failed burn-in validation. Useful for identifying bad switches, racks, or NVLink cliques from Prometheus. |
+
+## Example PromQL queries
+
+### Job status
+
+```promql
+# Count of failed jobs
+count(cre_job_status{status="failed"} == 1) by (namespace)
+
+# All currently running jobs
+cre_job_status{status="in_progress"} == 1
+
+# Job status breakdown per namespace
+sum by (namespace, status) (cre_job_status == 1)
+```
+
+### Hardware failures
+
+```promql
+# Nodes with hardware failures across all jobs
+count(cre_hardware_failures_detected_total) by (node)
+
+# Hardware failure rate (per hour)
+sum(rate(cre_hardware_failures_detected_total[1h])) by (namespace)
+
+# Jobs with the most failed nodes
+topk(10, cre_job_failed_nodes)
+```
+
+### Goodput
+
+```promql
+# Average goodput across all measurements in a namespace
+avg(cre_goodput_ratio) by (namespace)
+
+# Jobs with low goodput (below 80%)
+cre_goodput_ratio < 0.8
+
+# Training time breakdown for a specific job
+{__name__=~"cre_goodput_(training|reschedule|resume|checkpoint_save|warmup|non_warmup)_time_seconds", job="my-training-job"}
+
+# Average TFLOPS per GPU across measurements
+avg(cre_goodput_avg_tflops_per_gpu) by (namespace)
+```
+
+### NCCL bandwidth
+
+```promql
+# Bus bandwidth for all_reduce across all message sizes
+cre_nccl_busbw_gbps{nccl_test="all_reduce"}
+
+# Average algorithmic bandwidth per test type
+avg(cre_nccl_algbw_gbps) by (nccl_test)
+
+# Compare bandwidth across message sizes for a specific measurement
+cre_nccl_algbw_gbps{measurement="nccl-allreduce-bw"}
+```
+
+### Reconciliation performance
+
+```promql
+# Reconciliation error rate
+sum(rate(cre_reconcile_total{result="error"}[5m])) by (namespace)
+
+# 99th percentile reconciliation duration
+histogram_quantile(0.99, sum(rate(cre_reconcile_duration_seconds_bucket[5m])) by (le))
+
+# Node health check duration (p95)
+histogram_quantile(0.95, sum(rate(cre_node_health_check_duration_seconds_bucket[5m])) by (le))
+```
+
+### Topology validation
+
+```promql
+# Nodes validated per topology domain
+cre_topology_validated_nodes{topology_key="nvidia.com/gpu.clique"}
+
+# Total validated nodes per workflow
+sum(cre_topology_validated_nodes) by (namespace, workflow)
+```
+
+## Example alerting rules
+
+The following `PrometheusRule` examples provide starting points for monitoring a burn-in cluster.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cre-alerts
+  labels:
+    app.kubernetes.io/name: cluster-readiness-engine
+spec:
+  groups:
+    - name: burnin.rules
+      rules:
+        # Alert when hardware failure rate exceeds threshold
+        - alert: CREHighHardwareFailureRate
+          expr: |
+            sum(rate(cre_hardware_failures_detected_total[1h])) by (namespace) > 0.5
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "High hardware failure rate in namespace {{ $labels.namespace }}"
+            description: >
+              More than 0.5 hardware failures per second detected in
+              namespace {{ $labels.namespace }} over the last hour.
+
+        # Alert when goodput drops below acceptable threshold
+        - alert: CRELowGoodput
+          expr: |
+            cre_goodput_ratio < 0.75
+            and cre_goodput_ratio > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Low goodput for measurement {{ $labels.measurement }}"
+            description: >
+              Goodput ratio for {{ $labels.measurement }} in
+              {{ $labels.namespace }} is {{ $value | humanize }},
+              below the 75% threshold. Check for frequent checkpointing
+              or rescheduling overhead.
+
+        # Alert when a job appears stuck (in_progress for too long)
+        - alert: CREJobStuck
+          expr: |
+            cre_job_status{status="in_progress"} == 1
+            unless on(namespace, job) (
+              increase(cre_reconcile_total[30m]) > 0
+            )
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CRE job {{ $labels.job }} appears stuck"
+            description: >
+              Job {{ $labels.job }} in namespace {{ $labels.namespace }}
+              has been in_progress for at least 30 minutes with no
+              reconciliation activity.
+```
+
+## See also
+
+- [Job API](../api-reference/job.md) — the resource that emits job status and hardware failure metrics
+- [GoodputMeasurement API](../api-reference/goodput-measurement.md) and [BandwidthMeasurement API](../api-reference/bandwidth-measurement.md) — the resources that populate goodput and bandwidth metrics
+- [Workflow API](../api-reference/workflow.md) — the resource that populates topology validation metrics
+- [Goodput & Bandwidth Measurement](../concepts/goodput-bandwidth.md) — conceptual overview of the goodput formula and its components

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,165 @@
+---
+title: Monitoring
+description: Prometheus metrics, structured logging, and alerting for the Cluster Readiness Engine controller.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+Set up Prometheus metrics, structured log queries, and alert rules for the Cluster Readiness Engine (CRE) controller.
+
+## Prometheus integration
+
+### ServiceMonitor
+
+The Helm chart installs a `ServiceMonitor` for the Prometheus Operator by default (`metrics.serviceMonitor.enabled: true`; set it to `false` on clusters without the Prometheus Operator CRDs). The shipped monitor scrapes the controller's HTTPS metrics endpoint:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cluster-readiness-engine-metrics-monitor
+  namespace: cluster-readiness-engine
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true  # Use cert-manager in production
+  selector:
+    matchLabels:
+      control-plane: manager
+```
+
+Verify it is installed:
+
+```bash
+kubectl get servicemonitor -n cluster-readiness-engine
+```
+
+### Key metrics
+
+The table below highlights the most important metrics. See the [Metrics Reference](./metrics.md) for the full list, labels, and example PromQL queries.
+
+| Metric | Type | What it tells you |
+|--------|------|-------------------|
+| `cre_job_status` | Gauge | Current state of each job (in_progress, succeeded, failed) |
+| `cre_job_failed_nodes` | Gauge | Number of nodes with hardware failures per job |
+| `cre_hardware_failures_detected_total` | Counter | Cumulative hardware failure detections per node |
+| `cre_reconcile_duration_seconds` | Histogram | How long each reconcile loop takes |
+| `cre_reconcile_total` | Counter | Reconcile attempts by result (success, error, requeue) |
+| `cre_goodput_ratio` | Gauge | Training efficiency from 0.0 to 1.0 |
+| `cre_nccl_algbw_gbps` | Gauge | NCCL algorithmic bandwidth in GB/s per message size |
+| `cre_nccl_busbw_gbps` | Gauge | NCCL bus bandwidth in GB/s per message size |
+| `cre_topology_validated_nodes` | Gauge | Nodes that passed validation per topology domain |
+
+## Structured logging
+
+The controller emits structured zap logs. In the shipped manager configuration, zap development mode is enabled, so logs use console encoding unless you set `--zap-encoder=json`.
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| `controller` | Which controller emitted the log (job, workflow, certification, goodputmeasurement) |
+| `namespace` | Kubernetes namespace of the resource |
+| `name` | Resource name |
+| `reconcileID` | Unique ID for the reconcile pass — use this to trace a single reconciliation |
+
+### Log levels
+
+| Level | Flag | Use case |
+|-------|------|----------|
+| info (0) | `--zap-log-level=0` | Normal operations, status changes |
+| debug (1) | `--zap-log-level=1` | Detailed troubleshooting |
+
+Enable debug logging by adding the flag to the manager container args in the Deployment spec:
+
+```yaml
+args:
+  - --zap-log-level=1
+```
+
+### Example log queries
+
+Using Loki or a similar log aggregation system (adjust the stream selector to how your agent labels the controller pods — the pods carry the `control-plane=manager` label in the `cluster-readiness-engine` namespace):
+
+```
+# Hardware failures
+{namespace="cluster-readiness-engine"} |= "Hardware failure detected"
+
+# Errors for a specific job
+{namespace="cluster-readiness-engine"} |= "my-job" |= "error"
+
+# All hardware failure detections
+{namespace="cluster-readiness-engine"} |= "HardwareFailed"
+```
+
+If you switch the manager to JSON logs with `--zap-encoder=json`, you can filter on fields like `controller`, `name`, and `reconcileID` directly in your log backend.
+
+## Recommended alerts
+
+Production GPU fleets require alerting across three dimensions: **hardware failures** (GPU faults, NVLink errors, ECC violations detected during workloads), **performance regressions** (bandwidth or goodput falling below expected thresholds), and **operational health** (controller reconciliation latency, error rates). The starter rules below cover all three.
+
+```yaml
+groups:
+  - name: cluster-readiness-engine
+    rules:
+      - alert: CREHardwareFailure
+        expr: cre_job_failed_nodes > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Hardware failure in job {{ $labels.job }}"
+          description: "{{ $value }} node(s) failed in {{ $labels.namespace }}/{{ $labels.job }}."
+
+      - alert: CREJobStuck
+        expr: cre_job_status{status="in_progress"} == 1
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Job {{ $labels.job }} stuck in progress"
+          description: "Job has been in_progress for over 6 hours."
+
+      - alert: CRELowGoodput
+        expr: cre_goodput_ratio > 0 and cre_goodput_ratio < 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low goodput for {{ $labels.measurement }}"
+          description: "Goodput ratio is {{ $value | humanizePercentage }}."
+
+      - alert: CREHighReconcileLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(cre_reconcile_duration_seconds_bucket[5m]))
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciliation P95 latency above 5s"
+
+      - alert: CREReconcileErrors
+        expr: |
+          sum(rate(cre_reconcile_total{result="error"}[5m]))
+          / sum(rate(cre_reconcile_total[5m])) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciliation error rate above 10%"
+```
+
+**Tune alert thresholds:** the `for` durations and thresholds above are starting points. Adjust them based on your workload profiles — long-running multi-day training jobs will need a longer `CREJobStuck` threshold.
+
+## Next steps
+
+- [Metrics Reference](./metrics.md) — Full list of metrics with labels and PromQL examples.
+- [Troubleshooting](./troubleshooting.md) — Diagnose issues using logs and metrics.
+- [Deployment](./deployment.md) — Resource sizing and health-check configuration.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,198 @@
+---
+title: Troubleshooting
+description: Diagnose and resolve common issues — stuck jobs, hardware detection failures, and stalls.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+
+This page is for operators who need to diagnose problems with the Cluster Readiness Engine (CRE). Each section follows a problem-solution format: symptoms, diagnostic commands, and fixes.
+
+## Job not progressing
+
+**Symptoms:** Job stays in `InProgress` for longer than expected. No `Succeeded` or `Failed` condition appears.
+
+**Diagnosis:**
+
+```bash
+# Check the Job conditions
+kubectl describe jobs.cre.nvidia.com <name> -n <namespace>
+
+# Check the underlying workload (use the kind from status.workloadRef)
+kubectl get trainjob -n <namespace>
+kubectl get pods -l cre.nvidia.com/job=<name> -n <namespace> -o wide
+
+# Check controller logs for this job
+kubectl logs -n cluster-readiness-engine deploy/cluster-readiness-engine-manager \
+  | grep <name>
+```
+
+**Solutions:**
+
+- The workload resource exists but is not completing — check Kubeflow Trainer logs and pod events.
+- Pods are `Pending` — verify GPU resources are available on target nodes (`kubectl describe node <node>`).
+- Kubeflow Trainer is not running — confirm its pods are healthy (`kubectl get pods -n kubeflow-system`).
+
+## Workflow stuck without a Job
+
+**Symptoms:** Workflow condition is `InProgress`, but no child Job appears.
+
+**Diagnosis:**
+
+```bash
+# Check Workflow status and conditions
+kubectl get workflows.cre.nvidia.com <name> -o yaml
+
+# Look for the child Job
+kubectl get jobs.cre.nvidia.com -l cre.nvidia.com/workflow=<name>
+
+# Check if dependencies were created
+kubectl get workflows.cre.nvidia.com <name> \
+  -o jsonpath='{.status.dependencyRefs}' | jq .
+```
+
+**Solutions:**
+
+- Dependency creation failed — check controller logs for RBAC errors when creating ConfigMaps, PVCs, or other dependency resources.
+- Target nodes do not match — verify the Workflow's `nodeSelector` or `nodeNames` matches existing nodes (`kubectl get nodes -l <selector>`).
+- The Workflow spec is invalid — look for validation errors in the controller logs.
+
+## Hardware failures not detected
+
+**Symptoms:** A node has a known hardware problem, but the Job does not report the `HardwareFailed` condition.
+
+**Diagnosis:**
+
+```bash
+# Verify pods are running on the expected nodes
+kubectl get pods -l cre.nvidia.com/job=<name> -o wide
+
+# Check that the pod label was injected
+kubectl get pods -l cre.nvidia.com/job=<name> --show-labels
+
+# Inspect the node for the expected conditions/taints
+kubectl get node <node> -o yaml
+
+# Check controller logs for CEL evaluation errors
+kubectl logs -n cluster-readiness-engine deploy/cluster-readiness-engine-manager \
+  | grep "CEL"
+```
+
+**Solutions:**
+
+- The CEL expression has a syntax error — look for parse errors in controller logs. Test your expression against a node object.
+- Pods are not scheduled on target nodes — the controller only evaluates nodes where Job pods are running. Verify pod placement.
+- The pod label is missing — the controller injects `cre.nvidia.com/job` automatically. If pods were created before the controller started, they may lack the label.
+- Node conditions or taints do not exist yet — CRE only reads node state; it relies on your cluster's health monitoring stack to set the conditions or taints your CEL expression checks. Verify with `kubectl describe node`.
+
+## High reconciliation latency
+
+**Symptoms:** Status updates are slow. The `cre_reconcile_duration_seconds` P95 is above 5 seconds.
+
+**Diagnosis:**
+
+```bash
+# Check controller resource usage
+kubectl top pod -n cluster-readiness-engine
+
+# Check for API server throttling (429 responses)
+kubectl logs -n cluster-readiness-engine deploy/cluster-readiness-engine-manager \
+  | grep "throttling"
+```
+
+**Solutions:**
+
+- Controller is resource-constrained — increase CPU and memory limits. See the [Deployment](./deployment.md) page for sizing guidance.
+- Too many nodes per health check — large clusters increase CEL evaluation time. Consider splitting workloads across fewer nodes.
+- API server is under load — check API server metrics and reduce concurrent reconciles if needed.
+
+## Certification not progressing
+
+**Symptoms:** Certification stays `InProgress` after Workflows have finished.
+
+**Diagnosis:**
+
+```bash
+# Check category statuses
+kubectl get certifications.cre.nvidia.com <name> \
+  -o jsonpath='{.status.categoryStatuses}' | jq .
+
+# List child Workflows
+kubectl get workflows.cre.nvidia.com -l cre.nvidia.com/certification=<name>
+
+# Check for CategoryNotFound errors
+kubectl logs -n cluster-readiness-engine deploy/cluster-readiness-engine-manager \
+  | grep "CategoryNotFound"
+```
+
+**Solutions:**
+
+- A category is not registered in the catalog — the controller sets the Certification to `Failed` with reason `CategoryNotFound`. Verify your domain and variant values against `ncrectl certification list-categories`.
+- A child Workflow is still running — the Certification waits for all Workflows to complete before transitioning.
+
+## Stall detection not triggering
+
+**Symptoms:** A Job appears stuck but is not marked `Failed` with reason `WorkloadStalled`.
+
+**Diagnosis:**
+
+```bash
+# Verify stallMultiplier is set on the Job
+kubectl get jobs.cre.nvidia.com <name> -o jsonpath='{.spec.stallMultiplier}'
+
+# Check if a GoodputMeasurement exists and has step data
+kubectl get goodputmeasurement -l cre.nvidia.com/job=<name> -o yaml
+
+# Look for avgStepTimeSec and lastStepTimestamp
+kubectl get goodputmeasurement -l cre.nvidia.com/job=<name> \
+  -o jsonpath='{.items[0].status.avgStepTimeSec}'
+```
+
+**Solutions:**
+
+- `stallMultiplier` is not set — stall detection is opt-in. Add `stallMultiplier` to the Job spec (e.g., `10` means stalled if no step for 10x average step time).
+- No GoodputMeasurement exists — stall detection requires a GoodputMeasurement to provide `avgStepTimeSec` and `lastStepTimestamp`. Configure `goodputMeasurement` on the Job.
+- Not enough training steps — the controller needs at least two non-warmup steps to compute `avgStepTimeSec`. Wait for the workload to produce more log output.
+
+## BandwidthMeasurement not reporting results
+
+**Symptoms:** A BandwidthMeasurement exists but `status.results` is empty.
+
+**Diagnosis:**
+
+```bash
+# Check the BandwidthMeasurement status
+kubectl get bandwidthmeasurement <name> -o yaml
+
+# Verify the LogProfile has a bandwidthResult pattern
+kubectl get logprofile <profile-name> -o jsonpath='{.spec.patterns.bandwidthResult}'
+
+# Check pod logs for NCCL output
+kubectl logs <pod-name> | head -50
+```
+
+**Solutions:**
+
+- The LogProfile is missing the `bandwidthResult` pattern — BandwidthMeasurement requires a LogProfile with a `bandwidthResult` regex. Add it to the LogProfile spec.
+- The regex does not match the NCCL output format — verify the regex against actual log output. NCCL test output format varies between versions.
+- The workload has not produced output yet — bandwidth results appear only after the NCCL test completes its message-size sweep.
+- The `replicatedJobName` is wrong — for MPI workloads, set `workerStrategy.replicatedJobName: launcher` in the LogProfile since NCCL output goes to the launcher pod.
+
+## Enable debug logging
+
+For deeper investigation, enable debug-level logging by adding the flag to the manager container args:
+
+```yaml
+# In the Deployment spec
+args:
+  - --zap-log-level=1
+```
+
+This surfaces detailed reconciliation traces and CEL evaluation results.
+
+## Next steps
+
+- [Monitoring](./monitoring.md) — Set up alerts so you catch issues before they need manual diagnosis.
+- [Deployment](./deployment.md) — Review resource sizing and RBAC.
+- [Health Monitoring & Failed Node Attribution](../concepts/health-monitoring-remediation.md) — Understand how CEL-based hardware detection works.
+- [Certify a Cluster](../how-to-guides/certify-a-cluster.md) — End-to-end certification walkthrough.


### PR DESCRIPTION
## Summary

- Fix `mpirunPath` to `/usr/local/mpi/bin/mpirun` in the README WorkloadRun example, `workloadrun-quick-start.md`, `nccl-benchmarks.md`, and the WorkloadRun API reference — the value the catalog uses for `nvcr.io/nvidia/pytorch:26.01-py3` (`pkg/catalog/entries/communication/nccl-all-reduce.yaml:163`); the old path exits 127
- Add the ghcr.io `helm registry login` step before the manual Helm install commands (they 401 without it while the repo is internal)
- Document `numNodes` as nodes per job group in the README: the orchestrator partitions all eligible nodes into groups of this size, so `numNodes: 4` on 16 nodes runs four 4-node jobs
- Fix all 10 broken relative references: rename `061-excalibur-nvsentinel-remediation-decoupling.md` → `061-cre-nvsentinel-remediation-decoupling.md`, repoint catalog fragment links to `gb300-roce-torch.yaml` and `togetherai-ib-env.yaml`, unlink two internal-era ADRs (006, 011) that predate the public repo
- Add Nemotron 5 and DeepSeek-V3 WorkloadRun quickstarts (`docs/how-to-guides/`)
- Add an Operations section: deployment, monitoring, Prometheus metrics, troubleshooting, FAQ — including exactly what `setup reset` / `helm uninstall` retain and the cleanup commands
- Add `api-reference/validation-results.md` documenting the results JSON (fields from `pkg/report/report.go` json tags)
- Document `WorkloadRun.spec.gangScheduler` (`schedulerName`, `queue`) in the run-workloadrun guide and API reference
- Retitle the README WorkloadRun section to "Run a workload" and link the NCCL benchmarks guide and both training quickstarts
- Register all new pages in `docs/index.yml`

Every changed value was checked against code before editing (CLI flags against `ncrectl --help` built from this branch, YAML fields against `api/v1alpha1` json tags, metric names against `pkg/controller/metrics.go`). Relative-link sweep over docs/ + README returns 0 broken links.

## Type of Change
- [x] 📚 Documentation

## Component(s) Affected
- [x] Documentation / CI

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

Related: #175, #181
