### PR TITLE
feat(cli): add progress heartbeat to workloadrun run --wait

### DIFF
--- a/pkg/workloadrun/testdata/watch-line/failed-carries-mirrored-workflow-failure/expected.txt
+++ b/pkg/workloadrun/testdata/watch-line/failed-carries-mirrored-workflow-failure/expected.txt
@@ -1,0 +1,1 @@
+[watch] wr-torch: Failed (12m5s) — Job wr-torch-workflow-job failed: launcher pod exited with code 1

--- a/pkg/workloadrun/testdata/watch-line/failed-carries-mirrored-workflow-failure/input.yaml
+++ b/pkg/workloadrun/testdata/watch-line/failed-carries-mirrored-workflow-failure/input.yaml
@@ -1,0 +1,19 @@
+# The controller mirrors the Workflow failure message onto the Failed
+# condition, so the watch line surfaces the underlying failure without any
+# extra status plumbing. InProgress is False (Superseded), so the phase scan
+# must skip it and pick Failed.
+name: wr-torch
+elapsed: 12m5s
+run:
+  status:
+    conditions:
+      - type: InProgress
+        status: "False"
+        reason: Superseded
+      - type: Failed
+        status: "True"
+        reason: WorkflowFailed
+        message: 'Job wr-torch-workflow-job failed: launcher pod exited with code 1'
+      - type: Succeeded
+        status: "False"
+        reason: Superseded

--- a/pkg/workloadrun/testdata/watch-line/in-progress-appends-workflow-message/expected.txt
+++ b/pkg/workloadrun/testdata/watch-line/in-progress-appends-workflow-message/expected.txt
@@ -1,0 +1,1 @@
+[watch] wr-torch: InProgress (1m30s) — Workflow wr-torch-workflow created

--- a/pkg/workloadrun/testdata/watch-line/in-progress-appends-workflow-message/input.yaml
+++ b/pkg/workloadrun/testdata/watch-line/in-progress-appends-workflow-message/input.yaml
@@ -1,0 +1,18 @@
+# The ordinary heartbeat while the run executes. The InProgress condition
+# message carries the underlying Workflow name, which is the only Workflow
+# state mirrored onto the WorkloadRun before a terminal condition.
+name: wr-torch
+elapsed: 1m30s
+run:
+  status:
+    conditions:
+      - type: InProgress
+        status: "True"
+        reason: WorkflowCreated
+        message: Workflow wr-torch-workflow created
+      - type: Succeeded
+        status: "False"
+        reason: Superseded
+      - type: Failed
+        status: "False"
+        reason: Superseded

--- a/pkg/workloadrun/testdata/watch-line/no-conditions-yet/expected.txt
+++ b/pkg/workloadrun/testdata/watch-line/no-conditions-yet/expected.txt
@@ -1,0 +1,1 @@
+[watch] Waiting for status... (15s)

--- a/pkg/workloadrun/testdata/watch-line/no-conditions-yet/input.yaml
+++ b/pkg/workloadrun/testdata/watch-line/no-conditions-yet/input.yaml
@@ -1,0 +1,6 @@
+# Before the controller has set any execution condition (or before the first
+# successful Get), the line reports that status is still pending. The run name
+# is deliberately absent from the output because nothing is known about it yet.
+name: wr-torch
+elapsed: 15s
+run: {}

--- a/pkg/workloadrun/testdata/watch-line/succeeded-without-message-omits-suffix/expected.txt
+++ b/pkg/workloadrun/testdata/watch-line/succeeded-without-message-omits-suffix/expected.txt
@@ -1,0 +1,1 @@
+[watch] wr-torch: Succeeded (8m0s)

--- a/pkg/workloadrun/testdata/watch-line/succeeded-without-message-omits-suffix/input.yaml
+++ b/pkg/workloadrun/testdata/watch-line/succeeded-without-message-omits-suffix/input.yaml
@@ -1,0 +1,9 @@
+# A condition with an empty message must not leave a dangling separator.
+name: wr-torch
+elapsed: 8m0s
+run:
+  status:
+    conditions:
+      - type: Succeeded
+        status: "True"
+        reason: WorkflowSucceeded

--- a/pkg/workloadrun/watch_line_test.go
+++ b/pkg/workloadrun/watch_line_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadrun
+
+import (
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// workloadRunWatchLine formats the "[watch]" heartbeat that "ncrectl
+// workloadrun run --wait" prints while polling. These cases pin the line
+// format: which phase is picked from the execution conditions, when the
+// condition message is appended, and the pending line before the controller
+// has set any condition. Elapsed time is a fixed input, never wall clock.
+func TestWorkloadRunWatchLine(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "watch-line",
+		ExpectedSuffix: ".txt",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		// json tags, not yaml: sigs.k8s.io/yaml converts YAML to JSON and
+		// encoding/json ignores yaml tags, silently zeroing mistyped keys.
+		var input struct {
+			Name    string                  `json:"name"`
+			Elapsed string                  `json:"elapsed"`
+			Run     crev1alpha1.WorkloadRun `json:"run"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+		elapsed, err := time.ParseDuration(input.Elapsed)
+		if err != nil {
+			return err
+		}
+
+		tc.Actual = workloadRunWatchLine(&input.Run, input.Name, elapsed) + "\n"
+		return nil
+	})
+}

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -821,13 +821,22 @@ func runWorkloadRunExecute(
 }
 
 // watchWorkloadRun polls until the WorkloadRun reaches a terminal state.
+// It prints a "[watch]" line on every phase change and a periodic heartbeat
+// (same format and interval as the certification watch) so long runs show
+// progress instead of going silent until the terminal condition.
 func watchWorkloadRun(
 	ctx context.Context, c client.WithWatch,
-	name, namespace string, timeout time.Duration, _ io.Writer,
+	name, namespace string, timeout time.Duration, out io.Writer,
 ) (*crev1alpha1.WorkloadRun, error) {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	start := time.Now()
+	lastPhase := ""
+	var current crev1alpha1.WorkloadRun
 
 	for {
 		select {
@@ -835,21 +844,62 @@ func watchWorkloadRun(
 			return nil, fmt.Errorf("interrupted")
 		case <-deadline:
 			return nil, fmt.Errorf("timeout waiting for WorkloadRun %s", name)
+		case <-heartbeat.C:
+			elapsed := time.Since(start).Truncate(time.Second)
+			_, _ = fmt.Fprintln(out, workloadRunWatchLine(&current, name, elapsed))
 		case <-ticker.C:
-			var current crev1alpha1.WorkloadRun
 			key := client.ObjectKey{Name: name, Namespace: namespace}
 			if err := c.Get(ctx, key, &current); err != nil {
 				continue
 			}
+			elapsed := time.Since(start).Truncate(time.Second)
 			if controller.CondIsTrue(current.Status.Conditions, crev1alpha1.WorkloadRunSucceeded) {
+				_, _ = fmt.Fprintf(out, "[watch] WorkloadRun succeeded. (%s)\n", elapsed)
 				return &current, nil
 			}
 			if controller.CondIsTrue(current.Status.Conditions, crev1alpha1.WorkloadRunFailed) {
+				_, _ = fmt.Fprintf(out, "[watch] WorkloadRun failed. (%s)\n", elapsed)
 				msg := controller.CondMessage(current.Status.Conditions, crev1alpha1.WorkloadRunFailed)
 				return &current, fmt.Errorf("WorkloadRun failed: %s", msg)
 			}
+			if phase := workloadRunPhase(&current); phase != lastPhase {
+				_, _ = fmt.Fprintln(out, workloadRunWatchLine(&current, name, elapsed))
+				lastPhase = phase
+			}
 		}
 	}
+}
+
+// workloadRunPhase returns which execution condition (InProgress, Succeeded,
+// Failed) is currently true, or "" when the controller has not set one yet.
+func workloadRunPhase(run *crev1alpha1.WorkloadRun) string {
+	for _, t := range []string{
+		crev1alpha1.WorkloadRunInProgress,
+		crev1alpha1.WorkloadRunSucceeded,
+		crev1alpha1.WorkloadRunFailed,
+	} {
+		if controller.CondIsTrue(run.Status.Conditions, t) {
+			return t
+		}
+	}
+	return ""
+}
+
+// workloadRunWatchLine formats one "[watch]" progress line, matching the
+// certification watch format. It shows the current phase, its condition
+// message (which carries the underlying Workflow state, e.g. "Workflow
+// <name> created"), and elapsed time. Before the controller sets any
+// execution condition it reports that status is still pending.
+func workloadRunWatchLine(run *crev1alpha1.WorkloadRun, name string, elapsed time.Duration) string {
+	phase := workloadRunPhase(run)
+	if phase == "" {
+		return fmt.Sprintf("[watch] Waiting for status... (%s)", elapsed)
+	}
+	line := fmt.Sprintf("[watch] %s: %s (%s)", name, phase, elapsed)
+	if msg := controller.CondMessage(run.Status.Conditions, phase); msg != "" {
+		line += " — " + msg
+	}
+	return line
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- `workloadrun run --wait` printed "Waiting for completion..." and then nothing until the terminal report — 6–8 minutes of silence while Kubernetes had already surfaced the launcher failure
- `watchWorkloadRun` now emits the same `[watch] <name>: <phase> (<elapsed>)` lines certification uses: a phase-change line when the run enters InProgress (with the mirrored Workflow message), a 15-second heartbeat, and a terminal line before returning
- Heartbeat reads the last-polled object, so it can never show a terminal phase (terminal polls return immediately)
- Known limitation: the message is static during InProgress because WorkloadRunStatus mirrors no intermediate Job state — richer progress needs controller plumbing, out of scope here

## Type of Change
- [x] ✨ New feature

## Component(s) Affected
- [x] CLI (ncrectl)

## Testing
- [x] Tests pass locally (4 golden cases under `pkg/workloadrun/testdata/watch-line/`)
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

Fixes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced workload monitoring with clear progress updates while runs are pending or in progress.
  - Displays workflow names, execution phases, condition details, and periodic status updates.
  - Includes elapsed time in completed success and failure messages.
- **Bug Fixes**
  - Improved failed-run output by showing mirrored workflow failure details and exit codes.
  - Prevented unnecessary trailing separators when success messages have no additional details.
- **Tests**
  - Added coverage for pending, in-progress, successful, and failed workload watch output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->