### PR TITLE
fix(setup): surface Helm release health in setup status

### DIFF
--- a/docs/cli-reference/setup.md
+++ b/docs/cli-reference/setup.md
@@ -58,6 +58,8 @@ ncrectl setup status [flags]
 
 Components checked: `creCRDs`, `creController`, `kubeflowTrainer`, `logProfiles`, `gpuOperator`, `dcgm` (optional).
 
+The Helm releases managed by `setup init` (`cluster-readiness-engine` and `kubeflow-trainer`) are also checked via the helm CLI and reported under `helmReleases`. A release in a failed or pending state (e.g. `failed`, `pending-upgrade`) makes the status not ready. A release helm has no record of, or that cannot be queried (helm not in PATH), is reported but does not affect readiness.
+
 ### Flags
 
 | Flag | Default | Description |

--- a/pkg/setup/helm.go
+++ b/pkg/setup/helm.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -214,6 +215,65 @@ func uninstallTrainerHelmRelease(kubeconfig, kubeContext string, out io.Writer) 
 		_, _ = fmt.Fprintf(out, "[deps] Warning: failed to uninstall %s: %v\n", trainerReleaseName, err)
 	}
 	return nil
+}
+
+// Helm release states as reported by `helm status`, plus two sentinel values
+// for states the helm CLI cannot report: a release helm has no record of, and
+// a query that could not be completed (helm missing from PATH, cluster
+// unreachable). Neither sentinel blocks readiness, because CRE may have been
+// installed without Helm and `setup status` must still work without the CLI.
+const (
+	helmStateDeployed     = "deployed"
+	helmStateUninstalled  = "uninstalled"
+	helmStateNotInstalled = "not installed"
+	helmStateUnknown      = "unknown"
+)
+
+// helmStateFunc returns the state of a Helm release in a namespace. Tests
+// substitute a stub; production code uses newHelmStateQuery.
+type helmStateFunc func(release, namespace string) string
+
+// newHelmStateQuery returns a helmStateFunc backed by the helm CLI. When helm
+// is not in PATH every release reads as unknown, so the status command keeps
+// working instead of failing outright.
+func newHelmStateQuery(kubeconfig, kubeContext string) helmStateFunc {
+	helmPath, err := ensureHelm()
+	if err != nil {
+		return func(string, string) string { return helmStateUnknown }
+	}
+	return func(release, namespace string) string {
+		return helmReleaseState(helmPath, release, namespace, kubeconfig, kubeContext)
+	}
+}
+
+// helmReleaseState runs `helm status <release> -o json` and returns the
+// release state (e.g. "deployed", "failed", "pending-upgrade"). A release
+// helm has no record of reads as not installed; any other failure reads as
+// unknown.
+func helmReleaseState(helmPath, release, namespace, kubeconfig, kubeContext string) string {
+	args := []string{"status", release, "--namespace", namespace, "-o", "json"}
+	args = appendKubeconfigArgs(args, kubeconfig, kubeContext)
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(helmPath, args...) // #nosec G204 -- helmPath and args come from this CLI, not from untrusted input
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if strings.Contains(stderr.String(), "release: not found") {
+			return helmStateNotInstalled
+		}
+		return helmStateUnknown
+	}
+
+	var status struct {
+		Info struct {
+			Status string `json:"status"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil || status.Info.Status == "" {
+		return helmStateUnknown
+	}
+	return status.Info.Status
 }
 
 // runHelm executes a helm subcommand, printing output only on failure.

--- a/pkg/setup/status.go
+++ b/pkg/setup/status.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"text/tabwriter"
 
@@ -28,14 +29,27 @@ const (
 
 // SetupStatus is the JSON output structure for ncrectl setup status.
 type SetupStatus struct {
-	// Installed is true when all required components are present and ready.
+	// Installed is true when all required components are present and ready
+	// and no managed Helm release is in a failed or pending state.
 	Installed  bool                  `json:"installed"`
 	Components SetupStatusComponents `json:"components"`
+	// HelmReleases reports the state of the Helm releases setup init manages.
+	HelmReleases []HelmReleaseStatus `json:"helmReleases"`
 
 	// dcgmAbsent is true only when the API server answered that the service
 	// does not exist. A denied or failed lookup leaves it false, so the
 	// command does not tell the user to enable a service that may be there.
 	dcgmAbsent bool
+}
+
+// HelmReleaseStatus reports the Helm state of one managed release.
+type HelmReleaseStatus struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// State is the release state helm reports ("deployed", "failed",
+	// "pending-upgrade", ...), "not installed" when helm has no record of
+	// the release, or "unknown" when the query could not be completed.
+	State string `json:"state"`
 }
 
 // SetupStatusComponents reports the status of each individual component.
@@ -48,6 +62,16 @@ type SetupStatusComponents struct {
 	// DCGM is optional. Only the diagnostics/dcgm-level4 category needs it,
 	// so it does not count toward Installed.
 	DCGM bool `json:"dcgm"`
+}
+
+// allRequired reports whether every required component is present, ignoring
+// Helm release health. DCGM is optional and does not count.
+func (c SetupStatusComponents) allRequired() bool {
+	return c.CRECRDs &&
+		c.CREController &&
+		c.KubeflowTrainer &&
+		c.LogProfiles &&
+		c.GPUOperator
 }
 
 func newSetupStatusCommand() *cobra.Command {
@@ -69,8 +93,13 @@ Components checked:
   gpuOperator          NVIDIA GPU Operator (nodes with nvidia.com/gpu.present=true)
   dcgm                 NVIDIA DCGM service (optional; diagnostics/dcgm-level4 only)
 
-'installed' is true only when all required components are present. DCGM is
-optional, so it does not affect 'installed'.`,
+The Helm releases managed by 'setup init' (cluster-readiness-engine and
+kubeflow-trainer) are also checked via the helm CLI.
+
+'installed' is true only when all required components are present and no
+managed Helm release is in a failed or pending state. DCGM is optional, so it
+does not affect 'installed'. A release helm has no record of, or that cannot
+be queried (helm not in PATH), does not affect 'installed' either.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			c, err := newSetupClient(configFlags)
@@ -78,7 +107,8 @@ optional, so it does not affect 'installed'.`,
 				return fmt.Errorf("connect to cluster: %w", err)
 			}
 
-			status := collectSetupStatus(ctx, c)
+			query := newHelmStateQuery(*configFlags.KubeConfig, *configFlags.Context)
+			status := collectSetupStatus(ctx, c, query)
 
 			switch output {
 			case outputJSON:
@@ -86,7 +116,7 @@ optional, so it does not affect 'installed'.`,
 				enc.SetIndent("", "  ")
 				return enc.Encode(status)
 			default:
-				printSetupStatus(status)
+				printSetupStatus(os.Stdout, status)
 				return nil
 			}
 		},
@@ -98,8 +128,9 @@ optional, so it does not affect 'installed'.`,
 	return cmd
 }
 
-// collectSetupStatus queries the cluster and returns the current component status.
-func collectSetupStatus(ctx context.Context, c client.Client) *SetupStatus {
+// collectSetupStatus queries the cluster and the helm CLI and returns the
+// current component and release status.
+func collectSetupStatus(ctx context.Context, c client.Client, query helmStateFunc) *SetupStatus {
 	comp := SetupStatusComponents{}
 
 	comp.CRECRDs = checkCRECRDs(ctx, c)
@@ -111,15 +142,54 @@ func collectSetupStatus(ctx context.Context, c client.Client) *SetupStatus {
 	dcgmErr := checkDCGM(ctx, c)
 	comp.DCGM = dcgmErr == nil
 
+	releases := checkHelmReleases(query)
+
 	return &SetupStatus{
-		Installed: comp.CRECRDs &&
-			comp.CREController &&
-			comp.KubeflowTrainer &&
-			comp.LogProfiles &&
-			comp.GPUOperator,
-		Components: comp,
-		dcgmAbsent: apierrors.IsNotFound(dcgmErr),
+		Installed:    comp.allRequired() && len(unhealthyHelmReleases(releases)) == 0,
+		Components:   comp,
+		HelmReleases: releases,
+		dcgmAbsent:   apierrors.IsNotFound(dcgmErr),
 	}
+}
+
+// checkHelmReleases queries the state of every Helm release setup init manages.
+func checkHelmReleases(query helmStateFunc) []HelmReleaseStatus {
+	managed := []struct{ name, namespace string }{
+		{helmReleaseName, creNamespace},
+		{trainerReleaseName, trainerNamespace},
+	}
+	releases := make([]HelmReleaseStatus, 0, len(managed))
+	for _, rel := range managed {
+		releases = append(releases, HelmReleaseStatus{
+			Name:      rel.name,
+			Namespace: rel.namespace,
+			State:     query(rel.name, rel.namespace),
+		})
+	}
+	return releases
+}
+
+// helmStateBlocksReady reports whether a release state must block readiness.
+// Failed and pending states block. Deployed does not. Absent and unknown
+// states do not block either: CRE may have been installed without Helm, and
+// a missing helm binary must not fail the status command.
+func helmStateBlocksReady(state string) bool {
+	switch state {
+	case helmStateDeployed, helmStateUninstalled, helmStateNotInstalled, helmStateUnknown:
+		return false
+	}
+	return true
+}
+
+// unhealthyHelmReleases returns the releases whose state blocks readiness.
+func unhealthyHelmReleases(releases []HelmReleaseStatus) []HelmReleaseStatus {
+	var unhealthy []HelmReleaseStatus
+	for _, rel := range releases {
+		if helmStateBlocksReady(rel.State) {
+			unhealthy = append(unhealthy, rel)
+		}
+	}
+	return unhealthy
 }
 
 // checkCRECRDs returns true if CRE CRDs are installed.
@@ -213,7 +283,7 @@ func checkDCGM(ctx context.Context, c client.Client) error {
 }
 
 // printSetupStatus renders a human-readable table.
-func printSetupStatus(s *SetupStatus) {
+func printSetupStatus(out io.Writer, s *SetupStatus) {
 	check := func(ok bool) string {
 		if ok {
 			return "✓"
@@ -227,7 +297,7 @@ func printSetupStatus(s *SetupStatus) {
 		return "not found"
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 	_, _ = fmt.Fprintln(w, "Component\tStatus")
 	_, _ = fmt.Fprintln(w, "─────────────────────────\t──────────")
 	_, _ = fmt.Fprintf(w, "CRE CRDs\t%s %s\n", check(s.Components.CRECRDs), status(s.Components.CRECRDs))
@@ -238,24 +308,37 @@ func printSetupStatus(s *SetupStatus) {
 	_, _ = fmt.Fprintf(w, "Log Profiles\t%s %s\n", check(s.Components.LogProfiles), status(s.Components.LogProfiles))
 	_, _ = fmt.Fprintf(w, "GPU Operator\t%s %s\n", check(s.Components.GPUOperator), status(s.Components.GPUOperator))
 	_, _ = fmt.Fprintf(w, "DCGM (optional)\t%s %s\n", check(s.Components.DCGM), status(s.Components.DCGM))
+	for _, rel := range s.HelmReleases {
+		_, _ = fmt.Fprintf(w, "Helm release %s\t%s %s\n",
+			rel.Name, check(!helmStateBlocksReady(rel.State)), rel.State)
+	}
 	_ = w.Flush()
 
-	fmt.Println()
-	if s.Installed {
-		fmt.Println("Status: ready")
-	} else {
-		fmt.Println("Status: not ready — run 'ncrectl setup init' to install missing components")
+	_, _ = fmt.Fprintln(out)
+	unhealthy := unhealthyHelmReleases(s.HelmReleases)
+	switch {
+	case s.Installed:
+		_, _ = fmt.Fprintln(out, "Status: ready")
+	case !s.Components.allRequired():
+		_, _ = fmt.Fprintln(out, "Status: not ready — run 'ncrectl setup init' to install missing components")
 		if !s.Components.GPUOperator {
-			fmt.Println("  GPU Operator must be installed by your cluster administrator")
+			_, _ = fmt.Fprintln(out, "  GPU Operator must be installed by your cluster administrator")
 		}
+	default:
+		_, _ = fmt.Fprintln(out, "Status: not ready — a managed Helm release is unhealthy")
+	}
+	for _, rel := range unhealthy {
+		_, _ = fmt.Fprintf(out,
+			"  Helm release %s (namespace: %s) is %s — run 'ncrectl setup init' to repair it\n",
+			rel.Name, rel.Namespace, rel.State)
 	}
 
 	if s.dcgmAbsent {
-		fmt.Println()
-		fmt.Printf("Note: service %s/%s is missing. Only the diagnostics/dcgm-level4\n",
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintf(out, "Note: service %s/%s is missing. Only the diagnostics/dcgm-level4\n",
 			dcgmServiceNamespace, dcgmServiceName)
-		fmt.Println("      category needs it. Your cluster administrator can add it with:")
-		fmt.Println(`      kubectl patch clusterpolicy cluster-policy --type=merge \`)
-		fmt.Println(`        -p '{"spec":{"dcgm":{"enabled":true}}}'`)
+		_, _ = fmt.Fprintln(out, "      category needs it. Your cluster administrator can add it with:")
+		_, _ = fmt.Fprintln(out, `      kubectl patch clusterpolicy cluster-policy --type=merge \`)
+		_, _ = fmt.Fprintln(out, `        -p '{"spec":{"dcgm":{"enabled":true}}}'`)
 	}
 }

--- a/pkg/setup/status_test.go
+++ b/pkg/setup/status_test.go
@@ -4,10 +4,13 @@
 package setup
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 func newSetupScheme(t *testing.T) *runtime.Scheme {
@@ -73,7 +77,7 @@ func TestCheckDCGM(t *testing.T) {
 	})
 
 	t.Run("a denied lookup is not reported as absent", func(t *testing.T) {
-		status := collectSetupStatus(context.Background(), forbiddenServiceClient(t))
+		status := collectSetupStatus(context.Background(), forbiddenServiceClient(t), allDeployedHelmQuery)
 		assert.False(t, status.Components.DCGM)
 		assert.False(t, status.dcgmAbsent, "a denied lookup must not print the patch command")
 	})
@@ -145,7 +149,7 @@ func TestCollectSetupStatusDCGMIsOptional(t *testing.T) {
 
 	t.Run("ready without dcgm", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).WithObjects(objs...).Build()
-		s := collectSetupStatus(context.Background(), c)
+		s := collectSetupStatus(context.Background(), c, allDeployedHelmQuery)
 		assert.True(t, s.Installed, "installed must not depend on DCGM")
 		assert.False(t, s.Components.DCGM)
 	})
@@ -155,8 +159,56 @@ func TestCollectSetupStatusDCGMIsOptional(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: dcgmServiceName, Namespace: dcgmServiceNamespace},
 		})
 		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).WithObjects(withDCGM...).Build()
-		s := collectSetupStatus(context.Background(), c)
+		s := collectSetupStatus(context.Background(), c, allDeployedHelmQuery)
 		assert.True(t, s.Installed)
 		assert.True(t, s.Components.DCGM)
+	})
+}
+
+// allDeployedHelmQuery reports every managed Helm release as deployed.
+func allDeployedHelmQuery(string, string) string { return helmStateDeployed }
+
+// TestSetupStatusHelmReleases drives collectSetupStatus and printSetupStatus
+// against a ready cluster with the Helm release states given in input.yaml.
+// The golden file holds the JSON status followed by the rendered table, so a
+// failed release flipping 'installed' shows up in both output formats.
+func TestSetupStatusHelmReleases(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "setup-status-helm",
+		ExpectedSuffix: ".txt",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			// States maps a managed release name to the state the helm stub
+			// reports. A missing key reads as a release helm has no record of.
+			States map[string]string `yaml:"states"`
+		}
+		if err := sigsyaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+		query := func(release, _ string) string {
+			if state, ok := in.States[release]; ok {
+				return state
+			}
+			return helmStateNotInstalled
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(newSetupScheme(t)).
+			WithObjects(readyClusterObjects()...).
+			Build()
+		s := collectSetupStatus(context.Background(), c, query)
+
+		var out bytes.Buffer
+		enc := json.NewEncoder(&out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(s); err != nil {
+			return err
+		}
+		out.WriteString("\n")
+		printSetupStatus(&out, s)
+
+		tc.Actual = out.String()
+		return nil
 	})
 }

--- a/pkg/setup/testdata/setup-status-helm/cre-release-pending-upgrade/expected.txt
+++ b/pkg/setup/testdata/setup-status-helm/cre-release-pending-upgrade/expected.txt
@@ -1,0 +1,42 @@
+{
+  "installed": false,
+  "components": {
+    "creCRDs": true,
+    "creController": true,
+    "kubeflowTrainer": true,
+    "logProfiles": true,
+    "gpuOperator": true,
+    "dcgm": false
+  },
+  "helmReleases": [
+    {
+      "name": "cluster-readiness-engine",
+      "namespace": "cluster-readiness-engine",
+      "state": "pending-upgrade"
+    },
+    {
+      "name": "kubeflow-trainer",
+      "namespace": "kubeflow-system",
+      "state": "deployed"
+    }
+  ]
+}
+
+Component                               Status
+─────────────────────────               ──────────
+CRE CRDs                                ✓ installed
+CRE Controller                          ✓ installed
+Kubeflow Trainer                        ✓ installed
+Log Profiles                            ✓ installed
+GPU Operator                            ✓ installed
+DCGM (optional)                         ✗ not found
+Helm release cluster-readiness-engine   ✗ pending-upgrade
+Helm release kubeflow-trainer           ✓ deployed
+
+Status: not ready — a managed Helm release is unhealthy
+  Helm release cluster-readiness-engine (namespace: cluster-readiness-engine) is pending-upgrade — run 'ncrectl setup init' to repair it
+
+Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
+      category needs it. Your cluster administrator can add it with:
+      kubectl patch clusterpolicy cluster-policy --type=merge \
+        -p '{"spec":{"dcgm":{"enabled":true}}}'

--- a/pkg/setup/testdata/setup-status-helm/cre-release-pending-upgrade/input.yaml
+++ b/pkg/setup/testdata/setup-status-helm/cre-release-pending-upgrade/input.yaml
@@ -1,0 +1,5 @@
+# The CRE release is stuck in pending-upgrade (e.g. an interrupted helm
+# upgrade). Pending states block readiness the same way failed does.
+states:
+  cluster-readiness-engine: pending-upgrade
+  kubeflow-trainer: deployed

--- a/pkg/setup/testdata/setup-status-helm/helm-unavailable/expected.txt
+++ b/pkg/setup/testdata/setup-status-helm/helm-unavailable/expected.txt
@@ -1,0 +1,41 @@
+{
+  "installed": true,
+  "components": {
+    "creCRDs": true,
+    "creController": true,
+    "kubeflowTrainer": true,
+    "logProfiles": true,
+    "gpuOperator": true,
+    "dcgm": false
+  },
+  "helmReleases": [
+    {
+      "name": "cluster-readiness-engine",
+      "namespace": "cluster-readiness-engine",
+      "state": "unknown"
+    },
+    {
+      "name": "kubeflow-trainer",
+      "namespace": "kubeflow-system",
+      "state": "unknown"
+    }
+  ]
+}
+
+Component                               Status
+─────────────────────────               ──────────
+CRE CRDs                                ✓ installed
+CRE Controller                          ✓ installed
+Kubeflow Trainer                        ✓ installed
+Log Profiles                            ✓ installed
+GPU Operator                            ✓ installed
+DCGM (optional)                         ✗ not found
+Helm release cluster-readiness-engine   ✓ unknown
+Helm release kubeflow-trainer           ✓ unknown
+
+Status: ready
+
+Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
+      category needs it. Your cluster administrator can add it with:
+      kubectl patch clusterpolicy cluster-policy --type=merge \
+        -p '{"spec":{"dcgm":{"enabled":true}}}'

--- a/pkg/setup/testdata/setup-status-helm/helm-unavailable/input.yaml
+++ b/pkg/setup/testdata/setup-status-helm/helm-unavailable/input.yaml
@@ -1,0 +1,5 @@
+# The helm CLI is not in PATH, so every release state reads as unknown.
+# The unknown states are reported but do not block readiness.
+states:
+  cluster-readiness-engine: unknown
+  kubeflow-trainer: unknown

--- a/pkg/setup/testdata/setup-status-helm/ready/expected.txt
+++ b/pkg/setup/testdata/setup-status-helm/ready/expected.txt
@@ -1,0 +1,41 @@
+{
+  "installed": true,
+  "components": {
+    "creCRDs": true,
+    "creController": true,
+    "kubeflowTrainer": true,
+    "logProfiles": true,
+    "gpuOperator": true,
+    "dcgm": false
+  },
+  "helmReleases": [
+    {
+      "name": "cluster-readiness-engine",
+      "namespace": "cluster-readiness-engine",
+      "state": "deployed"
+    },
+    {
+      "name": "kubeflow-trainer",
+      "namespace": "kubeflow-system",
+      "state": "deployed"
+    }
+  ]
+}
+
+Component                               Status
+─────────────────────────               ──────────
+CRE CRDs                                ✓ installed
+CRE Controller                          ✓ installed
+Kubeflow Trainer                        ✓ installed
+Log Profiles                            ✓ installed
+GPU Operator                            ✓ installed
+DCGM (optional)                         ✗ not found
+Helm release cluster-readiness-engine   ✓ deployed
+Helm release kubeflow-trainer           ✓ deployed
+
+Status: ready
+
+Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
+      category needs it. Your cluster administrator can add it with:
+      kubectl patch clusterpolicy cluster-policy --type=merge \
+        -p '{"spec":{"dcgm":{"enabled":true}}}'

--- a/pkg/setup/testdata/setup-status-helm/ready/input.yaml
+++ b/pkg/setup/testdata/setup-status-helm/ready/input.yaml
@@ -1,0 +1,4 @@
+# Both managed releases healthy: status is ready.
+states:
+  cluster-readiness-engine: deployed
+  kubeflow-trainer: deployed

--- a/pkg/setup/testdata/setup-status-helm/release-missing/expected.txt
+++ b/pkg/setup/testdata/setup-status-helm/release-missing/expected.txt
@@ -1,0 +1,41 @@
+{
+  "installed": true,
+  "components": {
+    "creCRDs": true,
+    "creController": true,
+    "kubeflowTrainer": true,
+    "logProfiles": true,
+    "gpuOperator": true,
+    "dcgm": false
+  },
+  "helmReleases": [
+    {
+      "name": "cluster-readiness-engine",
+      "namespace": "cluster-readiness-engine",
+      "state": "deployed"
+    },
+    {
+      "name": "kubeflow-trainer",
+      "namespace": "kubeflow-system",
+      "state": "not installed"
+    }
+  ]
+}
+
+Component                               Status
+─────────────────────────               ──────────
+CRE CRDs                                ✓ installed
+CRE Controller                          ✓ installed
+Kubeflow Trainer                        ✓ installed
+Log Profiles                            ✓ installed
+GPU Operator                            ✓ installed
+DCGM (optional)                         ✗ not found
+Helm release cluster-readiness-engine   ✓ deployed
+Helm release kubeflow-trainer           ✓ not installed
+
+Status: ready
+
+Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
+      category needs it. Your cluster administrator can add it with:
+      kubectl patch clusterpolicy cluster-policy --type=merge \
+        -p '{"spec":{"dcgm":{"enabled":true}}}'

--- a/pkg/setup/testdata/setup-status-helm/release-missing/input.yaml
+++ b/pkg/setup/testdata/setup-status-helm/release-missing/input.yaml
@@ -1,0 +1,4 @@
+# Helm has no record of the kubeflow-trainer release (installed by other
+# means). The absent release is reported but does not block readiness.
+states:
+  cluster-readiness-engine: deployed

--- a/pkg/setup/testdata/setup-status-helm/trainer-release-failed/expected.txt
+++ b/pkg/setup/testdata/setup-status-helm/trainer-release-failed/expected.txt
@@ -1,0 +1,42 @@
+{
+  "installed": false,
+  "components": {
+    "creCRDs": true,
+    "creController": true,
+    "kubeflowTrainer": true,
+    "logProfiles": true,
+    "gpuOperator": true,
+    "dcgm": false
+  },
+  "helmReleases": [
+    {
+      "name": "cluster-readiness-engine",
+      "namespace": "cluster-readiness-engine",
+      "state": "deployed"
+    },
+    {
+      "name": "kubeflow-trainer",
+      "namespace": "kubeflow-system",
+      "state": "failed"
+    }
+  ]
+}
+
+Component                               Status
+─────────────────────────               ──────────
+CRE CRDs                                ✓ installed
+CRE Controller                          ✓ installed
+Kubeflow Trainer                        ✓ installed
+Log Profiles                            ✓ installed
+GPU Operator                            ✓ installed
+DCGM (optional)                         ✗ not found
+Helm release cluster-readiness-engine   ✓ deployed
+Helm release kubeflow-trainer           ✗ failed
+
+Status: not ready — a managed Helm release is unhealthy
+  Helm release kubeflow-trainer (namespace: kubeflow-system) is failed — run 'ncrectl setup init' to repair it
+
+Note: service gpu-operator/nvidia-dcgm is missing. Only the diagnostics/dcgm-level4
+      category needs it. Your cluster administrator can add it with:
+      kubectl patch clusterpolicy cluster-policy --type=merge \
+        -p '{"spec":{"dcgm":{"enabled":true}}}'

--- a/pkg/setup/testdata/setup-status-helm/trainer-release-failed/input.yaml
+++ b/pkg/setup/testdata/setup-status-helm/trainer-release-failed/input.yaml
@@ -1,0 +1,5 @@
+# The kubeflow-trainer release failed (e.g. a helm upgrade that timed out).
+# All components are present, but status must not report ready.
+states:
+  cluster-readiness-engine: deployed
+  kubeflow-trainer: failed


### PR DESCRIPTION
## Summary

- `setup status` reported `Status: ready` while the kubeflow-trainer Helm release was `failed` — it checked resource presence but never release health
- Status now queries the managed Helm releases (same helm-CLI invocation style the package already uses) and reports a failed or pending release as not ready, with the release name and state
- Helm unavailable or release absent is reported as its own state instead of erroring the command

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] CLI (ncrectl)

## Testing
- [x] Tests pass locally (5 golden cases under `pkg/setup/testdata/setup-status-helm/`: ready, trainer-release-failed, cre-release-pending-upgrade, release-missing, helm-unavailable)
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (`docs/cli-reference/setup.md`)
- [x] Ready for review

Fixes #179
