### PR TITLE
fix(setup): report retained resources after reset

### DIFF
--- a/pkg/setup/retained_test.go
+++ b/pkg/setup/retained_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// retainedTestConfig is the input_config.yaml shape for the
+// print-retained-resources golden tests.
+type retainedTestConfig struct {
+	// SkipPhases mirrors the --skip-phases flag value passed to reset.
+	SkipPhases string `json:"skipPhases"`
+	// Forbidden makes every Get fail with a Forbidden error, the way an API
+	// server does when the user may not read the resource.
+	Forbidden bool `json:"forbidden"`
+}
+
+func TestPrintRetainedResources(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "print-retained-resources",
+		ExpectedSuffix: ".txt",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var cfg retainedTestConfig
+		if raw, ok := tc.Inputs["input_config.yaml"]; ok {
+			if err := sigsyaml.Unmarshal([]byte(raw), &cfg); err != nil {
+				return err
+			}
+		}
+
+		scheme := newSetupScheme(tc.T.(*testing.T))
+		objs, _, err := tc.GetObjects(scheme)
+		if err != nil {
+			return err
+		}
+
+		builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...)
+		if cfg.Forbidden {
+			builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey,
+					obj client.Object, _ ...client.GetOption) error {
+					return apierrors.NewForbidden(
+						schema.GroupResource{}, key.Name, errors.New("denied"))
+				},
+			})
+		}
+		c := builder.Build()
+
+		var out bytes.Buffer
+		printRetainedResources(context.Background(), c, parseSkipPhases(cfg.SkipPhases), &out)
+		tc.Actual = out.String()
+		return nil
+	})
+}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -271,6 +271,9 @@ Phases:
   [helm]  CRE Helm release (CRDs, controller, LogProfiles)
   [deps]  Kubeflow Trainer ` + kubeflowTrainerVersion + `
 
+Shared namespaces and the controller pull secret are intentionally retained;
+reset prints a "Retained resources" list with the cleanup command for each.
+
 Use --skip-phases=deps to keep Kubeflow Trainer.
 Use --auto-approve to skip the confirmation prompt (for CI/automation).`,
 		Args: cobra.NoArgs,
@@ -369,6 +372,7 @@ func RunReset(
 	if err := uninstallDepsPhase(sp); err != nil {
 		return err
 	}
+	printRetainedResources(ctx, c, skip, out)
 	_, _ = fmt.Fprintln(out, "\nCRE reset successfully.")
 	return nil
 }
@@ -393,6 +397,101 @@ func uninstallDepsPhase(sp setupPhaseParams) error {
 		return fmt.Errorf("[deps] %w", err)
 	}
 	return nil
+}
+
+// retainedResource is a resource reset intentionally leaves behind, paired
+// with the kubectl command that removes it.
+type retainedResource struct {
+	description string
+	cleanup     string
+	// unverified is true when the existence check failed (e.g. RBAC denied),
+	// so the resource is reported as "may remain" instead of being hidden.
+	unverified bool
+}
+
+// printRetainedResources reports what reset intentionally keeps — the shared
+// namespaces (`helm uninstall` never deletes the release namespace, and other
+// tenants may use it) and the controller pull secret created by setup init
+// outside the Helm release — together with the kubectl command to remove
+// each. Existence is checked with the client already in hand; resources
+// confirmed absent are omitted.
+func printRetainedResources(
+	ctx context.Context, c client.Client, skip map[string]bool, out io.Writer,
+) {
+	var retained []retainedResource
+	record := func(exists bool, err error, r retainedResource) {
+		if err != nil {
+			r.unverified = true
+			retained = append(retained, r)
+			return
+		}
+		if exists {
+			retained = append(retained, r)
+		}
+	}
+
+	exists, err := namespaceExists(ctx, c, creNamespace)
+	record(exists, err, retainedResource{
+		description: "Namespace " + creNamespace,
+		cleanup:     "kubectl delete namespace " + creNamespace,
+	})
+
+	exists, err = secretExists(ctx, c, creNamespace, pullSecretName)
+	record(exists, err, retainedResource{
+		description: fmt.Sprintf("Secret %s/%s", creNamespace, pullSecretName),
+		cleanup: fmt.Sprintf("kubectl delete secret %s -n %s",
+			pullSecretName, creNamespace),
+	})
+
+	// Only mention the Trainer namespace when the deps phase actually ran;
+	// with --skip-phases=deps the kubeflow-trainer release still lives there.
+	if !skip[phaseDeps] {
+		exists, err = namespaceExists(ctx, c, trainerNamespace)
+		record(exists, err, retainedResource{
+			description: "Namespace " + trainerNamespace,
+			cleanup:     "kubectl delete namespace " + trainerNamespace,
+		})
+	}
+
+	if len(retained) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(out, "\nRetained resources (not removed by reset):")
+	for _, r := range retained {
+		if r.unverified {
+			_, _ = fmt.Fprintf(out, "  - %s (may remain; existence check failed)\n", r.description)
+		} else {
+			_, _ = fmt.Fprintf(out, "  - %s\n", r.description)
+		}
+		_, _ = fmt.Fprintf(out, "      %s\n", r.cleanup)
+	}
+}
+
+// namespaceExists reports whether the named namespace exists. NotFound is not
+// an error; any other lookup failure is returned so the caller can report the
+// resource as unverified instead of silently dropping it.
+func namespaceExists(ctx context.Context, c client.Client, name string) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, client.ObjectKey{Name: name}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// secretExists reports whether the named Secret exists, with the same error
+// semantics as namespaceExists.
+func secretExists(ctx context.Context, c client.Client, namespace, name string) (bool, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/setup/testdata/print-retained-resources/all-retained/expected.txt
+++ b/pkg/setup/testdata/print-retained-resources/all-retained/expected.txt
@@ -1,0 +1,8 @@
+
+Retained resources (not removed by reset):
+  - Namespace cluster-readiness-engine
+      kubectl delete namespace cluster-readiness-engine
+  - Secret cluster-readiness-engine/ncrectl-pull-secret
+      kubectl delete secret ncrectl-pull-secret -n cluster-readiness-engine
+  - Namespace kubeflow-system
+      kubectl delete namespace kubeflow-system

--- a/pkg/setup/testdata/print-retained-resources/all-retained/input_config.yaml
+++ b/pkg/setup/testdata/print-retained-resources/all-retained/input_config.yaml
@@ -1,0 +1,1 @@
+skipPhases: ""

--- a/pkg/setup/testdata/print-retained-resources/all-retained/input_objects.yaml
+++ b/pkg/setup/testdata/print-retained-resources/all-retained/input_objects.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-readiness-engine
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ncrectl-pull-secret
+  namespace: cluster-readiness-engine
+type: kubernetes.io/dockerconfigjson

--- a/pkg/setup/testdata/print-retained-resources/forbidden-lookup-reports-may-remain/expected.txt
+++ b/pkg/setup/testdata/print-retained-resources/forbidden-lookup-reports-may-remain/expected.txt
@@ -1,0 +1,8 @@
+
+Retained resources (not removed by reset):
+  - Namespace cluster-readiness-engine (may remain; existence check failed)
+      kubectl delete namespace cluster-readiness-engine
+  - Secret cluster-readiness-engine/ncrectl-pull-secret (may remain; existence check failed)
+      kubectl delete secret ncrectl-pull-secret -n cluster-readiness-engine
+  - Namespace kubeflow-system (may remain; existence check failed)
+      kubectl delete namespace kubeflow-system

--- a/pkg/setup/testdata/print-retained-resources/forbidden-lookup-reports-may-remain/input_config.yaml
+++ b/pkg/setup/testdata/print-retained-resources/forbidden-lookup-reports-may-remain/input_config.yaml
@@ -1,0 +1,2 @@
+skipPhases: ""
+forbidden: true

--- a/pkg/setup/testdata/print-retained-resources/nothing-retained/input_config.yaml
+++ b/pkg/setup/testdata/print-retained-resources/nothing-retained/input_config.yaml
@@ -1,0 +1,1 @@
+skipPhases: ""

--- a/pkg/setup/testdata/print-retained-resources/pull-secret-absent/expected.txt
+++ b/pkg/setup/testdata/print-retained-resources/pull-secret-absent/expected.txt
@@ -1,0 +1,6 @@
+
+Retained resources (not removed by reset):
+  - Namespace cluster-readiness-engine
+      kubectl delete namespace cluster-readiness-engine
+  - Namespace kubeflow-system
+      kubectl delete namespace kubeflow-system

--- a/pkg/setup/testdata/print-retained-resources/pull-secret-absent/input_config.yaml
+++ b/pkg/setup/testdata/print-retained-resources/pull-secret-absent/input_config.yaml
@@ -1,0 +1,1 @@
+skipPhases: ""

--- a/pkg/setup/testdata/print-retained-resources/pull-secret-absent/input_objects.yaml
+++ b/pkg/setup/testdata/print-retained-resources/pull-secret-absent/input_objects.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-readiness-engine
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-system

--- a/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/expected.txt
+++ b/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/expected.txt
@@ -1,0 +1,6 @@
+
+Retained resources (not removed by reset):
+  - Namespace cluster-readiness-engine
+      kubectl delete namespace cluster-readiness-engine
+  - Secret cluster-readiness-engine/ncrectl-pull-secret
+      kubectl delete secret ncrectl-pull-secret -n cluster-readiness-engine

--- a/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/input_config.yaml
+++ b/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/input_config.yaml
@@ -1,0 +1,1 @@
+skipPhases: deps

--- a/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/input_objects.yaml
+++ b/pkg/setup/testdata/print-retained-resources/skip-deps-omits-trainer-namespace/input_objects.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-readiness-engine
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ncrectl-pull-secret
+  namespace: cluster-readiness-engine
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
## Summary

- `setup reset` exited 0 with "CRE reset successfully" while silently retaining the `cluster-readiness-engine` namespace, `ncrectl-pull-secret`, and (unless the deps phase ran) `kubeflow-system`
- Retention is deliberate — deleting shared namespaces is risky — so the success path now prints a "Retained resources" block derived from what the code actually skips, with the one-line kubectl cleanup command for each
- Existence is checked where cheap; a failed check prints "(may remain; existence check failed)" instead of hiding the resource
- CRDs are correctly not listed: reset already deletes them explicitly (`deleteCRDsByGroup`), unlike bare `helm uninstall`
- Deletion behavior is unchanged; the operations docs (#186) carry the full cleanup procedure

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] CLI (ncrectl)

## Testing
- [x] Tests pass locally (5 golden cases under `pkg/setup/testdata/print-retained-resources/`)
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (operations docs in #186)
- [x] Ready for review

Fixes #181
