### PR TITLE
feat(cli): disambiguate duplicate categories in live watch output

### DIFF
--- a/pkg/certification/certification.go
+++ b/pkg/certification/certification.go
@@ -1044,6 +1044,29 @@ func watchCertification(
 	}
 }
 
+// categoryWatchLabels returns one display label per entry in
+// cert.Status.CategoryStatuses. Labels are "domain/variant"; when the
+// certification contains two or more categories with the same domain/variant,
+// an "(MNNVL Enabled)"/"(MNNVL Disabled)" suffix — matching the report's
+// MNNVL label — disambiguates the duplicates.
+func categoryWatchLabels(cert *crev1alpha1.Certification) []string {
+	counts := map[string]int{}
+	for _, cs := range cert.Status.CategoryStatuses {
+		counts[cs.Domain+"/"+cs.Variant]++
+	}
+	labels := make([]string, len(cert.Status.CategoryStatuses))
+	for i, cs := range cert.Status.CategoryStatuses {
+		key := cs.Domain + "/" + cs.Variant
+		if counts[key] > 1 {
+			if mnnvl := report.CategoryMNNVL(cert, i); mnnvl != "" {
+				key = fmt.Sprintf("%s (MNNVL %s)", key, mnnvl)
+			}
+		}
+		labels[i] = key
+	}
+	return labels
+}
+
 // processWatchEvents handles events from a single watch session.
 // Returns (cert, true, err) on terminal condition, or (nil, false, nil)
 // when the watch channel closes and should be reconnected.
@@ -1072,8 +1095,9 @@ func processWatchEvents(
 			elapsed := time.Since(start).Truncate(time.Second)
 
 			// Print category status changes.
-			for _, cs := range cert.Status.CategoryStatuses {
-				key := cs.Domain + "/" + cs.Variant
+			labels := categoryWatchLabels(cert)
+			for i, cs := range cert.Status.CategoryStatuses {
+				key := labels[i]
 				if cs.Status != lastStatuses[key] {
 					_, _ = fmt.Fprintf(out, "[watch] %s: %s (%s)\n",
 						key, cs.Status, elapsed)

--- a/pkg/certification/certification_test.go
+++ b/pkg/certification/certification_test.go
@@ -91,6 +91,26 @@ func TestCertificationRender(t *testing.T) {
 	})
 }
 
+func TestCategoryWatchLabels(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "category-watch-labels",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var cert crev1alpha1.Certification
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input_certification.yaml"]), &cert); err != nil {
+			return err
+		}
+
+		data, err := json.MarshalIndent(categoryWatchLabels(&cert), "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(data) + "\n"
+		return nil
+	})
+}
+
 func TestCertificationRenderErrors(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "certification-render-errors",

--- a/pkg/certification/testdata/category-watch-labels/mnnvl-duplicate-pair/expected.json
+++ b/pkg/certification/testdata/category-watch-labels/mnnvl-duplicate-pair/expected.json
@@ -1,0 +1,4 @@
+[
+  "communication/nccl-all-reduce (MNNVL Enabled)",
+  "communication/nccl-all-reduce (MNNVL Disabled)"
+]

--- a/pkg/certification/testdata/category-watch-labels/mnnvl-duplicate-pair/input_certification.yaml
+++ b/pkg/certification/testdata/category-watch-labels/mnnvl-duplicate-pair/input_certification.yaml
@@ -1,0 +1,25 @@
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Certification
+metadata:
+  name: gpu-cluster-cert
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.product: NVIDIA-GB200
+  categories:
+    - domain: communication
+      variant: nccl-all-reduce
+      options:
+        enableMNNVL: true
+    - domain: communication
+      variant: nccl-all-reduce
+      options:
+        enableMNNVL: false
+status:
+  categoryStatuses:
+    - domain: communication
+      variant: nccl-all-reduce
+      status: InProgress
+    - domain: communication
+      variant: nccl-all-reduce
+      status: InProgress

--- a/pkg/certification/testdata/category-watch-labels/single-instance/expected.json
+++ b/pkg/certification/testdata/category-watch-labels/single-instance/expected.json
@@ -1,0 +1,4 @@
+[
+  "communication/nccl-all-reduce",
+  "training/nemotron5-8b"
+]

--- a/pkg/certification/testdata/category-watch-labels/single-instance/input_certification.yaml
+++ b/pkg/certification/testdata/category-watch-labels/single-instance/input_certification.yaml
@@ -1,0 +1,22 @@
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Certification
+metadata:
+  name: gpu-cluster-cert
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.product: NVIDIA-GB200
+  enableMNNVL: true
+  categories:
+    - domain: communication
+      variant: nccl-all-reduce
+    - domain: training
+      variant: nemotron5-8b
+status:
+  categoryStatuses:
+    - domain: communication
+      variant: nccl-all-reduce
+      status: InProgress
+    - domain: training
+      variant: nemotron5-8b
+      status: Pending

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -212,6 +212,28 @@ func CertFailedNodes(ctx context.Context, c client.Client, cert *crev1alpha1.Cer
 	return union
 }
 
+// CategoryMNNVL returns the MNNVL label for the category at index i of the
+// Certification's status: "Enabled", "Disabled", or "" when unknown.
+// Per-category spec options take precedence over the global spec value.
+func CategoryMNNVL(cert *crev1alpha1.Certification, i int) string {
+	if i >= len(cert.Spec.Categories) {
+		return ""
+	}
+	var mnnvl *bool
+	if specOpts := cert.Spec.Categories[i].Options; specOpts != nil && specOpts.EnableMNNVL != nil {
+		mnnvl = specOpts.EnableMNNVL
+	} else if cert.Spec.EnableMNNVL != nil {
+		mnnvl = cert.Spec.EnableMNNVL
+	}
+	if mnnvl == nil {
+		return ""
+	}
+	if *mnnvl {
+		return "Enabled"
+	}
+	return "Disabled"
+}
+
 // Build fetches Workflow and measurement data for a Certification (completed or running).
 func Build(ctx context.Context, c client.Client, cert *crev1alpha1.Certification) *CertReport {
 	result := "RUNNING"
@@ -239,21 +261,7 @@ func Build(ctx context.Context, c client.Client, cert *crev1alpha1.Certification
 		}
 
 		// Populate MNNVL: check per-category options first, fall back to global.
-		if i < len(cert.Spec.Categories) {
-			var mnnvl *bool
-			if specOpts := cert.Spec.Categories[i].Options; specOpts != nil && specOpts.EnableMNNVL != nil {
-				mnnvl = specOpts.EnableMNNVL
-			} else if cert.Spec.EnableMNNVL != nil {
-				mnnvl = cert.Spec.EnableMNNVL
-			}
-			if mnnvl != nil {
-				if *mnnvl {
-					cat.MNNVL = "Enabled"
-				} else {
-					cat.MNNVL = "Disabled"
-				}
-			}
-		}
+		cat.MNNVL = CategoryMNNVL(cert, i)
 
 		if cs.WorkflowRef != nil {
 			wf := &crev1alpha1.Workflow{}


### PR DESCRIPTION
## Summary

- When a Certification runs the same category twice with different options (`enableMNNVL: true`/`false`), `certification run --wait` printed identical rows that collapsed into one flip-flopping entry — rows were keyed on `domain/variant` alone
- Live rows now carry the option labels the final report already computes (" (MNNVL Enabled)"/" (MNNVL Disabled)" via `report.CategoryMNNVL`), applied only when duplicate categories exist
- Single-instance output is byte-identical to before
- The status[i]↔spec[i] index assumption holds: `initializeCategoryStatuses` builds all statuses at once in spec order, the same assumption `report.Build` already relies on

## Type of Change
- [x] ✨ New feature

## Component(s) Affected
- [x] CLI (ncrectl)

## Testing
- [x] Tests pass locally (golden cases `mnnvl-duplicate-pair` and `single-instance` under `pkg/certification/testdata/category-watch-labels/`; `pkg/report` tests pass unmodified)
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

Fixes #182
