### PR TITLE
fix(controller): freeze GoodputMeasurement status at Job terminal state

### DIFF
--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -99,6 +100,13 @@ func TestIntegration(t *testing.T) {
 
 		waitForCondition(tt, mgr.GetClient(), cfg)
 
+		// Verify a Complete GoodputMeasurement stays frozen across a terminal
+		// re-entry (ADR-072). Runs before collection so the golden pins it.
+		var frozenGoodput map[string]any
+		if cfg.VerifyFrozenGoodput != nil {
+			frozenGoodput = verifyFrozenGoodput(tt, suite.Client, mgr.GetClient(), cfg)
+		}
+
 		// Delete resources after the initial wait (e.g., to test deletion cascade).
 		if len(cfg.DeleteAfterWait) > 0 {
 			deleteAfterWait(tt, mgr.GetClient(), cfg.DeleteAfterWait)
@@ -108,7 +116,7 @@ func TestIntegration(t *testing.T) {
 			waitForDeletion(tt, mgr.GetClient(), cfg)
 		}
 
-		tc.Actual = collectAndSerialize(tt, mgr.GetClient(), cfg)
+		tc.Actual = collectAndSerialize(tt, mgr.GetClient(), cfg, frozenGoodput)
 		return nil
 	})
 }
@@ -422,11 +430,28 @@ type fakeLogFetcher struct {
 	logs map[string][]string
 }
 
-func (f *fakeLogFetcher) FetchLogs(_ context.Context, _, podName string, _ podlogs.LogOptions) ([]string, error) {
-	if lines, ok := f.logs[podName]; ok {
+func (f *fakeLogFetcher) FetchLogs(_ context.Context, _, podName string, opts podlogs.LogOptions) ([]string, error) {
+	lines, ok := f.logs[podName]
+	if !ok {
+		return nil, fmt.Errorf("no fake logs for pod %s", podName)
+	}
+	if opts.SinceTime == nil {
 		return lines, nil
 	}
-	return nil, fmt.Errorf("no fake logs for pod %s", podName)
+	// Mirror the real fetcher: SinceTime is passed server-side and the kubelet
+	// returns only records at or after it (pkg/podlogs/fetcher.go). Filter the
+	// canned lines by their leading RFC3339 timestamp; lines without a parseable
+	// timestamp are kept so fixtures without timestamps behave as before.
+	since := opts.SinceTime.Time
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.SplitN(line, " ", 2)
+		if ts, err := time.Parse(time.RFC3339Nano, fields[0]); err == nil && ts.Before(since) {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return filtered, nil
 }
 
 func buildFakeLogFetcher(tc *testutil.TestCase) podlogs.PodLogFetcher {
@@ -457,6 +482,14 @@ type waitConfig struct {
 	// GenerateNodes creates N GPU nodes programmatically before test objects.
 	// Avoids repeating Node YAML in fixtures for multi-node tests.
 	GenerateNodes *generateNodesSpec `json:"generateNodes,omitempty"`
+	// VerifyFrozenGoodput drives the ADR-072 determinism check: after the
+	// initial wait it snapshots the named GoodputMeasurement's status, touches
+	// the referenced Job, strips the Complete condition to force the
+	// controller back through the full terminal path (the stale-cache /
+	// restart re-entry from issue #177), waits for Complete to be restored,
+	// and asserts the regenerated status is byte-identical (modulo condition
+	// transition timestamps, which re-adding a condition necessarily moves).
+	VerifyFrozenGoodput *verifyFrozenGoodputSpec `json:"verifyFrozenGoodput,omitempty"`
 	// DeleteAfterWait lists resources to delete after the initial wait completes.
 	// The manager remains running so controllers can process the deletion cascade.
 	DeleteAfterWait []collectSpec `json:"deleteAfterWait,omitempty"`
@@ -469,6 +502,20 @@ type generateNodesSpec struct {
 	Count      int               `json:"count"`
 	Labels     map[string]string `json:"labels"`
 	ProviderID string            `json:"providerID,omitempty"`
+}
+
+type verifyFrozenGoodputSpec struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	// Mode selects the re-entry style. "strip" (default) removes the Complete
+	// condition to force a full terminal re-run and asserts byte-identical
+	// regeneration — valid where every terminal field is a pure recompute.
+	// "intact" leaves Complete in place and asserts the first-write-wins guard
+	// keeps every status byte untouched. That is the honest assertion for the
+	// Failed path: handleFailed's lostWorkTime/interruptionCount are
+	// accumulators, so a strip-and-rerun legitimately re-adds them and
+	// byte-identity cannot hold there.
+	Mode string `json:"mode,omitempty"`
 }
 
 type collectMetricsSpec struct {
@@ -579,6 +626,131 @@ func waitForDeletion(t *testing.T, c client.Client, cfg waitConfig) {
 	}
 }
 
+// verifyFrozenGoodput pins the ADR-072 freeze: a Complete GoodputMeasurement's
+// status must be a pure function of its persisted status, the Job, and the
+// final log parse. It snapshots the status, touches the referenced Job, strips
+// the Complete condition so the controller replays the entire terminal path —
+// exactly what a stale informer cache or a controller restart before the
+// Complete write causes — waits for Complete to be restored, and requires the
+// regenerated status (including result, trainingTimeSec, and completionTime)
+// to be byte-identical. Only condition transition timestamps are cleared
+// before comparing: re-adding the stripped condition necessarily refreshes its
+// LastTransitionTime.
+// direct must be an uncached API client: the check strips a condition and then
+// waits for the controller to restore it, and a cached read could satisfy the
+// wait with the stale pre-strip object. cached is the manager's client, polled
+// at the end so the subsequent collection sees the restored state.
+func verifyFrozenGoodput(t *testing.T, direct, cached client.Client, cfg waitConfig) map[string]any {
+	t.Helper()
+	ctx := context.Background()
+	key := types.NamespacedName{Name: cfg.VerifyFrozenGoodput.Name, Namespace: cfg.VerifyFrozenGoodput.Namespace}
+	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+
+	gm := &crev1alpha1.GoodputMeasurement{}
+	require.NoError(t, direct.Get(ctx, key, gm))
+	before := frozenStatusJSON(t, gm)
+
+	// Touch the referenced Job: reconciling a terminal Job must not move the
+	// measurement.
+	if jobName := gm.Spec.JobRef.Name; jobName != "" {
+		job := &crev1alpha1.Job{}
+		require.NoError(t, direct.Get(ctx, types.NamespacedName{Name: jobName, Namespace: key.Namespace}, job))
+		if job.Annotations == nil {
+			job.Annotations = map[string]string{}
+		}
+		job.Annotations["test.cre.nvidia.com/touched"] = "true"
+		require.NoError(t, direct.Update(ctx, job))
+	}
+
+	// Intact mode: the GM controller has no Job watch, so the Job touch above
+	// does not itself trigger a GM reconcile — and any GM reconcile that does
+	// run (GM watch events, requeues) returns at the Complete gate. The
+	// require.Never below therefore pins the ADR-072 convention directly:
+	// nothing writes to a GoodputMeasurement whose Complete condition is True,
+	// so nothing in the status — condition timestamps included — may move
+	// during the window.
+	if cfg.VerifyFrozenGoodput.Mode == "intact" {
+		beforeRaw := rawStatusJSON(t, gm)
+		require.Never(t, func() bool {
+			fresh := &crev1alpha1.GoodputMeasurement{}
+			if err := direct.Get(ctx, key, fresh); err != nil {
+				return false
+			}
+			return rawStatusJSON(t, fresh) != beforeRaw
+		}, 4*time.Second, 250*time.Millisecond,
+			"status moved during a replay with Complete intact (first-write-wins violated, ADR-072)")
+		return map[string]any{
+			"untouchedWithCompleteIntact": true,
+			"result":                      gm.Status.Result,
+			"trainingTimeSec":             gm.Status.TrainingTimeSec,
+			"startTime":                   gm.Status.StartTime,
+			"completionTime":              gm.Status.CompletionTime,
+		}
+	}
+
+	// Strip Complete to force the controller back through the terminal path.
+	apimeta.RemoveStatusCondition(&gm.Status.Conditions, crev1alpha1.GoodputMeasurementComplete)
+	require.NoError(t, direct.Status().Update(ctx, gm))
+
+	require.Eventually(t, func() bool {
+		fresh := &crev1alpha1.GoodputMeasurement{}
+		if err := direct.Get(ctx, key, fresh); err != nil {
+			return false
+		}
+		return hasConditionWithReason(fresh.Status.Conditions, crev1alpha1.GoodputMeasurementComplete, "")
+	}, timeout, 250*time.Millisecond, "Complete was not restored after terminal re-entry")
+
+	after := &crev1alpha1.GoodputMeasurement{}
+	require.NoError(t, direct.Get(ctx, key, after))
+	afterJSON := frozenStatusJSON(t, after)
+
+	require.Equal(t, before, afterJSON,
+		"terminal re-entry must regenerate a byte-identical status (ADR-072)")
+
+	// Let the manager's cache catch up so collection sees the restored state.
+	require.Eventually(t, func() bool {
+		fresh := &crev1alpha1.GoodputMeasurement{}
+		if err := cached.Get(ctx, key, fresh); err != nil {
+			return false
+		}
+		return hasConditionWithReason(fresh.Status.Conditions, crev1alpha1.GoodputMeasurementComplete, "")
+	}, timeout, 250*time.Millisecond, "manager cache did not observe the restored Complete condition")
+
+	return map[string]any{
+		"byteIdenticalAfterReentry": before == afterJSON,
+		"result":                    after.Status.Result,
+		"trainingTimeSec":           after.Status.TrainingTimeSec,
+		"startTime":                 after.Status.StartTime,
+		"completionTime":            after.Status.CompletionTime,
+	}
+}
+
+// rawStatusJSON marshals the full status, timestamps included — used by the
+// intact-mode check where nothing at all may change.
+func rawStatusJSON(t *testing.T, gm *crev1alpha1.GoodputMeasurement) string {
+	t.Helper()
+	b, err := json.Marshal(gm.Status)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// frozenStatusJSON marshals a measurement status for byte-level comparison
+// across terminal re-entries. Conditions are a set keyed by type: stripping
+// and re-adding one necessarily re-appends it and refreshes its transition
+// timestamp, so conditions are sorted by type and their timestamps cleared.
+// Every other byte must match.
+func frozenStatusJSON(t *testing.T, gm *crev1alpha1.GoodputMeasurement) string {
+	t.Helper()
+	s := gm.Status.DeepCopy()
+	clearConditionTimestamps(s.Conditions)
+	slices.SortFunc(s.Conditions, func(a, b metav1.Condition) int {
+		return strings.Compare(a.Type, b.Type)
+	})
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	return string(b)
+}
+
 func hasConditionWithReason(conditions []metav1.Condition, condType, reason string) bool {
 	for _, c := range conditions {
 		if c.Type == condType && c.Status == metav1.ConditionTrue {
@@ -679,11 +851,14 @@ func getObject(ctx context.Context, t *testing.T, c client.Client, spec collectS
 	}
 }
 
-func collectAndSerialize(t *testing.T, c client.Client, cfg waitConfig) string {
+func collectAndSerialize(t *testing.T, c client.Client, cfg waitConfig, frozenGoodput map[string]any) string {
 	t.Helper()
 	ctx := context.Background()
 
 	results := make(map[string]any)
+	if frozenGoodput != nil {
+		results["frozenGoodput"] = frozenGoodput
+	}
 	for _, spec := range cfg.Collect {
 		obj := getObject(ctx, t, c, spec)
 		require.NotNil(t, obj, "failed to collect %s/%s in namespace %s", spec.Kind, spec.Name, spec.Namespace)

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/expected.json
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/expected.json
@@ -1,0 +1,62 @@
+{
+  "GoodputMeasurement/test-frozen-gm": {
+    "kind": "GoodputMeasurement",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-frozen-gm",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/goodputmeasurement-finalizer"
+      ]
+    },
+    "spec": {
+      "jobRef": {
+        "apiGroup": "cre.nvidia.com",
+        "kind": "Job",
+        "name": "test-frozen-job"
+      },
+      "logProfileRef": "test-frozen-logprofile",
+      "sampleInterval": "1s"
+    },
+    "status": {
+      "currentStep": 30,
+      "highestStep": 30,
+      "lostWorkTimeSec": "0.000000",
+      "rescheduleTimeSec": "0.000000",
+      "resumeTimeSec": "5.000000",
+      "checkpointSaveTimeSec": "12.000000",
+      "lastCheckpointStep": 20,
+      "lastCheckpointTime": "2026-01-22T10:02:00Z",
+      "avgStepTimeSec": "5.500000",
+      "warmupBaseStep": 10,
+      "nonWarmupTimeSec": "120.000000",
+      "lastNonWarmupStep": 30,
+      "applicationStartTime": "2026-01-22T10:00:00Z",
+      "conditions": [
+        {
+          "type": "Measuring",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobSucceeded",
+          "message": "Measurement completed"
+        },
+        {
+          "type": "Complete",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobSucceeded",
+          "message": "Referenced Job completed successfully"
+        }
+      ]
+    }
+  },
+  "frozenGoodput": {
+    "byteIdenticalAfterReentry": true,
+    "completionTime": "2026-01-22T10:05:00Z",
+    "result": "0.942373",
+    "startTime": "2026-01-22T10:00:05Z",
+    "trainingTimeSec": "295.000000"
+  }
+}

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_client_objects.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ADR-072 determinism case: the Job is already terminal when the measurement
+# first reconciles, so every terminal value derives from log timestamps and
+# the Job's Succeeded transition time — never the wall clock. The harness's
+# verifyFrozenGoodput step then strips the Complete condition to force a full
+# terminal re-run (the issue #177 re-entry) and requires a byte-identical
+# status.
+apiVersion: cre.nvidia.com/v1alpha1
+kind: LogProfile
+metadata:
+  name: test-frozen-logprofile
+spec:
+  timestamp:
+    layout: "2006-01-02T15:04:05.999999999Z"
+  patterns:
+    trainingStep:
+      regex: 'step (?P<globalStep>\d+) step_timing: (?P<stepTiming>[\d.]+) tflops: (?P<tflops>[\d.]+)'
+      example: "step 100 step_timing: 6.0 tflops: 100.0"
+      units:
+        stepTiming: s
+    applicationStart:
+      regex: 'Application initialized'
+      example: 'Application initialized'
+    checkpointSave:
+      regex: 'Checkpoint saved at step (?P<step>\d+) duration (?P<saveDuration>[\d.]+)s'
+      example: 'Checkpoint saved at step 150 duration 10.0s'
+      units:
+        saveDuration: s
+---
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: test-frozen-job-workload
+  namespace: default
+spec:
+  runtimeRef:
+    kind: TrainingRuntime
+    name: test-runtime
+  trainer:
+    image: test-image:latest
+    command:
+      - python
+      - train.py
+    numNodes: 1
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-frozen-job
+  namespace: default
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - python
+          - train.py
+        numNodes: 1
+status:
+  conditions:
+    - type: InProgress
+      status: "False"
+      reason: WorkloadCompleted
+      message: "Workload has completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadSucceeded
+      message: "Workload succeeded"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Failed
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+  workloadRef:
+    apiVersion: trainer.kubeflow.org/v1alpha1
+    kind: TrainJob
+    name: test-frozen-job-workload
+    namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-frozen-job-workload-worker-0
+  namespace: default
+  labels:
+    jobset.sigs.k8s.io/jobset-name: test-frozen-job-workload
+    batch.kubernetes.io/job-completion-index: "0"
+    cre.nvidia.com/job: test-frozen-job
+spec:
+  containers:
+    - name: node
+      image: test-image:latest
+status:
+  phase: Running
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: GoodputMeasurement
+metadata:
+  name: test-frozen-gm
+  namespace: default
+spec:
+  jobRef:
+    apiGroup: cre.nvidia.com
+    kind: Job
+    name: test-frozen-job
+  logProfileRef: test-frozen-logprofile
+  sampleInterval: 1s

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_config.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: GoodputMeasurement
+  name: test-frozen-gm
+  namespace: default
+  condition: Complete
+verifyFrozenGoodput:
+  namespace: default
+  name: test-frozen-gm
+collect:
+  - kind: GoodputMeasurement
+    name: test-frozen-gm
+    namespace: default

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_logs_test-frozen-job-workload-worker-0.txt
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-complete/input_logs_test-frozen-job-workload-worker-0.txt
@@ -1,0 +1,5 @@
+2026-01-22T10:00:00.000000000Z Application initialized
+2026-01-22T10:00:05.000000000Z step 10 step_timing: 5.0 tflops: 100.0
+2026-01-22T10:01:00.000000000Z step 20 step_timing: 5.5 tflops: 110.0
+2026-01-22T10:02:00.000000000Z Checkpoint saved at step 20 duration 12.0s
+2026-01-22T10:03:00.000000000Z step 30 step_timing: 6.0 tflops: 120.0

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/expected.json
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/expected.json
@@ -1,0 +1,69 @@
+{
+  "GoodputMeasurement/test-frozenf-gm": {
+    "kind": "GoodputMeasurement",
+    "apiVersion": "cre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-frozenf-gm",
+      "namespace": "default",
+      "finalizers": [
+        "cre.nvidia.com/goodputmeasurement-finalizer"
+      ]
+    },
+    "spec": {
+      "jobRef": {
+        "apiGroup": "cre.nvidia.com",
+        "kind": "Job",
+        "name": "test-frozenf-job"
+      },
+      "logProfileRef": "test-frozenf-logprofile",
+      "sampleInterval": "1s"
+    },
+    "status": {
+      "currentStep": 30,
+      "highestStep": 30,
+      "lostWorkTimeSec": "180.000000",
+      "rescheduleTimeSec": "0.000000",
+      "resumeTimeSec": "5.000000",
+      "checkpointSaveTimeSec": "12.000000",
+      "interruptionCount": 1,
+      "lastCheckpointStep": 20,
+      "lastCheckpointTime": "2026-01-22T10:02:00Z",
+      "avgStepTimeSec": "5.500000",
+      "warmupBaseStep": 10,
+      "nonWarmupTimeSec": "120.000000",
+      "lastNonWarmupStep": 30,
+      "priorNonWarmupTimeSec": "120.000000",
+      "pendingInterruption": {
+        "checkpointStep": 20,
+        "lastStep": 30,
+        "tCh": "180.000000",
+        "reason": "JobFailed"
+      },
+      "conditions": [
+        {
+          "type": "Complete",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobFailed",
+          "message": "Referenced Job failed"
+        },
+        {
+          "type": "Measuring",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobFailed",
+          "message": "Measurement completed"
+        }
+      ]
+    }
+  },
+  "frozenGoodput": {
+    "completionTime": "2026-01-22T10:05:00Z",
+    "result": "0.332203",
+    "startTime": "2026-01-22T10:00:05Z",
+    "trainingTimeSec": "295.000000",
+    "untouchedWithCompleteIntact": true
+  }
+}

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_client_objects.yaml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ADR-072 freeze case, Failed path: the Job is already Failed when the
+# measurement first reconciles, so every terminal value derives from log
+# timestamps and the Job's Failed transition time — never the wall clock.
+# The harness's verifyFrozenGoodput step runs in intact mode: it touches the
+# Job with the Complete condition left in place and requires the status not
+# to move at all (first-write-wins, ADR-072). Strip-and-rerun byte-identity
+# cannot hold on the Failed path because lostWorkTime/interruptionCount are
+# accumulators, not pure recomputes.
+apiVersion: cre.nvidia.com/v1alpha1
+kind: LogProfile
+metadata:
+  name: test-frozenf-logprofile
+spec:
+  timestamp:
+    layout: "2006-01-02T15:04:05.999999999Z"
+  patterns:
+    trainingStep:
+      regex: 'step (?P<globalStep>\d+) step_timing: (?P<stepTiming>[\d.]+) tflops: (?P<tflops>[\d.]+)'
+      example: "step 100 step_timing: 6.0 tflops: 100.0"
+      units:
+        stepTiming: s
+    applicationStart:
+      regex: 'Application initialized'
+      example: 'Application initialized'
+    checkpointSave:
+      regex: 'Checkpoint saved at step (?P<step>\d+) duration (?P<saveDuration>[\d.]+)s'
+      example: 'Checkpoint saved at step 150 duration 10.0s'
+      units:
+        saveDuration: s
+---
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: test-frozenf-job-workload
+  namespace: default
+spec:
+  runtimeRef:
+    kind: TrainingRuntime
+    name: test-runtime
+  trainer:
+    image: test-image:latest
+    command:
+      - python
+      - train.py
+    numNodes: 1
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-frozenf-job
+  namespace: default
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - python
+          - train.py
+        numNodes: 1
+status:
+  conditions:
+    - type: InProgress
+      status: "False"
+      reason: WorkloadFailed
+      message: "Workload has failed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: Succeeded
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Failed
+      status: "True"
+      reason: WorkloadFailed
+      message: "Workload failed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+  workloadRef:
+    apiVersion: trainer.kubeflow.org/v1alpha1
+    kind: TrainJob
+    name: test-frozenf-job-workload
+    namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-frozenf-job-workload-worker-0
+  namespace: default
+  labels:
+    jobset.sigs.k8s.io/jobset-name: test-frozenf-job-workload
+    batch.kubernetes.io/job-completion-index: "0"
+    cre.nvidia.com/job: test-frozenf-job
+spec:
+  containers:
+    - name: node
+      image: test-image:latest
+status:
+  phase: Running
+---
+apiVersion: cre.nvidia.com/v1alpha1
+kind: GoodputMeasurement
+metadata:
+  name: test-frozenf-gm
+  namespace: default
+spec:
+  jobRef:
+    apiGroup: cre.nvidia.com
+    kind: Job
+    name: test-frozenf-job
+  logProfileRef: test-frozenf-logprofile
+  sampleInterval: 1s

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_config.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: GoodputMeasurement
+  name: test-frozenf-gm
+  namespace: default
+  condition: Complete
+verifyFrozenGoodput:
+  namespace: default
+  name: test-frozenf-gm
+  mode: intact
+collect:
+  - kind: GoodputMeasurement
+    name: test-frozenf-gm
+    namespace: default

--- a/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_logs_test-frozenf-job-workload-worker-0.txt
+++ b/cmd/integration/testdata/reconcile/goodput-measurement-frozen-after-failed/input_logs_test-frozenf-job-workload-worker-0.txt
@@ -1,0 +1,5 @@
+2026-01-22T10:00:00.000000000Z Application initialized
+2026-01-22T10:00:05.000000000Z step 10 step_timing: 5.0 tflops: 100.0
+2026-01-22T10:01:00.000000000Z step 20 step_timing: 5.5 tflops: 110.0
+2026-01-22T10:02:00.000000000Z Checkpoint saved at step 20 duration 12.0s
+2026-01-22T10:03:00.000000000Z step 30 step_timing: 6.0 tflops: 120.0

--- a/cmd/integration/testdata/reconcile/job-goodput-threshold-fail/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/job-goodput-threshold-fail/input_client_objects.yaml
@@ -52,6 +52,9 @@ status:
     name: test-goodput-threshold-fail-workload
     namespace: default
 ---
+# The measurement is already frozen (Complete=True): since ADR-072, threshold
+# evaluation skips goodput keys until the GoodputMeasurement controller's
+# terminal write lands, so a provisional result must not drive pass/fail.
 apiVersion: cre.nvidia.com/v1alpha1
 kind: GoodputMeasurement
 metadata:
@@ -65,3 +68,15 @@ spec:
   logProfileRef: nemo-training
 status:
   result: "0.8800"
+  completionTime: "2026-01-22T10:00:00Z"
+  conditions:
+    - type: Complete
+      status: "True"
+      reason: JobSucceeded
+      message: "Referenced Job completed successfully"
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Measuring
+      status: "False"
+      reason: JobSucceeded
+      message: "Measurement completed"
+      lastTransitionTime: "2026-01-22T10:00:00Z"

--- a/docs/concepts/goodput-bandwidth.md
+++ b/docs/concepts/goodput-bandwidth.md
@@ -16,6 +16,14 @@ A `LogProfile` (cluster-scoped) defines named regex capture groups that match lo
 
 Built-in LogProfiles installed by `ncrectl setup init`: `megatron-training`, `megatron-bridge`, `nccl-bandwidth`, `nccl-loopback`.
 
+### Measurement lifecycle
+
+While the measured `Job` is running, the measurement's `Measuring` condition is `True` and every value in its status — including `result` — is **provisional**: it is recomputed on each sampling pass and changes as the run progresses.
+
+When the `Job` reaches a terminal state, the controller performs one final log read and folds it into a single terminal status write, anchored to the timestamp of the Job's terminal condition rather than the controller's wall clock: `completionTime` is the Job's terminal transition time, and `trainingTimeSec` (and therefore `result`) is measured up to that instant. That write sets `Complete=True` and `Measuring=False`.
+
+Once `Complete` is `True` the measurement is **frozen**: its status never changes again, so `ncrectl certification report` returns the same goodput on every read, and controller restarts or repeated reconciles cannot move the value (see [ADR-072](../designs/072-goodput-terminal-freeze.md)). Goodput-based threshold evaluation (`goodputRatio`, `avgTFLOPSPerGPU`, `avgStepTimeSec`) waits for `Complete=True` and only ever consumes the frozen values.
+
 ### Interpreting goodput
 
 A goodput ratio of 1.0 means the job was making continuous progress. Values below ~0.95 indicate meaningful overhead — stalls, restarts, or slow nodes.

--- a/docs/designs/072-goodput-terminal-freeze.md
+++ b/docs/designs/072-goodput-terminal-freeze.md
@@ -1,0 +1,93 @@
+# ADR-072: Freeze GoodputMeasurement Status at Job Terminal State
+
+> **Status:** Accepted
+
+## Context
+
+The goodput reported for a completed certification changes between report reads (issue #177). `ncrectl certification report` reads `GoodputMeasurement.status.result` live from the cluster on every invocation ([report.go:758](../../pkg/report/report.go#L758), `buildDomainReports`), and GoodputMeasurements are deliberately owned by the Workflow and preserved until teardown so the report can read them after Jobs are gone ([workflow_controller.go:1710-1713](../../pkg/controller/workflow_controller.go#L1710)). Nothing snapshots the measurement when the measured Job reaches a terminal condition, so any post-success status churn shows up as report-to-report drift.
+
+The terminal path in [goodputmeasurement_controller.go](../../pkg/controller/goodputmeasurement_controller.go) has three distinct sources of that churn:
+
+1. **Wall-clock training time.** `handleSucceeded` computes `t_w = time.Since(cm.TrainingStartTime)` at *reconcile* time, not at the Job's terminal time; `handleFailed` falls back to `time.Now()` when no log-derived termination time exists. `CalculateGoodput` ([calculator.go](../../pkg/goodput/calculator.go)) is a pure function — the nondeterminism is entirely in the `t_w` fed to it. Every pass through the terminal path produces a different `trainingTimeSec` and therefore a different `result`.
+
+2. **Two-write terminal sequence.** On `JobSucceeded`/`JobFailed`, `finalSample` first runs the full `handleRunning` path (a last log read, then `Status().Update`) to capture the trailing sample window, and `handleSucceeded`/`handleFailed` then writes a second time via `setComplete` with a later "now". A report read between the two writes sees a different goodput than one after. The first write also re-asserts `Measuring=True/"JobRunning"` on a Job that has already succeeded.
+
+3. **Re-entry is not idempotent.** The controller watches only GoodputMeasurement (`SetupWithManager` has no Job watch), so every status write triggers another reconcile. If the cached measurement does not yet show `Complete=True` — stale informer cache, or a manager restart between Job success and the `Complete` write landing — the whole terminal path runs again with a fresh wall clock. `finalSample` clears its own sampling throttle, so each re-entry re-reads logs and rewrites `result`. Worse, `handleSucceeded` recomputes `t_w` only when in-memory `JobState` survived (`r.getState(key)`), so a restarted controller takes a different code path than a long-lived one and lands on a different value. A restart hours after Job success recomputes `time.Since(TrainingStartTime)` across those hours.
+
+The drift is visible beyond the report: `collectJobMeasuredValues` ([job_threshold_helpers.go:64](../../pkg/controller/job_threshold_helpers.go#L64)) reads `status.result` live for `goodputRatio` threshold evaluation, so a Job's pass/fail can depend on *when* the Job controller happens to evaluate.
+
+The existing `Complete=True` gate at [goodputmeasurement_controller.go:122](../../pkg/controller/goodputmeasurement_controller.go#L122) already stops reconciliation once the condition lands — the problem is everything that happens (and can happen again) before it lands, and that the values written are not a deterministic function of their inputs.
+
+## Decision
+
+1. **Anchor all terminal-time computation to the measured Job's terminal condition timestamp.** Define `anchor = LastTransitionTime` of the Job's `Succeeded` (or `Failed`) condition. Terminal `t_w = anchor - TrainingStartTime`. `handleFailed`'s termination-time fallback chain ends at `anchor` instead of `time.Now()`. `status.completionTime` is set to `anchor`, not `metav1.Now()`. The terminal status payload becomes a pure function of (persisted GoodputMeasurement status, Job object, final log parse) — the same inputs always produce the same bytes.
+
+2. **Collapse the terminal path into a single atomic status write.** The final log sample is parsed in memory and folded into the same `setComplete` write that records the terminal metrics, `completionTime`, `Complete=True`, and `Measuring=False`. No intermediate `Status().Update` from the final-sample path, and no transient `Measuring=True` after Job success. Readers can never observe a half-final state: before the write the values are explicitly provisional (`Measuring=True`), after it they are final.
+
+3. **`Complete=True` is the freeze marker and the reconcile gate.** No new `final` field or marker is added — the existing condition already carries exactly this meaning, the gate already exists, and after `Complete` the controller returns without a requeue, so reconciliation stops naturally. **No CRD status addition is needed.**
+
+4. **Deterministic handling of in-flight parsing at the boundary.** The final log read remains best-effort: on failure, the terminal write proceeds from the last persisted values (today's behavior, minus the second write). `ApplicationStopTime` and the log read window are capped at `anchor` so late-arriving log timestamps cannot push terminal metrics past the Job's terminal time. Because re-entry recomputes from the same anchored inputs, a duplicate terminal write (stale cache, conflict retry, controller restart) is byte-identical rather than a new value.
+
+5. **Threshold evaluation consumes only frozen values.** `collectJobMeasuredValues` skips goodput-derived keys (`goodputRatio`, `avgTFLOPSPerGPU`, `avgStepTimeSec`) while the GoodputMeasurement's `Complete` condition is not `True`. The existing missing-key requeue and `measurementTimeout` machinery in `checkPerformanceThresholds` already handles the wait.
+
+6. **Do not copy final values into Job/Workflow/Certification status.** The report aggregates GoodputMeasurements directly, and they already outlive their Jobs by design.
+
+## Implementation
+
+- **`pkg/controller/goodputmeasurement_controller.go`**
+  - New `terminalAnchor(job) time.Time` helper returning the `LastTransitionTime` of the Job's terminal condition (with a `time.Now()` last-resort fallback for a condition that somehow lacks one).
+  - `finalSample` becomes `collectFinalSample`, returning the parsed `ParseResult`/state deltas in memory instead of calling `handleRunning`; it no longer writes status, sets conditions, or touches the sampling throttle map.
+  - `handleSucceeded`/`handleFailed` compute `t_w` from `anchor` (dropping the `time.Since` calls and the in-memory-state-dependent recompute), merge the final sample, and hand the complete payload to `setComplete`, which stamps `completionTime = anchor`.
+  - Reconcile gate unchanged; after `Complete=True` the measurement is inert.
+- **`pkg/controller/job_threshold_helpers.go`** — `collectJobMeasuredValues` gates goodput keys on the GM's `Complete` condition.
+- **`pkg/goodput/calculator.go`** — no change; it is already pure.
+- **No API change.** `Complete` condition and `status.completionTime` already exist in `GoodputMeasurementStatus`. If review concludes an explicit `status.final` marker is wanted after all, that is a CRD schema change requiring user approval and `make manifests generate` — flagged here, and rejected in Alternatives.
+- **Integration tests** (`cmd/integration/testdata/reconcile/`):
+  - Existing cases `goodput-measurement`, `goodput-measurement-job-succeed`, `goodput-measurement-job-fail`, `goodput-measurement-restart-missed`, `goodput-measurement-state-recovery`, `job-goodput-threshold-pass/fail`, and `job-auto-goodput` exercise the changed paths. Their golden files collect only the post-`Complete` state, so diffs are expected to be nil or confined to condition reasons/messages; any regeneration happens only after diagnosis and with explicit user approval per repo policy.
+  - New case `goodput-measurement-frozen-after-complete`: drive a measurement to `Complete`, then touch the Job and the measurement, and assert the collected `status` (including `result`) is unchanged.
+  - The harness's GM sanitization (`integration_test.go` clears `trainingTimeSec`, `result`, `startTime`, `completionTime`, …) **stays**: anchoring makes values stable across reads within a run, but they still depend on envtest wall-clock spacing between training start and Job terminal transition, so they remain non-comparable across runs.
+- **Docs** — update the goodput page under `docs/` (and `site/content/docs/` if present) to state that measurement values are provisional while `Measuring=True` and frozen once `Complete=True`.
+
+## Rationale
+
+- **Purity is the idempotency mechanism.** Anchoring to the Job's terminal condition timestamp makes the terminal computation replay-safe across conflict retries, stale-cache re-entries, and controller restarts of any duration — the classes of nondeterminism observed in #177. Gating alone ("stop reconciling") cannot achieve this because the gate itself is subject to cache staleness.
+- **One write, one observable transition.** Merging the final sample into the terminal write removes the window where a report read returns a value that the very next read contradicts, and stops `Measuring=True` from flapping on an already-succeeded Job.
+- **The `Complete` condition is already the contract.** Introducing a parallel `final` marker creates two sources of truth that can disagree; every consumer (report, thresholds, the gate) can key off the condition that already exists.
+- **Keeping the final sample (rather than freezing at the last periodic sample)** preserves the fix documented in `finalSample`'s comment: without the trailing read, up to one sample interval of data is lost — observed on hardware as step 90 recorded for a run that reached step 100.
+- **Not copying into Job/Workflow status** keeps a single source of truth. The Workflow-ownership design exists precisely so measurements survive Job deletion for the report; duplicating values across tiers reintroduces the synchronization problem this ADR removes.
+
+## Consequences
+
+- **Positive:** report output for a completed certification is byte-stable across reads; threshold pass/fail is computed on the frozen value regardless of Job-controller timing; controller restarts around the terminal boundary no longer change results; the transient `Measuring=True`-after-success flap disappears.
+- `t_w` is measured to the Job's terminal transition, not to the last observed log line. For a workload that idles between its last step and Job success, terminal `t_w` is slightly larger than "active training time". This matches the wall-clock definition of `t_w` in the goodput formula, and — unlike today — it is one number, not a family of numbers indexed by reconcile time.
+- Goodput threshold evaluation waits for the GM's `Complete` condition — at most roughly one sample interval of added latency on the Job success path, bounded by the existing `measurementTimeout`.
+- The terminal reconcile does more in a single pass (final log read + terminal metrics + conditions), but performs one API write where today there are two.
+- Anything relying on post-success intermediate status states (none known in-tree; the harness collects only final state) would need updating.
+
+## Alternatives Considered
+
+- **Gate-only fix: keep the two-write sequence, rely on `Complete` to stop reconciling.** Rejected — the inter-write window still yields contradictory report reads, and re-entry before the gate lands still rewrites values; the gate already exists and demonstrably does not fix #177 alone.
+- **Add `status.final` bool (or `status.finalResult`).** Rejected — redundant with the `Complete` condition, requires a CRD schema change and regeneration, and two markers can disagree. Flagged in Implementation in case review overrides.
+- **Copy final goodput into Job/Workflow status.** Rejected — duplicates metrics across tiers, needs CRD changes at two tiers, and creates a second source of truth the report would have to reconcile with the GM it already reads.
+- **Freeze at the last periodic sample (skip the final log read).** Rejected — deterministic but discards up to one sample interval of trailing data, regressing the documented hardware-observed loss `finalSample` was added to fix.
+- **Anchor to worker-pod container termination time.** Rejected — pods may already be garbage-collected when the terminal reconcile (or its restart replay) runs, so it is not restart-idempotent; the Job condition timestamp is always available on the object being watched. It remains a *preferred* source where present (via `ApplicationStopTime`), with `anchor` as the deterministic floor/ceiling.
+
+## Notes
+
+- The Job controller's checkpoint-restart stall reset ([job_controller.go:733](../../pkg/controller/job_controller.go#L733)) writes GM status (`lastStepTimestamp`, `avgStepTimeSec`, `startTime`) strictly pre-terminal and is unaffected. Convention after this ADR: the GM controller is the only writer of GM status after the measured Job is terminal, and nothing writes to a GM whose `Complete=True`.
+- That stall reset moves `status.startTime`, which is also the `t_w` baseline via `buildCumulativeFromStatus` — a pre-existing interaction that is out of scope here; this ADR only guarantees the terminal computation over that baseline is deterministic.
+- Prometheus gauges emit one final sample with the frozen values at terminal handling; operational-metric cleanup is unchanged.
+- Iteration reuse is safe: per-iteration Jobs get distinct names (`<workflow>-<group>-iter-<n>`), so each iteration's GM (`<job>-goodput`) freezes independently.
+
+## References
+
+- Issue #177 — goodput of a completed certification changes between report reads
+- [`pkg/controller/goodputmeasurement_controller.go`](../../pkg/controller/goodputmeasurement_controller.go) — `reconcileMeasurement`, `finalSample`, `handleSucceeded`, `handleFailed`, `setComplete`
+- [`pkg/goodput/calculator.go`](../../pkg/goodput/calculator.go) — `CalculateGoodput`
+- [`pkg/report/report.go`](../../pkg/report/report.go) — `buildDomainReports` reads `status.result` live
+- [`pkg/controller/job_threshold_helpers.go`](../../pkg/controller/job_threshold_helpers.go) — `collectJobMeasuredValues`
+- ADR-005: LogProfile-based goodput measurement
+- ADR-008: Checkpoint restart
+- ADR-009: Adaptive stall detection — the other consumer of live GM status fields
+- ADR-013: Prometheus observability
+- ADR-014: Integration test strategy — golden-file sanitization of wall-clock-dependent GM fields

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -79,4 +79,5 @@ Read the relevant record before you change the behaviour it describes. `CLAUDE.m
 | 069 | [cmd/ layout — kubernetes/kubernetes convention](069-cmd-layout.md) |
 | 070 | [WorkloadRun MPI Transport-Layer Overrides for AWS GB300 (RoCE)](070-workloadrun-gb300-mpi-transport.md) |
 | 071 | [Threshold Violation Reason Propagation into Report Surfaces](071-threshold-reason-propagation.md) |
+| 072 | [Freeze GoodputMeasurement Status at Job Terminal State](072-goodput-terminal-freeze.md) |
 | 073 | [Convergent `setup init` Retry After a Partial Kubeflow Trainer Install](073-setup-retry-convergence.md) |

--- a/pkg/controller/collect_job_measured_values_test.go
+++ b/pkg/controller/collect_job_measured_values_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// Goodput-derived threshold values are provisional until the measurement's
+// Complete condition is True (ADR-072): the terminal write freezes them, and
+// evaluating earlier would make pass/fail depend on when the Job controller
+// happened to read. Bandwidth values are not gated. These cases pin the gate.
+func TestCollectJobMeasuredValues(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "collect-job-measured-values",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			GoodputComplete bool   `yaml:"goodputComplete"`
+			Result          string `yaml:"result"`
+			AvgTFLOPSPerGPU string `yaml:"avgTFLOPSPerGPU"`
+			AvgStepTimeSec  string `yaml:"avgStepTimeSec"`
+			BusBW           string `yaml:"busBW"`
+			AlgBW           string `yaml:"algBW"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		scheme := runtime.NewScheme()
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
+			return err
+		}
+
+		jobRef := corev1.TypedLocalObjectReference{Name: "j"}
+		gm := &crev1alpha1.GoodputMeasurement{
+			ObjectMeta: metav1.ObjectMeta{Name: "j-goodput", Namespace: "ns"},
+			Spec:       crev1alpha1.GoodputMeasurementSpec{JobRef: jobRef},
+			Status: crev1alpha1.GoodputMeasurementStatus{
+				Result:          in.Result,
+				AvgTFLOPSPerGPU: in.AvgTFLOPSPerGPU,
+				AvgStepTimeSec:  in.AvgStepTimeSec,
+			},
+		}
+		if in.GoodputComplete {
+			gm.Status.Conditions = []metav1.Condition{{
+				Type:               crev1alpha1.GoodputMeasurementComplete,
+				Status:             metav1.ConditionTrue,
+				Reason:             "JobSucceeded",
+				LastTransitionTime: metav1.Now(),
+			}}
+		}
+		bm := &crev1alpha1.BandwidthMeasurement{
+			ObjectMeta: metav1.ObjectMeta{Name: "j-bandwidth", Namespace: "ns"},
+			Spec:       crev1alpha1.BandwidthMeasurementSpec{JobRef: jobRef},
+			Status: crev1alpha1.BandwidthMeasurementStatus{
+				Results: []crev1alpha1.BandwidthResult{{
+					SizeBytes: 1 << 30, BusBW: in.BusBW, AlgBW: in.AlgBW, Samples: 1,
+				}},
+			},
+		}
+		job := &crev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+
+		gmIndex := func(obj client.Object) []string {
+			return []string{obj.(*crev1alpha1.GoodputMeasurement).Spec.JobRef.Name}
+		}
+		bmIndex := func(obj client.Object) []string {
+			return []string{obj.(*crev1alpha1.BandwidthMeasurement).Spec.JobRef.Name}
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithIndex(&crev1alpha1.GoodputMeasurement{}, measurementJobRefIndexField, gmIndex).
+			WithIndex(&crev1alpha1.BandwidthMeasurement{}, measurementJobRefIndexField, bmIndex).
+			WithObjects(gm, bm, job).Build()
+
+		values := collectJobMeasuredValues(context.Background(), c, job)
+
+		b, err := json.MarshalIndent(values, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/goodput_final_sample_test.go
+++ b/pkg/controller/goodput_final_sample_test.go
@@ -12,21 +12,38 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
 	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
-// handleSucceeded and handleFailed build from the stored status and never read
-// logs again, so everything written in the last sampling window was lost. A
-// script that logged to iteration 100 was recorded as reaching step 90.
+// stubLogFetcher returns fixed log lines for every pod and records the
+// options of the last fetch so tests can assert the read window.
+type stubLogFetcher struct {
+	lines    []string
+	lastOpts *podlogs.LogOptions
+}
+
+func (s *stubLogFetcher) FetchLogs(_ context.Context, _, _ string, opts podlogs.LogOptions) ([]string, error) {
+	s.lastOpts = &opts
+	return s.lines, nil
+}
+
+// handleSucceeded and handleFailed build from the stored status, so the last
+// sampling window would be lost without a final log read — observed on
+// hardware as a script that logged to iteration 100 recorded as step 90.
 //
-// handleRunning throttles reads so status updates do not re-trigger one, and
-// the final read lands moments after the previous sample. finalSample therefore
-// has to clear the sample time first, or the fix does nothing. These two cases
-// pin both halves.
+// Before ADR-072 that final read went through handleRunning: it had to clear
+// the sampling throttle to run at all, wrote an intermediate status, and
+// re-asserted Measuring=True on an already-terminal Job — the two-write
+// terminal sequence behind issue #177. collectFinalSample now bypasses the
+// throttle without touching it, folds the window into the in-memory status,
+// and performs no API write: only setComplete persists the terminal state.
+// These cases pin all of that, plus the anchor cap on ApplicationStopTime.
 func TestGoodputFinalSample(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "goodput-final-sample",
@@ -34,8 +51,18 @@ func TestGoodputFinalSample(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
-			Call              string `yaml:"call"`
-			SampledSecondsAgo int    `yaml:"sampledSecondsAgo"`
+			Call              string   `yaml:"call"`
+			SampledSecondsAgo int      `yaml:"sampledSecondsAgo"`
+			LogProfileRef     string   `yaml:"logProfileRef"`
+			Logs              []string `yaml:"logs"`
+			// Status seeds the measurement's persisted status, standing in
+			// for values written by earlier periodic samples.
+			Status struct {
+				CurrentStep       int    `yaml:"currentStep"`
+				HighestStep       int    `yaml:"highestStep"`
+				LastStepTimestamp string `yaml:"lastStepTimestamp"`
+				AvgStepTimeSec    string `yaml:"avgStepTimeSec"`
+			} `yaml:"status"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
 			return err
@@ -45,30 +72,85 @@ func TestGoodputFinalSample(t *testing.T) {
 		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
+		if err := corev1.AddToScheme(scheme); err != nil {
+			return err
+		}
 
+		anchor := time.Date(2026, 1, 22, 10, 5, 0, 0, time.UTC)
+
+		profile := &crev1alpha1.LogProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: "lp"},
+			Spec: crev1alpha1.LogProfileSpec{
+				Timestamp: crev1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05.999999999Z"},
+				Patterns: crev1alpha1.LogPatternSet{
+					TrainingStep: &crev1alpha1.EventPattern{
+						Regex:   `step (?P<globalStep>\d+)`,
+						Example: "step 100",
+					},
+				},
+			},
+		}
 		m := &crev1alpha1.GoodputMeasurement{
 			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
 			Spec: crev1alpha1.GoodputMeasurementSpec{
 				JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
-				LogProfileRef: "does-not-resolve",
+				LogProfileRef: in.LogProfileRef,
 			},
 		}
-		job := &crev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		m.Status.CurrentStep = in.Status.CurrentStep
+		m.Status.HighestStep = in.Status.HighestStep
+		m.Status.AvgStepTimeSec = in.Status.AvgStepTimeSec
+		if in.Status.LastStepTimestamp != "" {
+			ts, err := time.Parse(time.RFC3339, in.Status.LastStepTimestamp)
+			if err != nil {
+				return err
+			}
+			mt := metav1.NewTime(ts)
+			m.Status.LastStepTimestamp = &mt
+		}
+		initialStatus := m.Status.DeepCopy()
+		job := &crev1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
+			Status: crev1alpha1.JobStatus{
+				WorkloadRef: &crev1alpha1.WorkloadReference{Kind: "TrainJob", Name: "w"},
+				Conditions: []metav1.Condition{{
+					Type:               crev1alpha1.JobSucceeded,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WorkloadCompleted",
+					LastTransitionTime: metav1.NewTime(anchor),
+				}},
+			},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "w-node-0",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"jobset.sigs.k8s.io/jobset-name":           "w",
+					"batch.kubernetes.io/job-completion-index": "0",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).
-			WithObjects(m, job).WithStatusSubresource(m, job).Build()
-		r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
+			WithObjects(m, job, pod, profile).WithStatusSubresource(m, job).Build()
+		fetcher := &stubLogFetcher{lines: in.Logs}
+		r := &GoodputMeasurementReconciler{
+			Client:     c,
+			Scheme:     scheme,
+			LogFetcher: fetcher,
+		}
 
 		key := "ns/m"
+		throttledAt := time.Now().Add(-time.Duration(in.SampledSecondsAgo) * time.Second)
 		r.mu.Lock()
-		r.lastSample = map[string]time.Time{
-			key: time.Now().Add(-time.Duration(in.SampledSecondsAgo) * time.Second),
-		}
+		r.lastSample = map[string]time.Time{key: throttledAt}
 		r.mu.Unlock()
 
 		requeued := false
-		if in.Call == "finalSample" {
-			r.finalSample(context.Background(), m, job)
+		if in.Call == "collectFinalSample" {
+			r.collectFinalSample(context.Background(), m, job, anchor)
 		} else {
 			res, err := r.handleRunning(context.Background(), m, job)
 			if err != nil {
@@ -78,13 +160,52 @@ func TestGoodputFinalSample(t *testing.T) {
 		}
 
 		r.mu.Lock()
-		_, stillThrottled := r.lastSample[key]
+		stamp, present := r.lastSample[key]
 		r.mu.Unlock()
 
+		fresh := &crev1alpha1.GoodputMeasurement{}
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "m"}, fresh); err != nil {
+			return err
+		}
+
+		stopTime := ""
+		if m.Status.ApplicationStopTime != nil {
+			stopTime = m.Status.ApplicationStopTime.UTC().Format(time.RFC3339)
+		}
+		sinceWindow := ""
+		if fetcher.lastOpts != nil && fetcher.lastOpts.SinceTime != nil {
+			sinceWindow = fetcher.lastOpts.SinceTime.UTC().Format(time.RFC3339)
+		}
+
+		// Compare marshaled bytes, not reflect.DeepEqual: the fake client
+		// returns timestamps relocated to time.Local, which is a different
+		// in-memory representation of the same instant.
+		freshJSON, err := json.Marshal(fresh.Status)
+		if err != nil {
+			return err
+		}
+		initialJSON, err := json.Marshal(*initialStatus)
+		if err != nil {
+			return err
+		}
+
 		b, err := json.MarshalIndent(struct {
-			ThrottleCleared bool `json:"throttleCleared"`
-			AskedForRequeue bool `json:"askedForRequeue"`
-		}{!stillThrottled, requeued}, "", "  ")
+			CurrentStepInMemory         int    `json:"currentStepInMemory"`
+			ApplicationStopTimeCappedAt string `json:"applicationStopTimeCappedAt"`
+			APIStatusUntouched          bool   `json:"apiStatusUntouched"`
+			ThrottleUntouched           bool   `json:"throttleUntouched"`
+			AskedForRequeue             bool   `json:"askedForRequeue"`
+			SinceWindowStart            string `json:"sinceWindowStart,omitempty"`
+			AvgStepTimeSec              string `json:"avgStepTimeSec,omitempty"`
+		}{
+			CurrentStepInMemory:         m.Status.CurrentStep,
+			ApplicationStopTimeCappedAt: stopTime,
+			APIStatusUntouched:          string(freshJSON) == string(initialJSON),
+			ThrottleUntouched:           present && stamp.Equal(throttledAt),
+			AskedForRequeue:             requeued,
+			SinceWindowStart:            sinceWindow,
+			AvgStepTimeSec:              m.Status.AvgStepTimeSec,
+		}, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/goodput_set_complete_test.go
+++ b/pkg/controller/goodput_set_complete_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// setComplete is the single terminal status write and its first-write-wins
+// guard is the freeze: once Complete is True on the live object, no replay —
+// fresh-cache or stale-cache — may overwrite the frozen status (ADR-072).
+// These cases pin the guard itself: a replay against a live Complete=True
+// object performs no write at all (unchanged status bytes, unchanged
+// resourceVersion), including the stale-cache path where the first attempt
+// conflicts and the guard fires on the refreshed object.
+func TestGoodputSetComplete(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "goodput-set-complete",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			// LiveComplete seeds the live object with an already-landed
+			// terminal write (Complete=True, frozen values).
+			LiveComplete bool `yaml:"liveComplete"`
+			// StaleInMemory hands setComplete a copy taken before the live
+			// object gained Complete, forcing the conflict-then-refresh path.
+			StaleInMemory bool `yaml:"staleInMemory"`
+			// AttemptedResult is the result this pass computed and would write.
+			AttemptedResult string `yaml:"attemptedResult"`
+			Anchor          string `yaml:"anchor"`
+			Reason          string `yaml:"reason"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+		anchor, err := time.Parse(time.RFC3339, in.Anchor)
+		if err != nil {
+			return err
+		}
+
+		scheme := runtime.NewScheme()
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
+			return err
+		}
+
+		ctx := context.Background()
+		key := types.NamespacedName{Namespace: "ns", Name: "m"}
+		frozenAt := metav1.NewTime(time.Date(2026, 1, 22, 10, 5, 0, 0, time.UTC))
+
+		m := &crev1alpha1.GoodputMeasurement{
+			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+			Status: crev1alpha1.GoodputMeasurementStatus{
+				Result:          "0.900000",
+				TrainingTimeSec: "295.000000",
+			},
+		}
+		if in.LiveComplete {
+			m.Status.CompletionTime = &frozenAt
+			meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
+				Type:    crev1alpha1.GoodputMeasurementComplete,
+				Status:  metav1.ConditionTrue,
+				Reason:  "JobSucceeded",
+				Message: "Referenced Job completed successfully",
+			})
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(m).WithStatusSubresource(m).Build()
+		r := &GoodputMeasurementReconciler{Client: c, Scheme: scheme}
+
+		// The copy handed to setComplete: fetched fresh, or — for the
+		// stale-cache replay — taken before the live object gained Complete.
+		arg := &crev1alpha1.GoodputMeasurement{}
+		if err := c.Get(ctx, key, arg); err != nil {
+			return err
+		}
+		if in.StaleInMemory {
+			live := &crev1alpha1.GoodputMeasurement{}
+			if err := c.Get(ctx, key, live); err != nil {
+				return err
+			}
+			live.Status.CompletionTime = &frozenAt
+			meta.SetStatusCondition(&live.Status.Conditions, metav1.Condition{
+				Type:    crev1alpha1.GoodputMeasurementComplete,
+				Status:  metav1.ConditionTrue,
+				Reason:  "JobSucceeded",
+				Message: "Referenced Job completed successfully",
+			})
+			if err := c.Status().Update(ctx, live); err != nil {
+				return err
+			}
+		}
+
+		before := &crev1alpha1.GoodputMeasurement{}
+		if err := c.Get(ctx, key, before); err != nil {
+			return err
+		}
+		beforeStatus, err := json.Marshal(before.Status)
+		if err != nil {
+			return err
+		}
+
+		// The replay computed different values than the frozen ones.
+		if in.AttemptedResult != "" {
+			arg.Status.Result = in.AttemptedResult
+			arg.Status.AvgStepTimeSec = "9.999999"
+		}
+		callErr := r.setComplete(ctx, arg, anchor, in.Reason, "test message")
+
+		after := &crev1alpha1.GoodputMeasurement{}
+		if err := c.Get(ctx, key, after); err != nil {
+			return err
+		}
+		afterStatus, err := json.Marshal(after.Status)
+		if err != nil {
+			return err
+		}
+
+		completionTime := ""
+		if after.Status.CompletionTime != nil {
+			completionTime = after.Status.CompletionTime.UTC().Format(time.RFC3339)
+		}
+		completeReason := ""
+		if cond := meta.FindStatusCondition(after.Status.Conditions, crev1alpha1.GoodputMeasurementComplete); cond != nil {
+			completeReason = cond.Reason
+		}
+		measuringStatus := ""
+		if cond := meta.FindStatusCondition(after.Status.Conditions, crev1alpha1.GoodputMeasurementMeasuring); cond != nil {
+			measuringStatus = string(cond.Status)
+		}
+
+		b, err := json.MarshalIndent(struct {
+			Errored                  bool   `json:"errored"`
+			LiveResourceVersionMoved bool   `json:"liveResourceVersionMoved"`
+			LiveStatusBytesUnchanged bool   `json:"liveStatusBytesUnchanged"`
+			LiveResult               string `json:"liveResult"`
+			LiveCompletionTime       string `json:"liveCompletionTime"`
+			LiveCompleteReason       string `json:"liveCompleteReason"`
+			LiveMeasuringStatus      string `json:"liveMeasuringStatus,omitempty"`
+			LiveAvgStepTimeSec       string `json:"liveAvgStepTimeSec,omitempty"`
+		}{
+			Errored:                  callErr != nil,
+			LiveResourceVersionMoved: before.ResourceVersion != after.ResourceVersion,
+			LiveStatusBytesUnchanged: string(beforeStatus) == string(afterStatus),
+			LiveResult:               after.Status.Result,
+			LiveCompletionTime:       completionTime,
+			LiveCompleteReason:       completeReason,
+			LiveMeasuringStatus:      measuringStatus,
+			LiveAvgStepTimeSec:       after.Status.AvgStepTimeSec,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/goodput_state_recovery_test.go
+++ b/pkg/controller/goodput_state_recovery_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// getOrCreateState rebuilds the in-memory JobState from persisted status after
+// a controller restart. These cases pin what a restarted controller recovers —
+// in particular that LastCountedCheckpointStep mirrors LastCheckpointStep:
+// every checkpoint recorded in status has already been folded into
+// checkpointSaveTimeSec, so a restart-replay of a log window that still shows
+// that checkpoint must not count its save time a second time.
+func TestGoodputStateRecovery(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "goodput-state-recovery",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Status crev1alpha1.GoodputMeasurementStatus `yaml:"status"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		m := &crev1alpha1.GoodputMeasurement{}
+		m.Name = "m"
+		m.Namespace = "ns"
+		m.Status = in.Status
+
+		r := &GoodputMeasurementReconciler{}
+		state := r.getOrCreateState("ns/m", m)
+
+		b, err := json.MarshalIndent(struct {
+			TrainingStarted           bool `json:"trainingStarted"`
+			HighestStep               int  `json:"highestStep"`
+			LastKnownStep             int  `json:"lastKnownStep"`
+			LastCheckpointStep        int  `json:"lastCheckpointStep"`
+			LastCountedCheckpointStep int  `json:"lastCountedCheckpointStep"`
+			LastNonWarmupStep         int  `json:"lastNonWarmupStep"`
+			WarmupBaseStep            int  `json:"warmupBaseStep"`
+			HasPendingInterruption    bool `json:"hasPendingInterruption"`
+		}{
+			TrainingStarted:           state.TrainingStarted,
+			HighestStep:               state.HighestStep,
+			LastKnownStep:             state.LastKnownStep,
+			LastCheckpointStep:        state.LastCheckpointStep,
+			LastCountedCheckpointStep: state.LastCountedCheckpointStep,
+			LastNonWarmupStep:         state.LastNonWarmupStep,
+			WarmupBaseStep:            state.WarmupBaseStep,
+			HasPendingInterruption:    state.PendingInterruption != nil,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/goodput_terminal_anchor_test.go
+++ b/pkg/controller/goodput_terminal_anchor_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
+)
+
+// Terminal goodput computation is anchored to the Job's terminal condition
+// timestamp so that replaying the terminal path produces the same values
+// (ADR-072). These cases pin the anchor source per terminal condition and the
+// wall-clock last resort for a terminal condition without a timestamp.
+func TestTerminalAnchor(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "goodput-terminal-anchor",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Conditions []metav1.Condition `yaml:"conditions"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		job := &crev1alpha1.Job{
+			Status: crev1alpha1.JobStatus{Conditions: in.Conditions},
+		}
+
+		before := time.Now()
+		anchor := terminalAnchor(job)
+		wallClockFallback := !anchor.Before(before)
+
+		out := struct {
+			Anchor                string `json:"anchor"`
+			UsedWallClockFallback bool   `json:"usedWallClockFallback"`
+		}{UsedWallClockFallback: wallClockFallback}
+		if !wallClockFallback {
+			out.Anchor = anchor.UTC().Format(time.RFC3339)
+		}
+
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/goodputmeasurement_controller.go
+++ b/pkg/controller/goodputmeasurement_controller.go
@@ -137,14 +137,19 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("failed to get referenced Job: %w", err)
 	}
 
-	// Determine Job phase from conditions.
+	// Determine Job phase from conditions. All terminal-time computation is
+	// anchored to the Job's terminal condition timestamp so that replaying the
+	// terminal path (stale cache, conflict retry, controller restart) produces
+	// the same status bytes (ADR-072).
 	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
-		r.finalSample(ctx, measurement, job)
-		return r.handleSucceeded(ctx, measurement, job)
+		anchor := terminalAnchor(job)
+		r.collectFinalSample(ctx, measurement, job, anchor)
+		return r.handleSucceeded(ctx, measurement, job, anchor)
 	}
 	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
-		r.finalSample(ctx, measurement, job)
-		return r.handleFailed(ctx, measurement, job)
+		anchor := terminalAnchor(job)
+		r.collectFinalSample(ctx, measurement, job, anchor)
+		return r.handleFailed(ctx, measurement, job, anchor)
 	}
 	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
 		return r.handleRunning(ctx, measurement, job)
@@ -155,28 +160,255 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 	return ctrl.Result{RequeueAfter: r.getSampleInterval(measurement)}, nil
 }
 
-// finalSample reads the logs one last time before a measurement goes terminal.
+// terminalAnchor returns the timestamp of the Job's terminal condition
+// (Succeeded or Failed). Terminal goodput computation is anchored here rather
+// than at the reconcile wall clock so that every replay of the terminal path
+// lands on the same values (ADR-072). A terminal condition always carries a
+// LastTransitionTime; time.Now() is a last-resort fallback for one that
+// somehow does not.
+func terminalAnchor(job *crev1alpha1.Job) time.Time {
+	for _, condType := range []string{crev1alpha1.JobSucceeded, crev1alpha1.JobFailed} {
+		cond := meta.FindStatusCondition(job.Status.Conditions, condType)
+		if cond != nil && cond.Status == metav1.ConditionTrue && !cond.LastTransitionTime.IsZero() {
+			return cond.LastTransitionTime.Time
+		}
+	}
+	return time.Now()
+}
+
+// collectFinalSample reads the logs one last time before a measurement goes
+// terminal and folds the parsed window into the measurement's in-memory
+// status.
 //
 // handleSucceeded and handleFailed both build from the stored status and never
-// read logs again, so everything written in the last sampling window was lost —
-// up to sampleInterval, 60s by default. That matters most on failure, where the
-// last lines before a crash are the interesting ones. Observed on hardware: a
-// script that logged to iteration 100 was recorded as reaching step 90.
+// read logs again, so everything written in the last sampling window would be
+// lost — up to sampleInterval, 60s by default. That matters most on failure,
+// where the last lines before a crash are the interesting ones. Observed on
+// hardware: a script that logged to iteration 100 was recorded as reaching
+// step 90.
 //
-// The throttle in handleRunning exists to stop status updates re-triggering a
-// read, and would usually skip this one, so the sample time is cleared first.
-// Best effort: a failure here leaves the previous status in place, which is
-// what would have happened anyway.
-func (r *GoodputMeasurementReconciler) finalSample(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) {
+// Unlike the running path, this performs no API writes, sets no conditions,
+// and does not consult or update the sampling throttle: the terminal write in
+// setComplete persists everything at once, so a reader can never observe a
+// half-final state (ADR-072). Wall-clock stamps derived from this window are
+// capped at anchor so terminal metrics cannot move past the Job's terminal
+// transition. Best effort: on any failure the previously persisted values
+// stand, which is what would have happened anyway.
+func (r *GoodputMeasurementReconciler) collectFinalSample(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job, anchor time.Time) {
+	log := logf.FromContext(ctx)
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
-	r.mu.Lock()
-	delete(r.lastSample, key)
-	r.mu.Unlock()
+	// A terminal Job is not restarting: no restart detection here, and with no
+	// workload reference there is nothing to read.
+	if job.Status.WorkloadRef == nil {
+		return
+	}
 
-	if _, err := r.handleRunning(ctx, measurement, job); err != nil {
-		logf.FromContext(ctx).Error(err, "Final log read before completion failed",
-			"measurement", key)
+	profile, err := r.getLogProfile(ctx, measurement.Spec.LogProfileRef)
+	if err != nil {
+		log.V(1).Info("Final log read skipped: LogProfile unresolved",
+			"measurement", key, "logProfile", measurement.Spec.LogProfileRef)
+		return
+	}
+	parser, err := r.getOrCreateParser(profile)
+	if err != nil {
+		log.V(1).Info("Final log read skipped: LogProfile patterns do not compile",
+			"measurement", key, "logProfile", profile.Name)
+		return
+	}
+
+	// Serialize against a concurrent reconcile of the same measurement; the
+	// merge below is a read-modify-write cycle over JobState.
+	state := r.getOrCreateState(key, measurement)
+	state.Lock()
+	defer state.Unlock()
+
+	discoverer := podutil.NewWorkerDiscoverer(r.Client)
+	worker0, lastWorker, err := discoverer.GetWorkerPods(ctx, measurement.Namespace, job.Status.WorkloadRef.Name, job.Status.WorkloadRef.Kind)
+	if err != nil {
+		log.V(1).Info("Final log read skipped: worker pods not found", "measurement", key, "error", err)
+		return
+	}
+	if !podutil.IsPodRunning(worker0) {
+		log.V(1).Info("Final log read skipped: worker-0 not running",
+			"measurement", key, "phase", worker0.Status.Phase)
+		return
+	}
+
+	opts := podlogs.LogOptions{
+		Container: profile.Spec.ContainerName,
+	}
+	// The terminal read is windowed by persisted inputs only — never by the
+	// in-memory LastLogFetch. A same-process re-entry and a restarted
+	// controller must parse the same window, or the terminal write is not a
+	// pure function of (persisted status, Job, final log parse) as ADR-072
+	// requires.
+	//
+	// The window starts at the later of the pod's start time and one sample
+	// interval before the persisted lastStepTimestamp, clamped by
+	// maxLogLookback from the anchor. The narrowing matters because the
+	// fetcher caps every read at LimitBytes and the API server keeps the HEAD
+	// of the window (pkg/podlogs/fetcher.go, DefaultMaxLogBytes): on a
+	// heavy-log run a window opened at pod start would truncate away the
+	// newest lines — the ones a final sample exists to capture. One interval
+	// before lastStepTimestamp re-covers the whole last sampling window
+	// without re-reading history the status already reflects, and because
+	// lastStepTimestamp is persisted status, every pre-Complete replay derives
+	// the same window.
+	var since time.Time
+	if worker0.Status.StartTime != nil {
+		since = worker0.Status.StartTime.Time
+	}
+	if ts := measurement.Status.LastStepTimestamp; ts != nil {
+		if fromStatus := ts.Add(-r.getSampleInterval(measurement)); fromStatus.After(since) {
+			since = fromStatus
+		}
+	}
+	// Bound the lookback relative to the anchor, not the wall clock, so a
+	// replayed terminal reconcile reads the same window.
+	if !since.IsZero() {
+		if oldest := anchor.Add(-maxLogLookback); since.Before(oldest) {
+			log.V(1).Info("Clamping final log read anchor to max lookback",
+				"pod", worker0.Name, "since", since, "maxLookback", maxLogLookback)
+			since = oldest
+		}
+		sinceTime := metav1.NewTime(since)
+		opts.SinceTime = &sinceTime
+	}
+
+	reader := goodput.NewLogReader(r.getLogFetcher(), parser)
+	var result *goodput.ParseResult
+	workerStrategy := getWorkerStrategy(profile)
+	if workerStrategy == "Multi" && lastWorker != nil && lastWorker.Name != worker0.Name && podutil.IsPodRunning(lastWorker) {
+		result, err = reader.ReadMultiWorkerLogs(ctx, measurement.Namespace, worker0.Name, lastWorker.Name, opts)
+	} else {
+		result, err = reader.ReadLogs(ctx, measurement.Namespace, worker0.Name, opts)
+	}
+	if err != nil {
+		log.Error(err, "Final log read before completion failed", "measurement", key)
+		return
+	}
+
+	// Cap the window's end at the anchor before merging: parsed entries
+	// stamped after the Job's terminal transition must not flow into terminal
+	// metrics (ADR-072 Decision 4). This is the single choke point for the
+	// cap — mergeSampleWindow itself stays terminal-agnostic.
+	capParseResultAtAnchor(result, anchor)
+
+	// Snapshot the persisted training progress before the merge. The merge
+	// takes the parsed window at face value, but a truncated final window
+	// (LimitBytes head-cap, see the window comment above) can end before the
+	// progress the status already holds, and the values written here freeze.
+	prevCurrentStep := measurement.Status.CurrentStep
+	prevHighestStep := measurement.Status.HighestStep
+	prevLastStepTS := measurement.Status.LastStepTimestamp
+	prevAvgStepTime := measurement.Status.AvgStepTimeSec
+	prevAvgTFLOPS := measurement.Status.AvgTFLOPSPerGPU
+
+	cm := r.buildCumulativeFromStatus(measurement)
+	r.mergeSampleWindow(ctx, measurement, state, cm, profile, result, anchor)
+
+	// Defense in depth: the terminal merge must never move training progress
+	// backward from what status already holds. The guard lives here rather
+	// than in mergeSampleWindow or UpdateTrainingProgress because the running
+	// path must allow regressions — a checkpoint restart legitimately resumes
+	// from an earlier step — while on the terminal path a lower step can only
+	// mean the final read saw less than the status already recorded.
+	if cm.CurrentStep < prevCurrentStep {
+		cm.CurrentStep = prevCurrentStep
+	}
+	if cm.HighestStep < prevHighestStep {
+		cm.HighestStep = prevHighestStep
+	}
+	if state.LastKnownStep < prevCurrentStep {
+		state.LastKnownStep = prevCurrentStep
+	}
+	if state.HighestStep < prevHighestStep {
+		state.HighestStep = prevHighestStep
+	}
+	// Window-derived fields (avg timings, lastStepTimestamp) keep their
+	// persisted values unless the final window advanced past the persisted
+	// last step. A window that ends at or before it is a re-read of history
+	// the status already reflects (or a truncated one): recomputing the
+	// averages over that partial window would change — or regress — values
+	// that are about to freeze, and a pre-Complete replay must land on the
+	// same bytes as the pass whose window it re-reads.
+	advanced := result.LastStep != nil &&
+		(prevLastStepTS == nil ||
+			result.LastStep.Timestamp.After(prevLastStepTS.Time) ||
+			result.LastStep.GlobalStep > prevCurrentStep)
+	if !advanced {
+		measurement.Status.LastStepTimestamp = prevLastStepTS
+		measurement.Status.AvgStepTimeSec = prevAvgStepTime
+		measurement.Status.AvgTFLOPSPerGPU = prevAvgTFLOPS
+	}
+
+	// A run that was never sampled while running has no persisted startTime.
+	// The first step's log timestamp is deterministic, unlike the wall clock,
+	// so record it as the training start for the terminal t_w computation.
+	if measurement.Status.StartTime == nil && !cm.TrainingStartTime.IsZero() {
+		t := metav1.NewTime(cm.TrainingStartTime)
+		measurement.Status.StartTime = &t
+	}
+
+	r.writeStatusFromCumulative(measurement, cm)
+}
+
+// capParseResultAtAnchor drops parsed entries stamped after the Job's terminal
+// anchor so the terminal merge cannot carry metrics past the Job's terminal
+// transition (ADR-072 Decision 4). It runs on the parse result before
+// mergeSampleWindow — the single choke point for the cap, keeping the merge
+// itself terminal-agnostic. Entries without a timestamp are kept: they cannot
+// claim to be later than the anchor.
+func capParseResultAtAnchor(result *goodput.ParseResult, anchor time.Time) {
+	if result == nil {
+		return
+	}
+
+	steps := result.Steps[:0]
+	for _, s := range result.Steps {
+		if s.Timestamp.After(anchor) {
+			continue
+		}
+		steps = append(steps, s)
+	}
+	result.Steps = steps
+	if result.FirstStep != nil && result.FirstStep.Timestamp.After(anchor) {
+		result.FirstStep = nil
+		if len(result.Steps) > 0 {
+			result.FirstStep = result.Steps[0]
+		}
+	}
+	if result.LastStep != nil && result.LastStep.Timestamp.After(anchor) {
+		result.LastStep = nil
+		if n := len(result.Steps); n > 0 {
+			result.LastStep = result.Steps[n-1]
+		}
+	}
+
+	ckpts := result.Checkpoints[:0]
+	for _, c := range result.Checkpoints {
+		if c.Timestamp.After(anchor) {
+			continue
+		}
+		ckpts = append(ckpts, c)
+	}
+	result.Checkpoints = ckpts
+	if result.LastCheckpoint != nil && result.LastCheckpoint.Timestamp.After(anchor) {
+		result.LastCheckpoint = nil
+		if n := len(result.Checkpoints); n > 0 {
+			result.LastCheckpoint = result.Checkpoints[n-1]
+		}
+	}
+
+	if result.PendingSave != nil && result.PendingSave.Timestamp.After(anchor) {
+		result.PendingSave = nil
+	}
+	if result.ApplicationStartTime.After(anchor) {
+		result.ApplicationStartTime = time.Time{}
+	}
+	if result.LastLogTimestamp.After(anchor) {
+		result.LastLogTimestamp = anchor
 	}
 }
 
@@ -304,6 +536,82 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 		return ctrl.Result{RequeueAfter: interval}, nil
 	}
 
+	// Get cumulative metrics from the GoodputMeasurement's in-memory state and
+	// fold the parsed window into it. The running path stamps wall-clock time.
+	cm := r.buildCumulativeFromStatus(measurement)
+	r.mergeSampleWindow(ctx, measurement, state, cm, profile, result, time.Now())
+
+	// Calculate training time (t_w) and goodput. The running value is
+	// provisional (wall clock); the terminal handlers recompute it anchored to
+	// the Job's terminal condition timestamp (ADR-072).
+	if state.TrainingStarted && !cm.TrainingStartTime.IsZero() {
+		cm.UpdateTrainingTime(time.Since(cm.TrainingStartTime).Seconds())
+	}
+
+	// Set measuring condition and record start time.
+	if measurement.Status.StartTime == nil {
+		now := metav1.Now()
+		measurement.Status.StartTime = &now
+	}
+	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
+		Type:               crev1alpha1.GoodputMeasurementMeasuring,
+		Status:             metav1.ConditionTrue,
+		Reason:             "JobRunning",
+		Message:            "Referenced Job is running, measurement in progress",
+		ObservedGeneration: measurement.Generation,
+	})
+
+	// Write cumulative metrics to status.
+	r.writeStatusFromCumulative(measurement, cm)
+
+	workflow := job.Labels["cre.nvidia.com/workflow"]
+	recordGoodputMetrics(
+		measurement.Namespace, measurement.Name, measurement.Spec.JobRef.Name, workflow,
+		goodputMetricValues{
+			GoodputRatio:       cm.Goodput,
+			AvgTFLOPS:          parseFloat(measurement.Status.AvgTFLOPSPerGPU),
+			AvgStepTime:        parseFloat(measurement.Status.AvgStepTimeSec),
+			RescheduleTime:     cm.RescheduleTime,
+			ResumeTime:         cm.ResumeTime,
+			CheckpointSaveTime: cm.CheckpointSaveTime,
+			LostWorkTime:       cm.LostWorkTime,
+			TrainingTime:       cm.TrainingTime,
+			WarmupTime:         parseFloat(measurement.Status.WarmupTimeSec),
+			NonWarmupTime:      parseFloat(measurement.Status.NonWarmupTimeSec),
+		},
+	)
+
+	if err := r.Status().Update(ctx, measurement); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update measurement status: %w", err)
+	}
+
+	// Record sample time so we throttle the next status-triggered reconcile.
+	r.mu.Lock()
+	r.lastSample[key] = time.Now()
+	r.mu.Unlock()
+
+	return ctrl.Result{RequeueAfter: interval}, nil
+}
+
+// mergeSampleWindow folds one parsed log window into the in-memory JobState,
+// the cumulative metrics, and the measurement's in-memory status. now is the
+// wall-clock stamp used for ApplicationStopTime; the running path passes
+// time.Now(), the terminal path passes the Job's terminal anchor so terminal
+// metrics can never move past the Job's terminal transition (ADR-072).
+//
+// This performs no API writes and sets no conditions. The caller must hold
+// state's lock.
+func (r *GoodputMeasurementReconciler) mergeSampleWindow( //nolint:gocyclo
+	ctx context.Context,
+	measurement *crev1alpha1.GoodputMeasurement,
+	state *goodput.JobState,
+	cm *goodput.CumulativeMetrics,
+	profile *crev1alpha1.LogProfile,
+	result *goodput.ParseResult,
+	now time.Time,
+) {
+	log := logf.FromContext(ctx)
+
 	// Track the last log timestamp so subsequent reads use SinceTime.
 	// ApplicationStopTime uses wall-clock time (not the log-embedded timestamp)
 	// because the app continues running between logged steps. For models that
@@ -311,14 +619,10 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 	// can lag the actual crash time by a full log interval.
 	if !result.LastLogTimestamp.IsZero() {
 		state.LastLogFetch = result.LastLogTimestamp
-		now := time.Now()
 		state.ApplicationStopTime = now
 		t := metav1.NewTime(now)
 		measurement.Status.ApplicationStopTime = &t
 	}
-
-	// Get cumulative metrics from the GoodputMeasurement's in-memory state.
-	cm := r.buildCumulativeFromStatus(measurement)
 
 	// Fill in checkpoint save duration from persisted pending save when the
 	// save line was outside the tail window but the done line is visible.
@@ -462,31 +766,10 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 		state.LastCountedCheckpointStep = result.LastCheckpoint.Step
 	}
 
-	// Calculate training time (t_w) and goodput.
-	if state.TrainingStarted && !cm.TrainingStartTime.IsZero() {
-		cm.UpdateTrainingTime(time.Since(cm.TrainingStartTime).Seconds())
-	}
-
 	// Clear pending interruption from status after completion.
 	if state.PendingInterruption == nil {
 		cm.PendingInterruption = nil
 	}
-
-	// Set measuring condition and record start time.
-	if measurement.Status.StartTime == nil {
-		now := metav1.Now()
-		measurement.Status.StartTime = &now
-	}
-	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
-		Type:               crev1alpha1.GoodputMeasurementMeasuring,
-		Status:             metav1.ConditionTrue,
-		Reason:             "JobRunning",
-		Message:            "Referenced Job is running, measurement in progress",
-		ObservedGeneration: measurement.Generation,
-	})
-
-	// Write cumulative metrics to status.
-	r.writeStatusFromCumulative(measurement, cm)
 
 	// Persist ApplicationStartTime so it survives controller restarts.
 	if !state.ApplicationStartTime.IsZero() {
@@ -545,50 +828,20 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 		state.LastNonWarmupStep = result.LastStep.GlobalStep
 		measurement.Status.LastNonWarmupStep = state.LastNonWarmupStep
 	}
-
-	workflow := job.Labels["cre.nvidia.com/workflow"]
-	recordGoodputMetrics(
-		measurement.Namespace, measurement.Name, measurement.Spec.JobRef.Name, workflow,
-		goodputMetricValues{
-			GoodputRatio:       cm.Goodput,
-			AvgTFLOPS:          parseFloat(measurement.Status.AvgTFLOPSPerGPU),
-			AvgStepTime:        parseFloat(measurement.Status.AvgStepTimeSec),
-			RescheduleTime:     cm.RescheduleTime,
-			ResumeTime:         cm.ResumeTime,
-			CheckpointSaveTime: cm.CheckpointSaveTime,
-			LostWorkTime:       cm.LostWorkTime,
-			TrainingTime:       cm.TrainingTime,
-			WarmupTime:         parseFloat(measurement.Status.WarmupTimeSec),
-			NonWarmupTime:      parseFloat(measurement.Status.NonWarmupTimeSec),
-		},
-	)
-
-	if err := r.Status().Update(ctx, measurement); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update measurement status: %w", err)
-	}
-
-	// Record sample time so we throttle the next status-triggered reconcile.
-	r.mu.Lock()
-	r.lastSample[key] = time.Now()
-	r.mu.Unlock()
-
-	return ctrl.Result{RequeueAfter: interval}, nil
 }
 
 // handleSucceeded processes a succeeded job.
-func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job, anchor time.Time) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
-	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
 	cm := r.buildCumulativeFromStatus(measurement)
 
-	if state := r.getState(key); state != nil {
-		state.Lock()
-		trainingStarted := state.TrainingStarted
-		state.Unlock()
-		if trainingStarted && !cm.TrainingStartTime.IsZero() {
-			cm.UpdateTrainingTime(time.Since(cm.TrainingStartTime).Seconds())
-		}
+	// Terminal t_w is anchored to the Job's terminal transition, not the
+	// reconcile wall clock, and the training start comes from persisted
+	// status, not in-memory state: a restarted controller computes the same
+	// value as a long-lived one, and a replay writes the same bytes (ADR-072).
+	if !cm.TrainingStartTime.IsZero() && anchor.After(cm.TrainingStartTime) {
+		cm.UpdateTrainingTime(anchor.Sub(cm.TrainingStartTime).Seconds())
 	}
 	cm.SetStatus("Succeeded")
 
@@ -621,15 +874,15 @@ func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, meas
 	// never absent. Observed on hardware: a run whose logs missed the trainingStep
 	// pattern reported Complete/JobSucceeded with result 0.000000 and no steps.
 	if measurement.Status.Result == "" || parseFloat(measurement.Status.Result) == 0 {
-		return ctrl.Result{}, r.setComplete(ctx, measurement, reasonGoodputNoData,
+		return ctrl.Result{}, r.setComplete(ctx, measurement, anchor, reasonGoodputNoData,
 			"Job succeeded but no goodput was computed; check spec.logProfileRef")
 	}
 
-	return ctrl.Result{}, r.setComplete(ctx, measurement, "JobSucceeded", "Referenced Job completed successfully")
+	return ctrl.Result{}, r.setComplete(ctx, measurement, anchor, "JobSucceeded", "Referenced Job completed successfully")
 }
 
 // handleFailed processes a failed job by recording an interruption event.
-func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job, anchor time.Time) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
@@ -662,8 +915,12 @@ func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measure
 			}
 		}
 	}
-	if terminationTime.IsZero() {
-		terminationTime = time.Now()
+	// The anchor is the deterministic floor and ceiling for the termination
+	// time (ADR-072): the fallback for a missing log/pod-derived time, and a
+	// cap so late-arriving timestamps cannot push terminal metrics past the
+	// Job's terminal transition.
+	if terminationTime.IsZero() || terminationTime.After(anchor) {
+		terminationTime = anchor
 	}
 
 	// Build interruption event.
@@ -685,7 +942,10 @@ func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measure
 	cm.LostWorkTime += event.TCh
 	cm.InterruptionCount++
 
-	if state.TrainingStarted && !cm.TrainingStartTime.IsZero() {
+	// Terminal t_w derives from persisted status and the anchored termination
+	// time, not from in-memory state, so a replayed terminal reconcile writes
+	// the same bytes (ADR-072).
+	if !cm.TrainingStartTime.IsZero() && terminationTime.After(cm.TrainingStartTime) {
 		cm.TrainingTime = terminationTime.Sub(cm.TrainingStartTime).Seconds()
 		cm.Goodput = goodput.CalculateGoodput(cm.TrainingTime, cm.LostWorkTime, cm.RescheduleTime, cm.ResumeTime, cm.CheckpointSaveTime)
 	}
@@ -723,7 +983,7 @@ func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measure
 	)
 	cleanupOperationalGoodputMetrics(measurement.Namespace, measurement.Name, measurement.Spec.JobRef.Name, workflow)
 
-	return ctrl.Result{}, r.setComplete(ctx, measurement, "JobFailed", "Referenced Job failed")
+	return ctrl.Result{}, r.setComplete(ctx, measurement, anchor, "JobFailed", "Referenced Job failed")
 }
 
 // completeInterruption completes a pending interruption event after job restart.
@@ -879,6 +1139,10 @@ func (r *GoodputMeasurementReconciler) getOrCreateState(key string, measurement 
 	state.HighestStep = measurement.Status.HighestStep
 	state.LastKnownStep = measurement.Status.CurrentStep
 	state.LastCheckpointStep = measurement.Status.LastCheckpointStep
+	// Checkpoints recorded in status have already been folded into
+	// checkpointSaveTimeSec, so a restart-replay of a window that still shows
+	// the last checkpoint must not count its save time again.
+	state.LastCountedCheckpointStep = measurement.Status.LastCheckpointStep
 	state.LastNonWarmupStep = measurement.Status.LastNonWarmupStep
 	if measurement.Status.LastCheckpointTime != nil {
 		state.LastCheckpointTime = measurement.Status.LastCheckpointTime.Time
@@ -917,16 +1181,6 @@ func (r *GoodputMeasurementReconciler) getOrCreateState(key string, measurement 
 
 	r.jobStates[key] = state
 	return state
-}
-
-// getState returns the in-memory job state if it exists.
-func (r *GoodputMeasurementReconciler) getState(key string) *goodput.JobState {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.jobStates == nil {
-		return nil
-	}
-	return r.jobStates[key]
 }
 
 // cleanupState removes in-memory state for a deleted measurement.
@@ -1038,18 +1292,31 @@ func (r *GoodputMeasurementReconciler) noteLogProfileUnresolved(ctx context.Cont
 	}
 }
 
-// setComplete sets the Complete condition, records CompletionTime, and stores the result.
-func (r *GoodputMeasurementReconciler) setComplete(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, reason, message string) error {
+// setComplete sets the Complete condition, records CompletionTime, and stores
+// the result. This is the single terminal status write: the final log sample,
+// the terminal metrics, completionTime, Complete=True, and Measuring=False all
+// land atomically, so a reader can never observe a half-final state (ADR-072).
+// CompletionTime is the Job's terminal anchor, not the reconcile wall clock.
+func (r *GoodputMeasurementReconciler) setComplete(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, anchor time.Time, reason, message string) error {
 	// The computed status payload is carried over on retry: a conflicting write
 	// only means the object moved on, not that this measurement's result changed.
 	status := measurement.Status.DeepCopy()
-	now := metav1.Now()
+	completion := metav1.NewTime(anchor)
 
 	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *crev1alpha1.GoodputMeasurement) bool {
+		// First terminal write wins (ADR-072). A replay normally recomputes
+		// the same bytes from the same persisted inputs, but a replay whose
+		// final log read fails (pod garbage-collected, logs rotated) proceeds
+		// from older persisted values instead, so once Complete is True on the
+		// live object the frozen status must never be overwritten, whatever
+		// this pass computed. Returning false skips the write entirely.
+		if meta.IsStatusConditionTrue(m.Status.Conditions, crev1alpha1.GoodputMeasurementComplete) {
+			return false
+		}
 		conditions := m.Status.Conditions
 		status.DeepCopyInto(&m.Status)
 		m.Status.Conditions = conditions
-		m.Status.CompletionTime = &now
+		m.Status.CompletionTime = &completion
 
 		meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
 			Type:               crev1alpha1.GoodputMeasurementComplete,

--- a/pkg/controller/job_threshold_helpers.go
+++ b/pkg/controller/job_threshold_helpers.go
@@ -60,7 +60,15 @@ func collectJobMeasuredValues(ctx context.Context, c client.Reader, job *crev1al
 		values["algBandwidthGBps"] = maxAlgBandwidth(bm.Status.Results)
 	}
 
-	if gm := findJobGoodputMeasurement(ctx, c, job); gm != nil {
+	// Goodput-derived values are provisional until the measurement's Complete
+	// condition is True: the GoodputMeasurement controller freezes the status
+	// in a single terminal write anchored to the Job's terminal transition
+	// (ADR-072). Evaluating earlier would make pass/fail depend on when this
+	// controller happened to read. The missing-key requeue and the
+	// measurementTimeout machinery in checkPerformanceThresholds handle the
+	// wait for Complete.
+	if gm := findJobGoodputMeasurement(ctx, c, job); gm != nil &&
+		meta.IsStatusConditionTrue(gm.Status.Conditions, crev1alpha1.GoodputMeasurementComplete) {
 		if v := parseStallFloat(gm.Status.Result); v > 0 {
 			values["goodputRatio"] = v
 		}

--- a/pkg/controller/testdata/collect-job-measured-values/complete-measurement-provides-goodput-keys/expected.json
+++ b/pkg/controller/testdata/collect-job-measured-values/complete-measurement-provides-goodput-keys/expected.json
@@ -1,0 +1,7 @@
+{
+  "algBandwidthGBps": 450.2,
+  "avgStepTimeSec": 1.25,
+  "avgTFLOPsPerGPU": 512.5,
+  "busBandwidthGBps": 980.1,
+  "goodputRatio": 0.88
+}

--- a/pkg/controller/testdata/collect-job-measured-values/complete-measurement-provides-goodput-keys/input.yaml
+++ b/pkg/controller/testdata/collect-job-measured-values/complete-measurement-provides-goodput-keys/input.yaml
@@ -1,0 +1,8 @@
+# Once the GoodputMeasurement is Complete=True, its frozen values feed
+# threshold evaluation alongside the bandwidth values.
+goodputComplete: true
+result: "0.88"
+avgTFLOPSPerGPU: "512.5"
+avgStepTimeSec: "1.25"
+busBW: "980.1"
+algBW: "450.2"

--- a/pkg/controller/testdata/collect-job-measured-values/incomplete-measurement-skips-goodput-keys/expected.json
+++ b/pkg/controller/testdata/collect-job-measured-values/incomplete-measurement-skips-goodput-keys/expected.json
@@ -1,0 +1,4 @@
+{
+  "algBandwidthGBps": 450.2,
+  "busBandwidthGBps": 980.1
+}

--- a/pkg/controller/testdata/collect-job-measured-values/incomplete-measurement-skips-goodput-keys/input.yaml
+++ b/pkg/controller/testdata/collect-job-measured-values/incomplete-measurement-skips-goodput-keys/input.yaml
@@ -1,0 +1,9 @@
+# While the GoodputMeasurement is not Complete, its values are provisional and
+# must not feed threshold evaluation — only the bandwidth keys are collected,
+# and the missing goodput keys make checkPerformanceThresholds requeue.
+goodputComplete: false
+result: "0.88"
+avgTFLOPSPerGPU: "512.5"
+avgStepTimeSec: "1.25"
+busBW: "980.1"
+algBW: "450.2"

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/expected.json
@@ -1,4 +1,0 @@
-{
-  "throttleCleared": true,
-  "askedForRequeue": false
-}

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-clears-the-throttle/input.yaml
@@ -1,4 +1,0 @@
-# The final read lands moments after the previous sample, so without clearing
-# the sample time it would be skipped and the last window of output lost.
-call: finalSample
-sampledSecondsAgo: 1

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-missing-profile-is-best-effort/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-missing-profile-is-best-effort/expected.json
@@ -3,5 +3,5 @@
   "applicationStopTimeCappedAt": "",
   "apiStatusUntouched": true,
   "throttleUntouched": true,
-  "askedForRequeue": true
+  "askedForRequeue": false
 }

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-missing-profile-is-best-effort/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-missing-profile-is-best-effort/input.yaml
@@ -1,0 +1,8 @@
+# An unresolved LogProfile at terminal time is best-effort: the previously
+# persisted values stand. Unlike the running path, no LogProfileNotFound
+# condition is written — the final-sample path performs no API writes.
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: does-not-resolve
+logs:
+  - "2026-01-22T10:00:05.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-reads-without-write-or-throttle/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-reads-without-write-or-throttle/expected.json
@@ -1,0 +1,7 @@
+{
+  "currentStepInMemory": 30,
+  "applicationStopTimeCappedAt": "2026-01-22T10:05:00Z",
+  "apiStatusUntouched": true,
+  "throttleUntouched": true,
+  "askedForRequeue": false
+}

--- a/pkg/controller/testdata/goodput-final-sample/final-sample-reads-without-write-or-throttle/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/final-sample-reads-without-write-or-throttle/input.yaml
@@ -1,0 +1,9 @@
+# The final read must run even moments after a periodic sample (the throttle
+# does not apply to it), must fold the window into the in-memory status only
+# (setComplete performs the single terminal write, ADR-072), and must cap
+# ApplicationStopTime at the Job's terminal anchor instead of the wall clock.
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: lp
+logs:
+  - "2026-01-22T10:00:05.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/plain-read-stays-throttled/input.yaml
@@ -1,4 +1,7 @@
-# The throttle exists so a status update does not re-trigger a read. This is
-# the behaviour finalSample has to work around.
+# The throttle exists so a status update does not re-trigger a read. A
+# periodic sample moments after the previous one is skipped and requeued.
 call: handleRunning
 sampledSecondsAgo: 1
+logProfileRef: lp
+logs:
+  - "2026-01-22T10:00:05.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-final-sample/terminal-cap-drops-post-anchor-entries/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-cap-drops-post-anchor-entries/expected.json
@@ -1,0 +1,7 @@
+{
+  "currentStepInMemory": 30,
+  "applicationStopTimeCappedAt": "2026-01-22T10:05:00Z",
+  "apiStatusUntouched": true,
+  "throttleUntouched": true,
+  "askedForRequeue": false
+}

--- a/pkg/controller/testdata/goodput-final-sample/terminal-cap-drops-post-anchor-entries/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-cap-drops-post-anchor-entries/input.yaml
@@ -1,0 +1,10 @@
+# ADR-072 Decision 4: the log window is capped at the anchor. A step line
+# stamped after the Job's terminal transition (10:05:00) must not flow into
+# terminal metrics: the merged step stays 30, not 40, and ApplicationStopTime
+# stays capped at the anchor.
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: lp
+logs:
+  - "2026-01-22T10:00:05.000000000Z step 30"
+  - "2026-01-22T10:06:00.000000000Z step 40"

--- a/pkg/controller/testdata/goodput-final-sample/terminal-merge-never-regresses-persisted-progress/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-merge-never-regresses-persisted-progress/expected.json
@@ -1,0 +1,8 @@
+{
+  "currentStepInMemory": 90,
+  "applicationStopTimeCappedAt": "2026-01-22T10:05:00Z",
+  "apiStatusUntouched": true,
+  "throttleUntouched": true,
+  "askedForRequeue": false,
+  "sinceWindowStart": "2026-01-22T10:03:00Z"
+}

--- a/pkg/controller/testdata/goodput-final-sample/terminal-merge-never-regresses-persisted-progress/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-merge-never-regresses-persisted-progress/input.yaml
@@ -1,0 +1,13 @@
+# Defense in depth for the LimitBytes head-cap: when the final window is
+# truncated and ends before the progress the status already holds (persisted
+# step 90, window ends at step 30), the terminal merge must not move
+# currentStep backward — the persisted value freezes.
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: lp
+status:
+  currentStep: 90
+  highestStep: 90
+  lastStepTimestamp: "2026-01-22T10:04:00Z"
+logs:
+  - "2026-01-22T10:00:05.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-final-sample/terminal-window-not-advanced-keeps-avg/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-window-not-advanced-keeps-avg/expected.json
@@ -1,0 +1,9 @@
+{
+  "currentStepInMemory": 30,
+  "applicationStopTimeCappedAt": "2026-01-22T10:05:00Z",
+  "apiStatusUntouched": true,
+  "throttleUntouched": true,
+  "askedForRequeue": false,
+  "sinceWindowStart": "2026-01-22T10:02:00Z",
+  "avgStepTimeSec": "5.500000"
+}

--- a/pkg/controller/testdata/goodput-final-sample/terminal-window-not-advanced-keeps-avg/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-window-not-advanced-keeps-avg/input.yaml
@@ -1,0 +1,17 @@
+# A final window whose last step does not advance past the persisted
+# lastStepTimestamp is a re-read of history the status already reflects:
+# window-derived fields (avgStepTimeSec) keep their persisted values instead
+# of being recomputed over the partial window, so a pre-Complete replay lands
+# on the same bytes as the pass whose window it re-reads. Recomputed over this
+# window alone the average would be 12s (120s gap / 10 steps).
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: lp
+status:
+  currentStep: 30
+  highestStep: 30
+  lastStepTimestamp: "2026-01-22T10:03:00Z"
+  avgStepTimeSec: "5.500000"
+logs:
+  - "2026-01-22T10:01:00.000000000Z step 20"
+  - "2026-01-22T10:03:00.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-final-sample/terminal-window-starts-before-persisted-last-step/expected.json
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-window-starts-before-persisted-last-step/expected.json
@@ -1,0 +1,8 @@
+{
+  "currentStepInMemory": 30,
+  "applicationStopTimeCappedAt": "2026-01-22T10:05:00Z",
+  "apiStatusUntouched": true,
+  "throttleUntouched": true,
+  "askedForRequeue": false,
+  "sinceWindowStart": "2026-01-22T10:02:00Z"
+}

--- a/pkg/controller/testdata/goodput-final-sample/terminal-window-starts-before-persisted-last-step/input.yaml
+++ b/pkg/controller/testdata/goodput-final-sample/terminal-window-starts-before-persisted-last-step/input.yaml
@@ -1,0 +1,15 @@
+# ADR-072 / issue #177 review finding: the terminal read window must derive
+# from persisted status, not from pod start. The fetcher's LimitBytes keeps
+# the HEAD of the window, so a window opened at pod start on a heavy-log run
+# truncates away the newest lines. With status.lastStepTimestamp persisted at
+# 10:03:00 and the default 60s sample interval, the final read must open at
+# 10:02:00 — re-covering exactly the last sampling window.
+call: collectFinalSample
+sampledSecondsAgo: 1
+logProfileRef: lp
+status:
+  currentStep: 30
+  highestStep: 30
+  lastStepTimestamp: "2026-01-22T10:03:00Z"
+logs:
+  - "2026-01-22T10:03:00.000000000Z step 30"

--- a/pkg/controller/testdata/goodput-set-complete/complete-intact-replay-writes-nothing/expected.json
+++ b/pkg/controller/testdata/goodput-set-complete/complete-intact-replay-writes-nothing/expected.json
@@ -1,0 +1,8 @@
+{
+  "errored": false,
+  "liveResourceVersionMoved": false,
+  "liveStatusBytesUnchanged": true,
+  "liveResult": "0.900000",
+  "liveCompletionTime": "2026-01-22T10:05:00Z",
+  "liveCompleteReason": "JobSucceeded"
+}

--- a/pkg/controller/testdata/goodput-set-complete/complete-intact-replay-writes-nothing/input.yaml
+++ b/pkg/controller/testdata/goodput-set-complete/complete-intact-replay-writes-nothing/input.yaml
@@ -1,0 +1,9 @@
+# The live object already carries a landed terminal write (Complete=True,
+# result 0.900000, completionTime 10:05). A replay that recomputed different
+# values (result 0.500000, a different anchor) must not write at all: the
+# guard returns false, the status bytes and resourceVersion do not move, and
+# the frozen values stand (ADR-072 first-write-wins).
+liveComplete: true
+attemptedResult: "0.500000"
+anchor: "2026-01-22T10:06:00Z"
+reason: JobSucceeded

--- a/pkg/controller/testdata/goodput-set-complete/first-terminal-write-lands/expected.json
+++ b/pkg/controller/testdata/goodput-set-complete/first-terminal-write-lands/expected.json
@@ -1,0 +1,10 @@
+{
+  "errored": false,
+  "liveResourceVersionMoved": true,
+  "liveStatusBytesUnchanged": false,
+  "liveResult": "0.950000",
+  "liveCompletionTime": "2026-01-22T10:05:00Z",
+  "liveCompleteReason": "JobSucceeded",
+  "liveMeasuringStatus": "False",
+  "liveAvgStepTimeSec": "9.999999"
+}

--- a/pkg/controller/testdata/goodput-set-complete/first-terminal-write-lands/input.yaml
+++ b/pkg/controller/testdata/goodput-set-complete/first-terminal-write-lands/input.yaml
@@ -1,0 +1,7 @@
+# The first terminal write is not blocked by the guard: Complete lands with
+# the caller's reason, completionTime is stamped from the Job's terminal
+# anchor (not the wall clock), Measuring flips to False, and the computed
+# payload (result, avg) is persisted.
+attemptedResult: "0.950000"
+anchor: "2026-01-22T10:05:00Z"
+reason: JobSucceeded

--- a/pkg/controller/testdata/goodput-set-complete/stale-cache-replay-conflicts-then-skips/expected.json
+++ b/pkg/controller/testdata/goodput-set-complete/stale-cache-replay-conflicts-then-skips/expected.json
@@ -1,0 +1,8 @@
+{
+  "errored": false,
+  "liveResourceVersionMoved": false,
+  "liveStatusBytesUnchanged": true,
+  "liveResult": "0.900000",
+  "liveCompletionTime": "2026-01-22T10:05:00Z",
+  "liveCompleteReason": "JobSucceeded"
+}

--- a/pkg/controller/testdata/goodput-set-complete/stale-cache-replay-conflicts-then-skips/input.yaml
+++ b/pkg/controller/testdata/goodput-set-complete/stale-cache-replay-conflicts-then-skips/input.yaml
@@ -1,0 +1,9 @@
+# Stale-cache replay: the copy handed to setComplete predates the live
+# object's Complete write, so its own conditions show no Complete and the
+# first update attempt conflicts on resourceVersion. The retry refreshes the
+# object, the guard sees Complete=True, and the write is skipped — the frozen
+# status survives a replay that could not even see it (ADR-072).
+staleInMemory: true
+attemptedResult: "0.500000"
+anchor: "2026-01-22T10:06:00Z"
+reason: JobSucceeded

--- a/pkg/controller/testdata/goodput-state-recovery/empty-status-recovers-zero-state/expected.json
+++ b/pkg/controller/testdata/goodput-state-recovery/empty-status-recovers-zero-state/expected.json
@@ -1,0 +1,10 @@
+{
+  "trainingStarted": false,
+  "highestStep": 0,
+  "lastKnownStep": 0,
+  "lastCheckpointStep": 0,
+  "lastCountedCheckpointStep": 0,
+  "lastNonWarmupStep": 0,
+  "warmupBaseStep": -1,
+  "hasPendingInterruption": false
+}

--- a/pkg/controller/testdata/goodput-state-recovery/empty-status-recovers-zero-state/input.yaml
+++ b/pkg/controller/testdata/goodput-state-recovery/empty-status-recovers-zero-state/input.yaml
@@ -1,0 +1,3 @@
+# A measurement that never sampled recovers a zero state: training not
+# started, all watermarks zero, and the warmup base sentinel -1 (unset).
+status: {}

--- a/pkg/controller/testdata/goodput-state-recovery/recovers-counted-checkpoint-watermark/expected.json
+++ b/pkg/controller/testdata/goodput-state-recovery/recovers-counted-checkpoint-watermark/expected.json
@@ -1,0 +1,10 @@
+{
+  "trainingStarted": true,
+  "highestStep": 180,
+  "lastKnownStep": 180,
+  "lastCheckpointStep": 150,
+  "lastCountedCheckpointStep": 150,
+  "lastNonWarmupStep": 180,
+  "warmupBaseStep": 10,
+  "hasPendingInterruption": false
+}

--- a/pkg/controller/testdata/goodput-state-recovery/recovers-counted-checkpoint-watermark/input.yaml
+++ b/pkg/controller/testdata/goodput-state-recovery/recovers-counted-checkpoint-watermark/input.yaml
@@ -1,0 +1,13 @@
+# Issue #177 review finding: a restarted controller recovered
+# LastCheckpointStep but left LastCountedCheckpointStep at zero, so a
+# restart-replay of a window still showing checkpoint 150 re-added its save
+# duration to checkpointSaveTimeSec. Recovery must set the counted watermark
+# to the persisted checkpoint step.
+status:
+  startTime: "2026-01-22T10:00:05Z"
+  currentStep: 180
+  highestStep: 180
+  lastCheckpointStep: 150
+  checkpointSaveTimeSec: "12.000000"
+  lastNonWarmupStep: 180
+  warmupBaseStep: 10

--- a/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-failed-condition/expected.json
+++ b/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-failed-condition/expected.json
@@ -1,0 +1,4 @@
+{
+  "anchor": "2026-01-22T10:07:30Z",
+  "usedWallClockFallback": false
+}

--- a/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-failed-condition/input.yaml
+++ b/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-failed-condition/input.yaml
@@ -1,0 +1,10 @@
+# The Failed condition's LastTransitionTime is the terminal anchor.
+conditions:
+  - type: Failed
+    status: "True"
+    reason: WorkloadFailed
+    lastTransitionTime: "2026-01-22T10:07:30Z"
+  - type: Succeeded
+    status: "False"
+    reason: NotApplicable
+    lastTransitionTime: "2026-01-22T10:07:30Z"

--- a/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-succeeded-condition/expected.json
+++ b/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-succeeded-condition/expected.json
@@ -1,0 +1,4 @@
+{
+  "anchor": "2026-01-22T10:05:00Z",
+  "usedWallClockFallback": false
+}

--- a/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-succeeded-condition/input.yaml
+++ b/pkg/controller/testdata/goodput-terminal-anchor/anchored-to-succeeded-condition/input.yaml
@@ -1,0 +1,10 @@
+# The Succeeded condition's LastTransitionTime is the terminal anchor.
+conditions:
+  - type: Succeeded
+    status: "True"
+    reason: WorkloadCompleted
+    lastTransitionTime: "2026-01-22T10:05:00Z"
+  - type: InProgress
+    status: "False"
+    reason: NotApplicable
+    lastTransitionTime: "2026-01-22T10:06:00Z"

--- a/pkg/controller/testdata/goodput-terminal-anchor/falls-back-to-wall-clock/expected.json
+++ b/pkg/controller/testdata/goodput-terminal-anchor/falls-back-to-wall-clock/expected.json
@@ -1,0 +1,4 @@
+{
+  "anchor": "",
+  "usedWallClockFallback": true
+}

--- a/pkg/controller/testdata/goodput-terminal-anchor/falls-back-to-wall-clock/input.yaml
+++ b/pkg/controller/testdata/goodput-terminal-anchor/falls-back-to-wall-clock/input.yaml
@@ -1,0 +1,7 @@
+# A Job with no true terminal condition should never reach the terminal path;
+# if it somehow does, the anchor degrades to the wall clock rather than zero.
+conditions:
+  - type: InProgress
+    status: "True"
+    reason: WorkloadRunning
+    lastTransitionTime: "2026-01-22T10:00:00Z"


### PR DESCRIPTION
## Summary

- A completed certification's goodput changed between report reads (56% → 58% in the field): the controller kept updating the measurement's status after the Job finished, and nothing ever froze it
- Terminal values are now anchored to the Job's terminal condition timestamp — `completionTime` and the terminal training-time math come from the Job's `Succeeded`/`Failed` transition, never the reconcile wall clock
- The whole terminal payload (final log sample, terminal metrics, `completionTime`, `Complete=True`, `Measuring=False`) lands in one atomic status write, so a reader can never observe a half-final state
- `Complete=True` is the freeze marker and reconcile gate — no new CRD fields; terminal writes are first-write-wins, so a stale-cache replay can never overwrite a frozen status
- The terminal log read windows on persisted inputs only (pod start time, or persisted `lastStepTimestamp` minus one sample interval, clamped from the anchor) — never the in-memory fetch watermark — so a same-process re-entry and a restarted controller parse the same window. The window end is capped at the anchor, so log lines after the Job's terminal time can't leak into terminal fields
- Threshold evaluation only consumes goodput values after `Complete=True`; `LastCountedCheckpointStep` is recovered from status on restart so checkpoint save time can't double-count across a restart replay
- Design in `docs/designs/072-goodput-terminal-freeze.md` (included)

Two integration cases pin the freeze end to end: strip-and-rerun on the Succeeded path must regenerate a byte-identical status, and on the Failed path a measurement with `Complete` intact must not move at all (its `lostWorkTime`/`interruptionCount` are accumulators, so byte-identity under rerun isn't the honest assertion there). The integration fake log fetcher now honors `SinceTime` like the real fetcher, so those replay tests exercise real windowing, not a full-log refetch.

Known limitations (documented in code comments): the terminal merge mutates in-memory state before the write lands, so a non-conflict write error followed by a same-process retry can under-count the final window (a restart recomputes correctly); and a heavy-log run that never produced a training step still opens the read window at pod start and can lose tail lines to the fetch size cap.

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (ncrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally (full `make test` incl. integration; new unit suites for the terminal anchor, threshold gating, state recovery, and the setComplete guard; two new frozen-replay integration cases with reviewed goldens)
- [x] Manual testing completed (replay traces through the conflict-refresh path; golden arithmetic recomputed by hand from the fixtures)
- [x] No breaking changes (zero pre-existing golden changes; one threshold-gate fixture input updated to match the new gating)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (new cases only; reviewed field by field)
- [x] Documentation updated (ADR-072 included; goodput concepts doc)
- [x] Ready for review

Fixes #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Goodput measurements now finalize using the Job’s terminal timestamp.
  - Completed measurements remain frozen and consistent across reads, restarts, and reconciliations.
  - Final log samples are included before completion when available.
  - Goodput-based threshold values are used only after measurement completion.

- **Bug Fixes**
  - Prevented completed measurements from changing during later reconciliations.
  - Improved recovery of measurement progress and checkpoint data after restarts.
  - Prevented post-termination log entries from affecting final results.

- **Documentation**
  - Documented the goodput measurement lifecycle and terminal-freeze behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->