### PR TITLE
chore: migrate module path and repo references to dsx-ai-factory org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow the project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,11 +4,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🔒 Security Issue
-    url: https://github.com/NVIDIA/cluster-readiness-engine/security/advisories/new
+    url: https://github.com/dsx-ai-factory/cluster-readiness-engine/security/advisories/new
     about: Report a security vulnerability (private disclosure)
   - name: 💬 Discussions
-    url: https://github.com/NVIDIA/cluster-readiness-engine/discussions
+    url: https://github.com/dsx-ai-factory/cluster-readiness-engine/discussions
     about: Ask questions, share ideas, and discuss with the community
   - name: 📖 Documentation
-    url: https://github.com/NVIDIA/cluster-readiness-engine/blob/main/README.md
+    url: https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/README.md
     about: Read the documentation and guides

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Please review existing [documentation issues](https://github.com/NVIDIA/cluster-readiness-engine/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fdocs) before submitting.
+      description: Please review existing [documentation issues](https://github.com/dsx-ai-factory/cluster-readiness-engine/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fdocs) before submitting.
       options:
         - label: I searched existing documentation and open documentation issues
           required: true
@@ -20,7 +20,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow the project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Please review existing [documentation issues](https://github.com/NVIDIA/cluster-readiness-engine/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fdocs) before submitting.
+      description: Please review existing [documentation issues](https://github.com/dsx-ai-factory/cluster-readiness-engine/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fdocs) before submitting.
       options:
         - label: I searched existing documentation and open documentation issues
           required: true
@@ -20,7 +20,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow the project's Code of Conduct
           required: true
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Documentation Location
       description: Link to the existing docs or source that needs correction.
-      placeholder: https://github.com/NVIDIA/cluster-readiness-engine/blob/main/docs/
+      placeholder: https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/docs/
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,7 +19,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/cluster-readiness-engine/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow the project's Code of Conduct
           required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     name: Lint
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,7 +39,7 @@ jobs:
   build:
     name: Build
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -80,7 +80,7 @@ jobs:
   test:
     name: Test
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
   analyze:
     name: Analyze Go
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -27,7 +27,7 @@ jobs:
   docker-build:
     name: Docker Build
     runs-on: linux-amd64-cpu32
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,4 +55,4 @@ jobs:
       - name: Build container image (no push)
         run: make docker-buildx BUILDX_PUSH=
         env:
-          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}
+          IMG: ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,7 +23,7 @@ jobs:
   govulncheck:
     name: Scan Go dependencies
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
   publish:
     name: Build and Push Container
     runs-on: linux-amd64-cpu32
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 40
     permissions:
       contents: read
@@ -68,11 +68,11 @@ jobs:
           make docker-buildx
           # Capture the image digest for signing
           DIGEST=$(docker buildx imagetools inspect \
-            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }} \
+            ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }} \
             --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         env:
-          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}
+          IMG: ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -80,12 +80,12 @@ jobs:
       - name: Sign container image
         run: |
           cosign sign --yes \
-            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+            ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0.24.0
         with:
-          image: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+          image: ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
 
@@ -94,4 +94,4 @@ jobs:
           cosign attest --yes \
             --predicate sbom.cyclonedx.json \
             --type cyclonedx \
-            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+            ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   helm-publish:
     name: Publish Helm Chart
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,11 +47,15 @@ jobs:
 
       - name: Package and push Helm chart
         run: make helm-push
+        env:
+          # Derive the OCI registry from the repository so a future org
+          # transfer cannot leave this workflow pushing to a stale path.
+          HELM_OCI_REGISTRY: oci://ghcr.io/${{ github.repository_owner }}
 
   build-cli:
     name: Build CLI Binaries
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -76,7 +80,7 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 10
     needs:
       - helm-publish
@@ -146,14 +150,14 @@ jobs:
             and communication workloads across topology-aware node groups,
             measures goodput and bandwidth, detects hardware failures, and
             quarantines bad nodes. See the
-            [README](https://github.com/NVIDIA/cluster-readiness-engine/blob/${{ steps.tag.outputs.value }}/README.md)
+            [README](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.value }}/README.md)
             for the full feature list.
 
             ## Install ncrectl
 
             ```bash
             # Requires gh CLI authenticated, or GITHUB_TOKEN set.
-            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
+            curl -sSL https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
             ```
 
             The version is named explicitly because `releases/latest` resolves only to
@@ -161,21 +165,21 @@ jobs:
             Once `v0.1.0` is tagged, this shorter form installs the newest stable one:
 
             ```bash
-            curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
+            curl -sSL https://github.com/${{ github.repository }}/releases/latest/download/installer | bash
             ```
 
             ## Helm Chart
 
             ```bash
             helm install cluster-readiness-engine \
-              oci://ghcr.io/nvidia/cluster-readiness-engine \
+              oci://ghcr.io/${{ github.repository }} \
               --version ${{ steps.tag.outputs.value }} \
               --namespace cluster-readiness-engine \
               --create-namespace
             ```
 
             The controller image for this release is
-            `ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}`.
+            `ghcr.io/${{ github.repository }}/manager:${{ steps.tag.outputs.value }}`.
 
             ## ncrectl CLI
 
@@ -200,14 +204,14 @@ jobs:
             ## Third-Party Notices
 
             Third-party Go module licenses are listed in
-            [`THIRD_PARTY_NOTICES.md`](https://github.com/NVIDIA/cluster-readiness-engine/blob/${{ steps.tag.outputs.value }}/THIRD_PARTY_NOTICES.md)
+            [`THIRD_PARTY_NOTICES.md`](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.value }}/THIRD_PARTY_NOTICES.md)
             and attached as a release asset.
 
             ## Support
 
-            - Ask questions in [GitHub Discussions](https://github.com/NVIDIA/cluster-readiness-engine/discussions).
-            - Report bugs with the [issue templates](https://github.com/NVIDIA/cluster-readiness-engine/issues/new/choose).
-            - Report security issues per [SECURITY.md](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/SECURITY.md), never through GitHub issues.
+            - Ask questions in [GitHub Discussions](https://github.com/${{ github.repository }}/discussions).
+            - Report bugs with the [issue templates](https://github.com/${{ github.repository }}/issues/new/choose).
+            - Report security issues per [SECURITY.md](https://github.com/${{ github.repository }}/blob/main/SECURITY.md), never through GitHub issues.
           files: |
             dist/ncrectl-*
             dist/installer

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -32,7 +32,7 @@ jobs:
   uat:
     name: UAT (Kind + KWOK + Tilt)
     runs-on: linux-amd64-cpu32
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,7 +21,7 @@ jobs:
   verify:
     name: Verify generated files, go.mod, and license headers
     runs-on: linux-amd64-cpu16
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    if: github.repository == 'dsx-ai-factory/cluster-readiness-engine'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `ci`,
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/NVIDIA/cluster-readiness-engine.git
+   git clone https://github.com/dsx-ai-factory/cluster-readiness-engine.git
    cd cluster-readiness-engine
    ```
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS ?= -s -w -X main.version=$(VERSION)
 # Image configuration
 # Registry and repository for the controller image
 IMAGE_REGISTRY ?= ghcr.io
-IMAGE_REPOSITORY ?= nvidia/cluster-readiness-engine/manager
+IMAGE_REPOSITORY ?= dsx-ai-factory/cluster-readiness-engine/manager
 IMAGE_TAG ?= $(VERSION)
 # Full image URL
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY):$(IMAGE_TAG)
@@ -268,7 +268,7 @@ HELM ?= helm
 HELM_PACKAGE_VERSION ?= $(VERSION)
 # OCI registry base for Helm chart publishing.
 # helm push pushes to $(HELM_OCI_REGISTRY)/<chart-name>:<version>.
-HELM_OCI_REGISTRY ?= oci://ghcr.io/nvidia
+HELM_OCI_REGISTRY ?= oci://ghcr.io/dsx-ai-factory
 
 .PHONY: helm-lint
 helm-lint: ## Lint the cluster-readiness-engine Helm chart.

--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,7 @@ domain: nvidia.com
 layout:
 - go.kubebuilder.io/v4
 projectName: cluster-readiness-engine
-repo: github.com/NVIDIA/cluster-readiness-engine
+repo: github.com/dsx-ai-factory/cluster-readiness-engine
 resources:
 - api:
     crdVersion: v1
@@ -16,7 +16,7 @@ resources:
   domain: nvidia.com
   group: cre
   kind: Job
-  path: github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1
+  path: github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -25,7 +25,7 @@ resources:
   domain: nvidia.com
   group: cre
   kind: Workflow
-  path: github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1
+  path: github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -34,7 +34,7 @@ resources:
   domain: nvidia.com
   group: cre
   kind: Certification
-  path: github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1
+  path: github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -43,6 +43,6 @@ resources:
   domain: nvidia.com
   group: cre
   kind: GoodputMeasurement
-  path: github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1
+  path: github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cluster Readiness Engine (CRE)
 
-[![CI](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml)
+[![CI](https://github.com/dsx-ai-factory/cluster-readiness-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/dsx-ai-factory/cluster-readiness-engine/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
 
@@ -65,14 +65,14 @@ newest **stable** release. Until `v0.1.0` is tagged, name the version explicitly
 
 ```bash
 CRE_VERSION=v0.1.0-rc.8
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
+curl -sSL https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
   | bash -s -- -v "${CRE_VERSION}"
 ```
 
 Once a stable release exists, this shorter form works and picks up the newest one:
 
 ```bash
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
+curl -sSL https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/latest/download/installer | bash
 ```
 
 The installer places `ncrectl` on your `$PATH` and creates a `kubectl-ncre` symlink so the CLI is also available as `kubectl ncre`.
@@ -147,16 +147,16 @@ published to the GitHub Container Registry on every release.
 CRE_VERSION=v0.1.0-rc.8
 
 # Inspect the chart before installing it
-helm show chart oci://ghcr.io/nvidia/cluster-readiness-engine --version "$CRE_VERSION"
+helm show chart oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine --version "$CRE_VERSION"
 
 helm install cluster-readiness-engine \
-  oci://ghcr.io/nvidia/cluster-readiness-engine \
+  oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
   --version "$CRE_VERSION" \
   --namespace cluster-readiness-engine \
   --create-namespace
 ```
 
-The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagged
+The controller image is `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`, tagged
 with the same release version. Builds from `main` are also published, tagged
 `main-<commit-sha>`; use a release tag rather than one of those.
 
@@ -218,8 +218,8 @@ A hosted documentation site is in progress.
 
 ## Community
 
-- Ask questions in [GitHub Discussions](https://github.com/NVIDIA/cluster-readiness-engine/discussions).
-- Report bugs and request features with the [issue templates](https://github.com/NVIDIA/cluster-readiness-engine/issues/new/choose).
+- Ask questions in [GitHub Discussions](https://github.com/dsx-ai-factory/cluster-readiness-engine/discussions).
+- Report bugs and request features with the [issue templates](https://github.com/dsx-ai-factory/cluster-readiness-engine/issues/new/choose).
 - Report security issues per [SECURITY.md](SECURITY.md), never through GitHub issues.
 - We follow the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,7 +44,7 @@ people do not tag at the same time.
    ```
 
    If you work from a fork, push the tag to the remote that points at
-   `NVIDIA/cluster-readiness-engine`, which is usually `upstream`.
+   `dsx-ai-factory/cluster-readiness-engine`, which is usually `upstream`.
 
    Sign the tag (`-s`). Pushing the tag is the release trigger; there is no button to
    press afterwards.
@@ -75,12 +75,12 @@ Pushing a `v*` tag runs three jobs in `.github/workflows/release.yml`:
 
 | Job | Publishes |
 |---|---|
-| Publish Helm Chart | `oci://ghcr.io/nvidia/cluster-readiness-engine` |
+| Publish Helm Chart | `oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine` |
 | Build CLI Binaries | cross-compiled `ncrectl` for linux and macOS, amd64 and arm64 |
 | Create GitHub Release | the GitHub Release, its notes, and the assets below |
 
 The container image is published separately by `.github/workflows/publish.yml` as
-`ghcr.io/nvidia/cluster-readiness-engine/manager:<tag>`.
+`ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<tag>`.
 
 Release assets:
 
@@ -93,7 +93,7 @@ Release assets:
 
 ```bash
 VERSION=v0.1.0
-BASE=https://github.com/NVIDIA/cluster-readiness-engine/releases/download/$VERSION
+BASE=https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/$VERSION
 curl -sSLO "$BASE/checksums.txt"
 curl -sSLO "$BASE/ncrectl-linux-amd64"
 sha256sum --check --ignore-missing checksums.txt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
 ## Supply Chain
 
 - CRE is licensed under Apache-2.0. Dependencies are reviewed for license compatibility with Apache-2.0; attributions are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
-- Container images are signed with Sigstore cosign (keyless OIDC) and ship with CycloneDX SBOMs attested via `cosign attest`. To verify: `cosign verify ghcr.io/nvidia/cluster-readiness-engine/manager:<tag> --certificate-identity-regexp='https://github.com/NVIDIA/cluster-readiness-engine' --certificate-oidc-issuer='https://token.actions.githubusercontent.com'`. CLI binaries include SHA256 checksums in each release.
+- Container images are signed with Sigstore cosign (keyless OIDC) and ship with CycloneDX SBOMs attested via `cosign attest`. To verify: `cosign verify ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<tag> --certificate-identity-regexp='https://github.com/dsx-ai-factory/cluster-readiness-engine' --certificate-oidc-issuer='https://token.actions.githubusercontent.com'`. CLI binaries include SHA256 checksums in each release.
 
 ## Product Security Resources
 

--- a/api/v1alpha1/bandwidthmeasurement_types.go
+++ b/api/v1alpha1/bandwidthmeasurement_types.go
@@ -19,7 +19,7 @@ const (
 
 // BandwidthMeasurementSpec defines the desired state of BandwidthMeasurement
 type BandwidthMeasurementSpec struct {
-	// jobRef is the reference to the burnin Job for which bandwidth should be measured.
+	// jobRef is the reference to the CRE Job for which bandwidth should be measured.
 	// +optional
 	JobRef corev1.TypedLocalObjectReference `json:"jobRef,omitempty"`
 

--- a/api/v1alpha1/goodputmeasurement_types.go
+++ b/api/v1alpha1/goodputmeasurement_types.go
@@ -19,7 +19,7 @@ const (
 
 // GoodputMeasurementSpec defines the desired state of GoodputMeasurement
 type GoodputMeasurementSpec struct {
-	// jobRef is the reference to the burnin Job for which goodput should be calculated.
+	// jobRef is the reference to the CRE Job for which goodput should be calculated.
 	// +optional
 	JobRef corev1.TypedLocalObjectReference `json:"jobRef,omitempty"`
 

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -754,7 +754,7 @@ type OverrideSpec struct {
 // WorkflowSpec defines the desired state of Workflow.
 type WorkflowSpec struct {
 	// namespace is the target namespace for Jobs and dependencies created by this Workflow.
-	// If not specified, the controller auto-generates one (e.g., "burnin-<workflow-name>").
+	// If not specified, the controller auto-generates one.
 	// The controller creates the namespace if it doesn't exist and sets an owner reference
 	// so it's cleaned up when the Workflow is deleted.
 	// +optional

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -35,18 +35,18 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	sigyaml "sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	_ "github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	_ "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
 )
 
 const metricLabelNamespace = "namespace"
 
 func init() {
-	_ = burninv1alpha1.AddToScheme(scheme.Scheme)
+	_ = crev1alpha1.AddToScheme(scheme.Scheme)
 	_ = trainerv1alpha1.AddToScheme(scheme.Scheme)
 }
 
@@ -131,7 +131,7 @@ func installTestCRDs(t *testing.T, cfg *rest.Config, tc *testutil.TestCase) {
 	var crdFiles []string
 	for name, content := range tc.Inputs {
 		if strings.HasPrefix(name, "input_crd_") && strings.HasSuffix(name, ".yaml") {
-			tmpDir := filepath.Join(os.TempDir(), "burnin-integration-crds", tc.Name)
+			tmpDir := filepath.Join(os.TempDir(), "cre-integration-crds", tc.Name)
 			require.NoError(t, os.MkdirAll(tmpDir, 0o755))
 			path := filepath.Join(tmpDir, name)
 			require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
@@ -236,36 +236,36 @@ func createTestObjects(t *testing.T, c client.Client, tc *testutil.TestCase) []c
 // copyStatus copies status from src to dst. Returns true if status was non-empty.
 func copyStatus(dst, src client.Object) bool { //nolint:gocyclo
 	switch d := dst.(type) {
-	case *burninv1alpha1.Job:
-		s := src.(*burninv1alpha1.Job)
+	case *crev1alpha1.Job:
+		s := src.(*crev1alpha1.Job)
 		hasStatus := len(s.Status.Conditions) > 0 || s.Status.WorkloadRef != nil ||
 			len(s.Status.FailedNodes) > 0 || s.Status.RestartCount > 0
 		if hasStatus {
 			d.Status = s.Status
 			return true
 		}
-	case *burninv1alpha1.Workflow:
-		s := src.(*burninv1alpha1.Workflow)
+	case *crev1alpha1.Workflow:
+		s := src.(*crev1alpha1.Workflow)
 		if len(s.Status.Conditions) > 0 || s.Status.Orchestration != nil ||
 			s.Status.SucceededNodesRef != nil || s.Status.FailedNodesRef != nil ||
 			len(s.Status.DependencyRefs) > 0 {
 			d.Status = s.Status
 			return true
 		}
-	case *burninv1alpha1.Certification:
-		s := src.(*burninv1alpha1.Certification)
+	case *crev1alpha1.Certification:
+		s := src.(*crev1alpha1.Certification)
 		if len(s.Status.Conditions) > 0 || len(s.Status.CategoryStatuses) > 0 {
 			d.Status = s.Status
 			return true
 		}
-	case *burninv1alpha1.WorkloadRun:
-		s := src.(*burninv1alpha1.WorkloadRun)
+	case *crev1alpha1.WorkloadRun:
+		s := src.(*crev1alpha1.WorkloadRun)
 		if len(s.Status.Conditions) > 0 || s.Status.WorkflowRef != nil {
 			d.Status = s.Status
 			return true
 		}
-	case *burninv1alpha1.GoodputMeasurement:
-		s := src.(*burninv1alpha1.GoodputMeasurement)
+	case *crev1alpha1.GoodputMeasurement:
+		s := src.(*crev1alpha1.GoodputMeasurement)
 		if len(s.Status.Conditions) > 0 || s.Status.Result != "" ||
 			s.Status.CurrentStep > 0 || s.Status.PendingInterruption != nil ||
 			s.Status.StartTime != nil || s.Status.InterruptionCount > 0 ||
@@ -275,8 +275,8 @@ func copyStatus(dst, src client.Object) bool { //nolint:gocyclo
 			d.Status = s.Status
 			return true
 		}
-	case *burninv1alpha1.BandwidthMeasurement:
-		s := src.(*burninv1alpha1.BandwidthMeasurement)
+	case *crev1alpha1.BandwidthMeasurement:
+		s := src.(*crev1alpha1.BandwidthMeasurement)
 		if len(s.Status.Conditions) > 0 || len(s.Status.Results) > 0 ||
 			s.Status.StartTime != nil || s.Status.CompletionTime != nil {
 			d.Status = s.Status
@@ -533,17 +533,17 @@ func waitForCondition(t *testing.T, c client.Client, cfg waitConfig) {
 
 		reason := cfg.WaitFor.Reason
 		switch o := obj.(type) {
-		case *burninv1alpha1.Job:
+		case *crev1alpha1.Job:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
-		case *burninv1alpha1.Workflow:
+		case *crev1alpha1.Workflow:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
-		case *burninv1alpha1.Certification:
+		case *crev1alpha1.Certification:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
-		case *burninv1alpha1.WorkloadRun:
+		case *crev1alpha1.WorkloadRun:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
-		case *burninv1alpha1.GoodputMeasurement:
+		case *crev1alpha1.GoodputMeasurement:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
-		case *burninv1alpha1.BandwidthMeasurement:
+		case *crev1alpha1.BandwidthMeasurement:
 			return hasConditionWithReason(o.Status.Conditions, cfg.WaitFor.Condition, reason)
 		}
 		return false
@@ -596,37 +596,37 @@ func getObject(ctx context.Context, t *testing.T, c client.Client, spec collectS
 
 	switch spec.Kind {
 	case "Job":
-		obj := &burninv1alpha1.Job{}
+		obj := &crev1alpha1.Job{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
 		return obj
 	case "Workflow":
-		obj := &burninv1alpha1.Workflow{}
+		obj := &crev1alpha1.Workflow{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
 		return obj
 	case "Certification":
-		obj := &burninv1alpha1.Certification{}
+		obj := &crev1alpha1.Certification{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
 		return obj
 	case "WorkloadRun":
-		obj := &burninv1alpha1.WorkloadRun{}
+		obj := &crev1alpha1.WorkloadRun{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
 		return obj
 	case "GoodputMeasurement":
-		obj := &burninv1alpha1.GoodputMeasurement{}
+		obj := &crev1alpha1.GoodputMeasurement{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
 		return obj
 	case "BandwidthMeasurement":
-		obj := &burninv1alpha1.BandwidthMeasurement{}
+		obj := &crev1alpha1.BandwidthMeasurement{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil
 		}
@@ -739,7 +739,7 @@ func sanitizeObject(obj client.Object) {
 
 	// Clear condition timestamps.
 	switch o := obj.(type) {
-	case *burninv1alpha1.Job:
+	case *crev1alpha1.Job:
 		clearConditionTimestamps(o.Status.Conditions)
 		// Sanitize stall detection messages (contain non-deterministic elapsed time).
 		for i := range o.Status.Conditions {
@@ -747,7 +747,7 @@ func sanitizeObject(obj client.Object) {
 				o.Status.Conditions[i].Message = "Workload stalled"
 			}
 		}
-	case *burninv1alpha1.Workflow:
+	case *crev1alpha1.Workflow:
 		clearConditionTimestamps(o.Status.Conditions)
 		// Node-result ConfigMaps use generateName, so their names are
 		// non-deterministic; normalize the refs to stable placeholders.
@@ -765,15 +765,15 @@ func sanitizeObject(obj client.Object) {
 				}
 			}
 		}
-	case *burninv1alpha1.Certification:
+	case *crev1alpha1.Certification:
 		clearConditionTimestamps(o.Status.Conditions)
 		for i := range o.Status.CategoryStatuses {
 			sanitizeNodeResultsRef(o.Status.CategoryStatuses[i].SucceededNodesRef, o.Status.CategoryStatuses[i].FailedNodesRef)
 		}
-	case *burninv1alpha1.WorkloadRun:
+	case *crev1alpha1.WorkloadRun:
 		clearConditionTimestamps(o.Status.Conditions)
 		sanitizeNodeResultsRef(o.Status.SucceededNodesRef, o.Status.FailedNodesRef)
-	case *burninv1alpha1.GoodputMeasurement:
+	case *crev1alpha1.GoodputMeasurement:
 		clearConditionTimestamps(o.Status.Conditions)
 		// Clear time-dependent fields.
 		o.Status.StartTime = nil
@@ -789,7 +789,7 @@ func sanitizeObject(obj client.Object) {
 			o.Status.PendingInterruption.TCheckpoint = nil
 			o.Status.PendingInterruption.TInterrupt = nil
 		}
-	case *burninv1alpha1.BandwidthMeasurement:
+	case *crev1alpha1.BandwidthMeasurement:
 		clearConditionTimestamps(o.Status.Conditions)
 		o.Status.StartTime = nil
 		o.Status.CompletionTime = nil

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,10 +29,10 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -47,7 +47,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(burninv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(crev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(trainerv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/cmd/ncrectl/main.go
+++ b/cmd/ncrectl/main.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	_ "github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/certification"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/cluster"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/setup"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workloadrun"
+	_ "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/certification"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/cluster"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/render"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/setup"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workloadrun"
 )
 
 var version = "dev"

--- a/docs/cli-reference/certification.md
+++ b/docs/cli-reference/certification.md
@@ -23,7 +23,7 @@ ncrectl certification run --category communication/nccl-all-reduce [flags]
 | `--category` | — | Category in `domain/variant` format; repeatable (mutually exclusive with `--cert-file`) |
 | `--name` | auto | Certification name (default: `ncrectl-<timestamp>`) |
 | `--setup` | `false` | Install CRDs, controller, and LogProfiles before creating the certification |
-| `--image` | — | Controller image for `--setup` (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Controller image for `--setup` (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
 | `--wait` | `false` | Block until the certification completes and print a report |
 | `--timeout` | `30m` | Timeout for `--wait` |
 | `--cleanup` | `false` | Delete the certification, namespace, and installed components after completion |

--- a/docs/cli-reference/overview.md
+++ b/docs/cli-reference/overview.md
@@ -12,7 +12,7 @@ description: The ncrectl CLI manages the full lifecycle of cluster certification
 
 ```bash
 export NCRECTL_VERSION=v0.1.0-rc.8
-curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NCRECTL_VERSION}/installer" | bash
+curl -sSL "https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${NCRECTL_VERSION}/installer" | bash
 ncrectl --version
 ```
 

--- a/docs/cli-reference/setup.md
+++ b/docs/cli-reference/setup.md
@@ -30,7 +30,7 @@ Use `--skip-phases=deps` to skip Kubeflow Trainer if it is already installed.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--image-pull-secret` | — | GitHub token — the CLI creates a `ghcr.io` pull secret and uses it to authenticate the Helm chart pull |
-| `--image` | — | Override the controller image (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Override the controller image (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
 | `--skip-phases` | — | Comma-separated phases to skip (e.g., `deps`) |
 | `--version` | — | Helm chart version to install (required for dev builds) |
 | `--auto-approve` | `false` | Skip the interactive confirmation prompt (for CI/automation) |

--- a/docs/designs/010-certification-catalog.md
+++ b/docs/designs/010-certification-catalog.md
@@ -27,11 +27,11 @@ Example category file:
 // pkg/catalog/training_nemotron.go
 func init() {
     Register("training", "nemotron", Entry{
-        Build: func(target burninv1alpha1.TargetSpec) burninv1alpha1.WorkflowSpec {
-            return burninv1alpha1.WorkflowSpec{
-                JobTemplate: burninv1alpha1.JobTemplateSpec{
-                    Spec: burninv1alpha1.JobSpec{
-                        Workload: &burninv1alpha1.WorkloadSpec{
+        Build: func(target crev1alpha1.TargetSpec) crev1alpha1.WorkflowSpec {
+            return crev1alpha1.WorkflowSpec{
+                JobTemplate: crev1alpha1.JobTemplateSpec{
+                    Spec: crev1alpha1.JobSpec{
+                        Workload: &crev1alpha1.WorkloadSpec{
                             TrainJob: &trainerv1alpha1.TrainJob{...},
                         },
                     },

--- a/docs/designs/021-performance-threshold-enforcement.md
+++ b/docs/designs/021-performance-threshold-enforcement.md
@@ -100,7 +100,7 @@ if workflow.Spec.Validation != nil &&
 }
 ```
 
-This runs after `DeepCopy()` and before `job := &burninv1alpha1.Job{...}`, so the threshold fields are part of the Job spec from creation.
+This runs after `DeepCopy()` and before `job := &crev1alpha1.Job{...}`, so the threshold fields are part of the Job spec from creation.
 
 ### Workflow Controller: ValidationFailed Aggregation
 
@@ -108,7 +108,7 @@ In the group evaluation logic and `setFinalStatus()`, aggregate `ValidationFaile
 
 ```go
 // In group evaluation (after checking Job Succeeded/Failed/HardwareFailed):
-validationCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobValidationFailed)
+validationCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobValidationFailed)
 if validationCond != nil && validationCond.Status == metav1.ConditionTrue {
     // Mark group as Failed with reason JobValidationFailed
 }
@@ -123,7 +123,7 @@ In `setFinalStatus()`, if any group failed due to validation, the Workflow is ma
 After the workload reaches `Succeeded`, the Job controller calls `checkPerformanceThresholds()`:
 
 ```go
-func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *burninv1alpha1.Job) error {
+func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *crev1alpha1.Job) error {
     // Check bandwidth threshold
     if job.Spec.BandwidthMeasurement != nil && job.Spec.BandwidthMeasurement.MinBusBandwidthGBps != nil {
         if err := r.checkBandwidthThreshold(ctx, job); err != nil {
@@ -157,9 +157,9 @@ func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *bur
 **`setJobValidationFailed()`** mirrors `setJobHardwareFailed()`:
 
 ```go
-func (r *JobReconciler) setJobValidationFailed(ctx context.Context, job *burninv1alpha1.Job, reason, message string) error {
+func (r *JobReconciler) setJobValidationFailed(ctx context.Context, job *crev1alpha1.Job, reason, message string) error {
     changed := meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
-        Type:               burninv1alpha1.JobValidationFailed,
+        Type:               crev1alpha1.JobValidationFailed,
         Status:             metav1.ConditionTrue,
         Reason:             reason,
         Message:            message,
@@ -198,7 +198,7 @@ The feature starts disabled. Catalog entries that produce `BandwidthMeasurement`
 ```go
 // To enforce minimum bandwidth thresholds, add to the Workflow's
 // PerformanceValidationSpec:
-//   Thresholds: &burninv1alpha1.ThresholdSpec{
+//   Thresholds: &crev1alpha1.ThresholdSpec{
 //       MinBusBandwidthGBps: ptr("370"), // 92% of 400 GB/s fabric
 //   },
 ```

--- a/docs/designs/023-catalog-configurability.md
+++ b/docs/designs/023-catalog-configurability.md
@@ -57,7 +57,7 @@ type BuildConfig struct {
 }
 
 type Entry struct {
-    Build func(target burninv1alpha1.TargetSpec, config BuildConfig) burninv1alpha1.WorkflowSpec
+    Build func(target crev1alpha1.TargetSpec, config BuildConfig) crev1alpha1.WorkflowSpec
 }
 ```
 

--- a/docs/designs/035-optional-legacy-kubeflow.md
+++ b/docs/designs/035-optional-legacy-kubeflow.md
@@ -46,9 +46,9 @@ In `JobReconciler.SetupWithManager()`, split the builder chain:
 
 ```go
 b := ctrl.NewControllerManagedBy(mgr).
-    For(&burninv1alpha1.Job{}).
+    For(&crev1alpha1.Job{}).
     Owns(&trainerv1alpha1.TrainJob{}).
-    Owns(&burninv1alpha1.GoodputMeasurement{})
+    Owns(&crev1alpha1.GoodputMeasurement{})
 
 if r.EnableLegacyKubeflow {
     b = b.Owns(&kubeflowv1.PyTorchJob{}).

--- a/docs/designs/050-xcalctl-unified-run-pipeline.md
+++ b/docs/designs/050-xcalctl-unified-run-pipeline.md
@@ -43,7 +43,7 @@ Both return a `certRunConfig` struct consumed by the single pipeline:
 
 ```go
 type certRunConfig struct {
-    cert            *burninv1alpha1.Certification
+    cert            *crev1alpha1.Certification
     namespace       string
     imagePullSecret string
     doWait          bool

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -30,7 +30,7 @@ Every release so far is a pre-release, and `releases/latest` resolves only to th
 
 ```bash
 CRE_VERSION=v0.1.0-rc.8
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
+curl -sSL https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${CRE_VERSION}/installer \
   | bash -s -- -v "${CRE_VERSION}"
 ```
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -19,7 +19,7 @@ Set the version you want to install, then run the installer:
 
 ```bash
 export NCRECTL_VERSION=v0.1.0-rc.8
-curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NCRECTL_VERSION}/installer" | bash
+curl -sSL "https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${NCRECTL_VERSION}/installer" | bash
 ```
 
 The installer automatically downloads and verifies a SHA-256 checksum before installing. On air-gapped systems, ensure `checksums.txt` from the same release is reachable alongside the binary.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,7 +14,7 @@ global-theme: nvidia
 
 navbar-links:
   - type: github
-    value: https://github.com/NVIDIA/cluster-readiness-engine
+    value: https://github.com/dsx-ai-factory/cluster-readiness-engine
 
 products:
   - display-name: Cluster Readiness Engine

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/NVIDIA/cluster-readiness-engine
+module github.com/dsx-ai-factory/cluster-readiness-engine
 
 go 1.26.6
 

--- a/helm/cluster-readiness-engine/crds/cre.nvidia.com_bandwidthmeasurements.yaml
+++ b/helm/cluster-readiness-engine/crds/cre.nvidia.com_bandwidthmeasurements.yaml
@@ -41,7 +41,7 @@ spec:
             description: spec defines the desired state of BandwidthMeasurement
             properties:
               jobRef:
-                description: jobRef is the reference to the burnin Job for which bandwidth
+                description: jobRef is the reference to the CRE Job for which bandwidth
                   should be measured.
                 properties:
                   apiGroup:

--- a/helm/cluster-readiness-engine/crds/cre.nvidia.com_goodputmeasurements.yaml
+++ b/helm/cluster-readiness-engine/crds/cre.nvidia.com_goodputmeasurements.yaml
@@ -41,7 +41,7 @@ spec:
             description: spec defines the desired state of GoodputMeasurement
             properties:
               jobRef:
-                description: jobRef is the reference to the burnin Job for which goodput
+                description: jobRef is the reference to the CRE Job for which goodput
                   should be calculated.
                 properties:
                   apiGroup:

--- a/helm/cluster-readiness-engine/crds/cre.nvidia.com_workflows.yaml
+++ b/helm/cluster-readiness-engine/crds/cre.nvidia.com_workflows.yaml
@@ -6806,7 +6806,7 @@ spec:
               namespace:
                 description: |-
                   namespace is the target namespace for Jobs and dependencies created by this Workflow.
-                  If not specified, the controller auto-generates one (e.g., "burnin-<workflow-name>").
+                  If not specified, the controller auto-generates one.
                   The controller creates the namespace if it doesn't exist and sets an owner reference
                   so it's cleaned up when the Workflow is deleted.
                 type: string

--- a/helm/cluster-readiness-engine/values.yaml
+++ b/helm/cluster-readiness-engine/values.yaml
@@ -8,7 +8,7 @@ nameOverride: cluster-readiness-engine
 manager:
   replicas: 1
   image:
-    repository: ghcr.io/nvidia/cluster-readiness-engine/manager
+    repository: ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager
     tag: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/installer
+++ b/installer
@@ -11,12 +11,12 @@ set -euo pipefail
 # Installs ncrectl if it is not present; upgrades it if it already is.
 #
 # Usage:
-#   curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
+#   curl -sSL https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/latest/download/installer | bash
 #   curl -sSL <url> | bash -s -- -d /custom/path
 # ---------------------------------------------------------------------------
 
 # Configuration
-GH_REPO="NVIDIA/cluster-readiness-engine"
+GH_REPO="dsx-ai-factory/cluster-readiness-engine"
 GH_API_URL="https://api.github.com/repos/${GH_REPO}"
 GH_RELEASE_URL="https://github.com/${GH_REPO}/releases/download"
 BIN_NAME="ncrectl"

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -12,8 +12,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/gpu"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/gpu"
 )
 
 // categoryKey uniquely identifies a certification category.
@@ -132,7 +132,7 @@ type Entry struct {
 	// and deployment-specific configuration. Returns an error if the
 	// configuration is invalid (e.g., nodesPerJob not a power of 2,
 	// or fewer GPUs than required).
-	Build func(target burninv1alpha1.TargetSpec, config BuildConfig) (burninv1alpha1.WorkflowSpec, error)
+	Build func(target crev1alpha1.TargetSpec, config BuildConfig) (crev1alpha1.WorkflowSpec, error)
 
 	// MinGPUs is the minimum number of GPUs (nodesPerJob × gpusPerNode)
 	// required by this entry. 0 means no minimum. Build returns an error

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -8,29 +8,29 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 type lookupInput struct {
-	Category           string                    `yaml:"category"`
-	Subcategory        string                    `yaml:"subcategory"`
-	Target             burninv1alpha1.TargetSpec `yaml:"target"`
-	NodesPerJob        int32                     `yaml:"nodesPerJob"`
-	GpusPerNode        int32                     `yaml:"gpusPerNode"`
-	EnableCheckpoint   bool                      `yaml:"enableCheckpoint"`
-	SaveInterval       int32                     `yaml:"saveInterval"`
-	SaveRetainInterval int32                     `yaml:"saveRetainInterval"`
-	SaveTopK           int32                     `yaml:"saveTopK"`
-	StorageSize        string                    `yaml:"storageSize"`
-	TestScale          string                    `yaml:"testScale"`
-	MaxBytes           string                    `yaml:"maxBytes"`
-	NumIterations      int32                     `yaml:"numIterations"`
-	NumCycles          int32                     `yaml:"numCycles"`
-	MaxConcurrent      int32                     `yaml:"maxConcurrent"`
-	Thresholds         map[string]string         `yaml:"thresholds"`
+	Category           string                 `yaml:"category"`
+	Subcategory        string                 `yaml:"subcategory"`
+	Target             crev1alpha1.TargetSpec `yaml:"target"`
+	NodesPerJob        int32                  `yaml:"nodesPerJob"`
+	GpusPerNode        int32                  `yaml:"gpusPerNode"`
+	EnableCheckpoint   bool                   `yaml:"enableCheckpoint"`
+	SaveInterval       int32                  `yaml:"saveInterval"`
+	SaveRetainInterval int32                  `yaml:"saveRetainInterval"`
+	SaveTopK           int32                  `yaml:"saveTopK"`
+	StorageSize        string                 `yaml:"storageSize"`
+	TestScale          string                 `yaml:"testScale"`
+	MaxBytes           string                 `yaml:"maxBytes"`
+	NumIterations      int32                  `yaml:"numIterations"`
+	NumCycles          int32                  `yaml:"numCycles"`
+	MaxConcurrent      int32                  `yaml:"maxConcurrent"`
+	Thresholds         map[string]string      `yaml:"thresholds"`
 }
 
 func TestLookup(t *testing.T) {
@@ -83,7 +83,7 @@ func TestLookupUnsupportedNodesPerJob(t *testing.T) {
 	if entry == nil {
 		t.Fatal("expected nemotron5-56b to be registered")
 	}
-	_, err := entry.Build(burninv1alpha1.TargetSpec{}, BuildConfig{
+	_, err := entry.Build(crev1alpha1.TargetSpec{}, BuildConfig{
 		NodesPerJob:     4,
 		GpusPerNode:     4,
 		GPUArchitecture: "gb200",
@@ -97,7 +97,7 @@ func TestLookupUnsupportedNodesPerJob(t *testing.T) {
 }
 
 // lookupOutput extracts key fields from a WorkflowSpec for golden file comparison.
-func lookupOutput(spec burninv1alpha1.WorkflowSpec) map[string]any {
+func lookupOutput(spec crev1alpha1.WorkflowSpec) map[string]any {
 	result := map[string]any{
 		"found": true,
 	}

--- a/pkg/catalog/gpu_defaults_test.go
+++ b/pkg/catalog/gpu_defaults_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/catalog/loader.go
+++ b/pkg/catalog/loader.go
@@ -16,7 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // Default values for template variables when not specified by the user.
@@ -27,7 +27,7 @@ const (
 	DefaultSaveRetainInterval = 1000
 	DefaultSaveTopK           = 1
 	DefaultStorageSize        = "10Ti"
-	DefaultTestScale          = burninv1alpha1.TestScaleFullScale
+	DefaultTestScale          = crev1alpha1.TestScaleFullScale
 	DefaultMaxBytes           = "16G"
 	DefaultNumIterations      = 100
 	DefaultNumCycles          = 10
@@ -345,9 +345,9 @@ func loadAndRegisterEntries() error {
 				}
 				return 0
 			},
-			Build: func(target burninv1alpha1.TargetSpec, config BuildConfig) (burninv1alpha1.WorkflowSpec, error) {
+			Build: func(target crev1alpha1.TargetSpec, config BuildConfig) (crev1alpha1.WorkflowSpec, error) {
 				if config.GPUArchitecture == "" {
-					return burninv1alpha1.WorkflowSpec{}, fmt.Errorf(
+					return crev1alpha1.WorkflowSpec{}, fmt.Errorf(
 						"%s/%s: GPUArchitecture is required but was not provided",
 						domain, variant)
 				}
@@ -356,19 +356,19 @@ func loadAndRegisterEntries() error {
 
 				// Validate GPU count against entry constraints.
 				if err := validateParallelism(domain, variant, meta, configArch, config.NodesPerJob, config.GpusPerNode); err != nil {
-					return burninv1alpha1.WorkflowSpec{}, err
+					return crev1alpha1.WorkflowSpec{}, err
 				}
 
 				td := buildTemplateData(config, configArch, variant, meta)
 
 				var rendered bytes.Buffer
 				if err := tmpl.Execute(&rendered, td); err != nil {
-					return burninv1alpha1.WorkflowSpec{}, fmt.Errorf("executing template %s/%s: %w", domain, variant, err)
+					return crev1alpha1.WorkflowSpec{}, fmt.Errorf("executing template %s/%s: %w", domain, variant, err)
 				}
 
-				var spec burninv1alpha1.WorkflowSpec
+				var spec crev1alpha1.WorkflowSpec
 				if err := yaml.Unmarshal(rendered.Bytes(), &spec); err != nil {
-					return burninv1alpha1.WorkflowSpec{}, fmt.Errorf("parsing rendered %s/%s: %w", domain, variant, err)
+					return crev1alpha1.WorkflowSpec{}, fmt.Errorf("parsing rendered %s/%s: %w", domain, variant, err)
 				}
 
 				spec.Orchestration.Target = &target
@@ -447,21 +447,21 @@ func buildTemplateData(config BuildConfig, configArch, variant string, meta entr
 	// Job. Partitioning reads the workload's numNodes, so this is the knob that
 	// makes the setting do anything; without it the template rendered the full
 	// node count and the scale was a no-op.
-	if td.TestScale == burninv1alpha1.TestScaleIntraNode {
+	if td.TestScale == crev1alpha1.TestScaleIntraNode {
 		td.NodesPerJob = 1
 	}
 	if td.MaxBytes == "" {
 		td.MaxBytes = DefaultMaxBytes
 	}
 	if td.NumIterations == 0 {
-		if td.TestScale == burninv1alpha1.TestScaleDiagnose {
+		if td.TestScale == crev1alpha1.TestScaleDiagnose {
 			td.NumIterations = DiagnoseNumIterations
 		} else {
 			td.NumIterations = DefaultNumIterations
 		}
 	}
 	if td.NumCycles == 0 {
-		if td.TestScale == burninv1alpha1.TestScaleDiagnose {
+		if td.TestScale == crev1alpha1.TestScaleDiagnose {
 			td.NumCycles = DiagnoseNumCycles
 		} else {
 			td.NumCycles = DefaultNumCycles
@@ -471,7 +471,7 @@ func buildTemplateData(config BuildConfig, configArch, variant string, meta entr
 		td.MinGroupSize = DefaultMinGroupSize
 	}
 	if td.TimeoutPerJob == "" {
-		if td.TestScale == burninv1alpha1.TestScaleDiagnose {
+		if td.TestScale == crev1alpha1.TestScaleDiagnose {
 			td.TimeoutPerJob = DiagnoseTimeoutPerJob
 		} else {
 			td.TimeoutPerJob = DefaultTimeoutPerJob

--- a/pkg/catalog/test_scale_test.go
+++ b/pkg/catalog/test_scale_test.go
@@ -10,8 +10,8 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // testScale: intra-node used to do nothing. The template had a branch for it
@@ -37,7 +37,7 @@ func TestTestScaleNodeCount(t *testing.T) {
 		}
 
 		entry := Lookup("communication", "nccl-all-reduce")
-		spec, err := entry.Build(burninv1alpha1.TargetSpec{
+		spec, err := entry.Build(crev1alpha1.TargetSpec{
 			NodeSelector: map[string]string{
 				"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
 			},

--- a/pkg/certification/certification.go
+++ b/pkg/certification/certification.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,14 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/cluster"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/report"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/setup"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/cluster"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/naming"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/render"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/report"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/setup"
 )
 
 // NewCommand returns the "certification" cobra command.
@@ -283,7 +283,7 @@ func runCertificationRender(certFile, outputFormat string, dryRun bool,
 // (from --platform or detected from cluster nodes) is used to resolve
 // platform-specific node defaults like OCI L40s {gpusPerNode: 4, mlnxPerNode: 2}
 // at template-render time. Pass "" to use architecture defaults only.
-func renderCertification(cert *burninv1alpha1.Certification, platform string) ([]burninv1alpha1.Workflow, error) {
+func renderCertification(cert *crev1alpha1.Certification, platform string) ([]crev1alpha1.Workflow, error) {
 	if len(cert.Spec.Categories) == 0 {
 		return nil, fmt.Errorf("certification has no categories")
 	}
@@ -296,7 +296,7 @@ func renderCertification(cert *burninv1alpha1.Certification, platform string) ([
 		)
 	}
 
-	var workflows []burninv1alpha1.Workflow
+	var workflows []crev1alpha1.Workflow
 	for _, cat := range cert.Spec.Categories {
 		entry := catalog.Lookup(cat.Domain, cat.Variant)
 		if entry == nil {
@@ -370,7 +370,7 @@ func renderCertification(cert *burninv1alpha1.Certification, platform string) ([
 			naming.MaxWorkflowNameLen,
 		)
 
-		workflow := burninv1alpha1.Workflow{
+		workflow := crev1alpha1.Workflow{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "cre.nvidia.com/v1alpha1",
 				Kind:       "Workflow",
@@ -410,13 +410,13 @@ func derefInt32Ptr(p *int32) int32 {
 }
 
 // readCertification parses a Certification YAML file from disk.
-func readCertification(path string) (*burninv1alpha1.Certification, error) {
+func readCertification(path string) (*crev1alpha1.Certification, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path is a user-provided CLI argument
 
 	if err != nil {
 		return nil, fmt.Errorf("read certification: %w", err)
 	}
-	var cert burninv1alpha1.Certification
+	var cert crev1alpha1.Certification
 	if err := yaml.Unmarshal(data, &cert); err != nil {
 		return nil, fmt.Errorf("parse certification: %w", err)
 	}
@@ -437,7 +437,7 @@ func platformToProviderID(platform string) string {
 // then consumed by the single executeCertificationRun pipeline.
 type certRunConfig struct {
 	version                  string // CLI version, passed to setup.RunInit
-	cert                     *burninv1alpha1.Certification
+	cert                     *crev1alpha1.Certification
 	namespace                string
 	controllerImage          string // --image: controller image for --setup
 	controllerPullSecret     string // --controller-pull-secret: controller registry token forwarded to setup init
@@ -570,7 +570,7 @@ Use --cleanup to teardown installed components after completion.`,
 	cmd.Flags().StringVar(&workloadRegistryPassword, "workload-registry-password", "",
 		"Registry password or API key for workload image pull — creates an workloadRegistryPassword in the certification namespace")
 	cmd.Flags().StringVar(&controllerImage, "image", "",
-		"Controller image for --setup (default: ghcr.io/nvidia/cluster-readiness-engine/manager:<version>)")
+		"Controller image for --setup (default: ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>)")
 	cmd.Flags().StringVar(&name, "name", "",
 		"Certification name (default: ncrectl-<timestamp>)")
 	cmd.Flags().Int32Var(&nodesPerJob, "nodes-per-job", 0,
@@ -637,7 +637,7 @@ func buildConfigFromFlags(
 	}
 	_, _ = fmt.Fprintf(out, "Discovered GPU nodes with product: %s\n", gpuProduct)
 
-	cert := &burninv1alpha1.Certification{
+	cert := &crev1alpha1.Certification{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cre.nvidia.com/v1alpha1",
 			Kind:       "Certification",
@@ -650,8 +650,8 @@ func buildConfigFromFlags(
 				"app.kubernetes.io/created-by": "ncrectl",
 			},
 		},
-		Spec: burninv1alpha1.CertificationSpec{
-			Target: burninv1alpha1.TargetSpec{
+		Spec: crev1alpha1.CertificationSpec{
+			Target: crev1alpha1.TargetSpec{
 				NodeSelector: map[string]string{
 					"nvidia.com/gpu.present": "true",
 					"nvidia.com/gpu.product": gpuProduct,
@@ -935,7 +935,7 @@ func executeCertificationRun(cfg *certRunConfig) (pipelineErr error) {
 // it to a JSON file. Caller must pass a non-nil cert.
 func handleReport(
 	ctx context.Context, wc client.WithWatch,
-	cert *burninv1alpha1.Certification, resultsFile string,
+	cert *crev1alpha1.Certification, resultsFile string,
 	waitErr error, out io.Writer,
 ) {
 	r := report.Build(ctx, wc, cert)
@@ -957,8 +957,8 @@ func handleReport(
 // discoverGPUProduct is replaced by discoverGPUNodes in run_common.go.
 
 // parseCategories splits "domain/variant" strings, validates each against the catalog.
-func parseCategories(strs []string) ([]burninv1alpha1.CertificateCategory, error) {
-	var cats []burninv1alpha1.CertificateCategory
+func parseCategories(strs []string) ([]crev1alpha1.CertificateCategory, error) {
+	var cats []crev1alpha1.CertificateCategory
 	for _, s := range strs {
 		parts := strings.SplitN(s, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -976,7 +976,7 @@ func parseCategories(strs []string) ([]burninv1alpha1.CertificateCategory, error
 				"unknown category %q\n\nAvailable categories:\n  %s",
 				s, strings.Join(names, "\n  "))
 		}
-		cats = append(cats, burninv1alpha1.CertificateCategory{
+		cats = append(cats, crev1alpha1.CertificateCategory{
 			Domain:  domain,
 			Variant: variant,
 		})
@@ -1005,7 +1005,7 @@ func generateCertNamespace() string {
 func watchCertification(
 	ctx context.Context, wc client.WithWatch,
 	name, namespace string, timeout time.Duration, out io.Writer,
-) (*burninv1alpha1.Certification, error) {
+) (*crev1alpha1.Certification, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -1020,7 +1020,7 @@ func watchCertification(
 		// (Re)establish watch. The API server closes watches after a
 		// server-side timeout (5-10 min). We reconnect until the client
 		// timeout (--timeout) expires or a terminal condition is seen.
-		certList := &burninv1alpha1.CertificationList{}
+		certList := &crev1alpha1.CertificationList{}
 		watcher, err := wc.Watch(ctx, certList, client.InNamespace(namespace),
 			client.MatchingFields{"metadata.name": name})
 		if err != nil {
@@ -1050,7 +1050,7 @@ func watchCertification(
 func processWatchEvents(
 	ctx context.Context, c client.Client, watcher watch.Interface, start time.Time,
 	lastStatuses map[string]string, heartbeat *time.Ticker, out io.Writer,
-) (*burninv1alpha1.Certification, bool, error) {
+) (*crev1alpha1.Certification, bool, error) {
 	events := watcher.ResultChan()
 	for {
 		select {
@@ -1065,7 +1065,7 @@ func processWatchEvents(
 				return nil, false, nil // transient error, reconnect
 			}
 
-			cert, isCert := event.Object.(*burninv1alpha1.Certification)
+			cert, isCert := event.Object.(*crev1alpha1.Certification)
 			if !isCert {
 				continue
 			}
@@ -1083,12 +1083,12 @@ func processWatchEvents(
 
 			// Check terminal conditions.
 			if apimeta.IsStatusConditionTrue(
-				cert.Status.Conditions, burninv1alpha1.CertificationSucceeded) {
+				cert.Status.Conditions, crev1alpha1.CertificationSucceeded) {
 				_, _ = fmt.Fprintf(out, "[watch] Certification succeeded. (%s)\n", elapsed)
 				return cert, true, nil
 			}
 			if apimeta.IsStatusConditionTrue(
-				cert.Status.Conditions, burninv1alpha1.CertificationFailed) {
+				cert.Status.Conditions, crev1alpha1.CertificationFailed) {
 				_, _ = fmt.Fprintf(out, "[watch] Certification failed. (%s)\n", elapsed)
 				if nodes := certFailedNodes(ctx, c, cert); len(nodes) > 0 {
 					_, _ = fmt.Fprintf(out, "Failed nodes: %s\n",
@@ -1134,7 +1134,7 @@ func waitForDeletion(ctx context.Context, c client.Client, name, namespace strin
 			_, _ = fmt.Fprintln(out, "[cleanup] Timed out waiting for deletion.")
 			return
 		case <-ticker.C:
-			cert := &burninv1alpha1.Certification{}
+			cert := &crev1alpha1.Certification{}
 			if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, cert); err != nil {
 				if apierrors.IsNotFound(err) {
 					return // deleted
@@ -1187,7 +1187,7 @@ func runReport(names []string, configFlags *kubeconfig.ConfigFlags, resultsFile 
 	var reports []*report.CertReport
 	var errs []string
 	for _, name := range names {
-		cert := &burninv1alpha1.Certification{}
+		cert := &crev1alpha1.Certification{}
 		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, cert); err != nil {
 			if apierrors.IsNotFound(err) {
 				return fmt.Errorf("certification %q not found in namespace %q", name, namespace)
@@ -1196,8 +1196,8 @@ func runReport(names []string, configFlags *kubeconfig.ConfigFlags, resultsFile 
 		}
 		reports = append(reports, report.Build(ctx, c, cert))
 
-		succeeded := apimeta.IsStatusConditionTrue(cert.Status.Conditions, burninv1alpha1.CertificationSucceeded)
-		failed := apimeta.IsStatusConditionTrue(cert.Status.Conditions, burninv1alpha1.CertificationFailed)
+		succeeded := apimeta.IsStatusConditionTrue(cert.Status.Conditions, crev1alpha1.CertificationSucceeded)
+		failed := apimeta.IsStatusConditionTrue(cert.Status.Conditions, crev1alpha1.CertificationFailed)
 		if !succeeded && !failed {
 			errs = append(errs, fmt.Sprintf("certification %q is still running", name))
 		} else if failed {

--- a/pkg/certification/certification_test.go
+++ b/pkg/certification/certification_test.go
@@ -11,15 +11,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
 )
 
 func TestCatalogListCategories(t *testing.T) {
@@ -560,7 +560,7 @@ func TestCategoryRunOptsWiringIntoCert(t *testing.T) {
 			storageClass:     "gp3",
 		}
 
-		cert := &burninv1alpha1.Certification{}
+		cert := &crev1alpha1.Certification{}
 
 		// Simulate the wiring logic from runCertificationRun.
 		if opts.enableCheckpoint != nil {
@@ -598,7 +598,7 @@ func TestCategoryRunOptsWiringIntoCert(t *testing.T) {
 
 	t.Run("zero opts leave fields nil", func(t *testing.T) {
 		opts := categoryRunOpts{}
-		cert := &burninv1alpha1.Certification{}
+		cert := &crev1alpha1.Certification{}
 
 		if opts.enableCheckpoint != nil {
 			cert.Spec.EnableCheckpoint = opts.enableCheckpoint
@@ -628,7 +628,7 @@ func TestCategoryRunOptsWiringIntoCert(t *testing.T) {
 	})
 
 	t.Run("nodesPerJob wiring", func(t *testing.T) {
-		cert := &burninv1alpha1.Certification{}
+		cert := &crev1alpha1.Certification{}
 		nodesPerJob := int32(4)
 		if nodesPerJob > 0 {
 			cert.Spec.NodesPerJob = &nodesPerJob
@@ -638,7 +638,7 @@ func TestCategoryRunOptsWiringIntoCert(t *testing.T) {
 	})
 
 	t.Run("nodesPerJob zero leaves nil", func(t *testing.T) {
-		cert := &burninv1alpha1.Certification{}
+		cert := &crev1alpha1.Certification{}
 		nodesPerJob := int32(0)
 		if nodesPerJob > 0 {
 			cert.Spec.NodesPerJob = &nodesPerJob

--- a/pkg/certification/nodes.go
+++ b/pkg/certification/nodes.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
 )
 
 const defaultKubeNamespace = "default"
@@ -21,7 +21,7 @@ const defaultKubeNamespace = "default"
 // message).
 func failedNodesFromRef(
 	ctx context.Context, c client.Client, namespace string, ref *corev1.TypedLocalObjectReference,
-) []burninv1alpha1.FailedNode {
+) []crev1alpha1.FailedNode {
 	if ref == nil || ref.Name == "" {
 		return nil
 	}
@@ -38,7 +38,7 @@ func failedNodesFromRef(
 
 // certFailedNodes returns the deduped union of failed node names across all
 // categories, resolved from each category's nodeResultsRef ConfigMap.
-func certFailedNodes(ctx context.Context, c client.Client, cert *burninv1alpha1.Certification) []string {
+func certFailedNodes(ctx context.Context, c client.Client, cert *crev1alpha1.Certification) []string {
 	seen := make(map[string]struct{})
 	var union []string
 	for _, cat := range cert.Status.CategoryStatuses {

--- a/pkg/certification/render_orchestration_test.go
+++ b/pkg/certification/render_orchestration_test.go
@@ -10,9 +10,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	_ "github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	_ "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // certification render is the check-before-you-apply tool, so what it prints
@@ -26,7 +26,7 @@ func TestRenderOrchestrationOptions(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		var opts burninv1alpha1.CategoryOptions
+		var opts crev1alpha1.CategoryOptions
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &opts); err != nil {
 			return err
 		}
@@ -39,21 +39,21 @@ func TestRenderOrchestrationOptions(t *testing.T) {
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &sel); err != nil {
 			return err
 		}
-		cat := burninv1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+		cat := crev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
 		if sel.Category != nil {
-			cat = burninv1alpha1.CertificateCategory{Domain: sel.Category.Domain, Variant: sel.Category.Variant}
+			cat = crev1alpha1.CertificateCategory{Domain: sel.Category.Domain, Variant: sel.Category.Variant}
 		}
 
-		cert := &burninv1alpha1.Certification{
+		cert := &crev1alpha1.Certification{
 			ObjectMeta: metav1.ObjectMeta{Name: "render-test"},
-			Spec: burninv1alpha1.CertificationSpec{
-				Target: burninv1alpha1.TargetSpec{
+			Spec: crev1alpha1.CertificationSpec{
+				Target: crev1alpha1.TargetSpec{
 					NodeSelector: map[string]string{
 						"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
 					},
 				},
 				CategoryOptions: opts,
-				Categories:      []burninv1alpha1.CertificateCategory{cat},
+				Categories:      []crev1alpha1.CertificateCategory{cat},
 			},
 		}
 
@@ -64,10 +64,10 @@ func TestRenderOrchestrationOptions(t *testing.T) {
 
 		wf := workflows[0]
 		out := struct {
-			Orchestration burninv1alpha1.OrchestrationSpec `json:"orchestration"`
-			NumNodes      *int32                           `json:"numNodes,omitempty"`
-			MaxRestarts   int32                            `json:"maxRestarts,omitempty"`
-			Measurement   string                           `json:"measurementTimeout,omitempty"`
+			Orchestration crev1alpha1.OrchestrationSpec `json:"orchestration"`
+			NumNodes      *int32                        `json:"numNodes,omitempty"`
+			MaxRestarts   int32                         `json:"maxRestarts,omitempty"`
+			Measurement   string                        `json:"measurementTimeout,omitempty"`
 		}{Orchestration: wf.Spec.Orchestration}
 
 		if tj := wf.Spec.JobTemplate.Spec.Workload.TrainJob; tj != nil && tj.Trainer != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -12,14 +12,14 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	sigyaml "sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/render"
 )
 
 const outputJSON = "json"

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // gpuNode builds a ready node. A negative count leaves nvidia.com/gpu unset,

--- a/pkg/cluster/discover.go
+++ b/pkg/cluster/discover.go
@@ -11,15 +11,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
 )
 
 // DiscoverGPUNodes discovers GPU nodes matching a target, validates that all
 // nodes share the same nvidia.com/gpu.product, and returns them with the
 // product string. If target is nil all GPU nodes are selected.
 func DiscoverGPUNodes(
-	ctx context.Context, c client.Client, target *burninv1alpha1.TargetSpec,
+	ctx context.Context, c client.Client, target *crev1alpha1.TargetSpec,
 ) ([]corev1.Node, string, error) {
 	nodes, err := controller.DiscoverTargetNodes(ctx, c, target)
 	if err != nil {

--- a/pkg/controller/bandwidthmeasurement_controller.go
+++ b/pkg/controller/bandwidthmeasurement_controller.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nccl"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nccl"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podutil"
 )
 
 const (
@@ -94,7 +94,7 @@ func (r *BandwidthMeasurementReconciler) getLogFetcher() podlogs.PodLogFetcher {
 	return podlogs.NewKubernetesLogFetcher(r.Clientset)
 }
 
-func (r *BandwidthMeasurementReconciler) getSampleInterval(m *burninv1alpha1.BandwidthMeasurement) time.Duration {
+func (r *BandwidthMeasurementReconciler) getSampleInterval(m *crev1alpha1.BandwidthMeasurement) time.Duration {
 	if m.Spec.SampleInterval != nil {
 		return m.Spec.SampleInterval.Duration
 	}
@@ -117,7 +117,7 @@ func (r *BandwidthMeasurementReconciler) getRequeueInterval() time.Duration {
 func (r *BandwidthMeasurementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	measurement := &burninv1alpha1.BandwidthMeasurement{}
+	measurement := &crev1alpha1.BandwidthMeasurement{}
 	if err := r.Get(ctx, req.NamespacedName, measurement); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("BandwidthMeasurement resource not found, likely deleted")
@@ -140,7 +140,7 @@ func (r *BandwidthMeasurementReconciler) Reconcile(ctx context.Context, req ctrl
 	return r.reconcileMeasurement(ctx, measurement)
 }
 
-func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement) (ctrl.Result, error) {
+func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Context, measurement *crev1alpha1.BandwidthMeasurement) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if measurement.Spec.JobRef.Name == "" {
@@ -149,12 +149,12 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 	}
 
 	// If already complete, nothing to do.
-	if cond := meta.FindStatusCondition(measurement.Status.Conditions, burninv1alpha1.BandwidthMeasurementComplete); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(measurement.Status.Conditions, crev1alpha1.BandwidthMeasurementComplete); cond != nil && cond.Status == metav1.ConditionTrue {
 		return ctrl.Result{}, nil
 	}
 
-	// Fetch the referenced burnin Job.
-	job := &burninv1alpha1.Job{}
+	// Fetch the referenced CRE Job.
+	job := &crev1alpha1.Job{}
 	jobKey := types.NamespacedName{Name: measurement.Spec.JobRef.Name, Namespace: measurement.Namespace}
 	if err := r.Get(ctx, jobKey, job); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -165,7 +165,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 	}
 
 	// Determine Job phase from conditions.
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
 		// Do a final log parse if we don't have results yet.
 		if len(measurement.Status.Results) == 0 {
 			if _, err := r.handleRunning(ctx, measurement, job); err != nil {
@@ -174,7 +174,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 		}
 		return r.handleTerminal(ctx, measurement, reasonBandwidthJobSucceeded, "Job succeeded")
 	}
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
 		// Attempt final log parse — failed jobs may still have partial bandwidth data.
 		if len(measurement.Status.Results) == 0 {
 			if _, err := r.handleRunning(ctx, measurement, job); err != nil {
@@ -183,7 +183,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 		}
 		return r.handleTerminal(ctx, measurement, reasonBandwidthJobFailed, "Job failed")
 	}
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
 		return r.handleRunning(ctx, measurement, job)
 	}
 
@@ -191,7 +191,7 @@ func (r *BandwidthMeasurementReconciler) reconcileMeasurement(ctx context.Contex
 	return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 }
 
-func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, measurement *crev1alpha1.BandwidthMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	key := measurement.Namespace + "/" + measurement.Name
 
@@ -323,7 +323,7 @@ func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, meas
 
 	// Set Measuring condition.
 	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
-		Type:               burninv1alpha1.BandwidthMeasurementMeasuring,
+		Type:               crev1alpha1.BandwidthMeasurementMeasuring,
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: measurement.Generation,
 		Reason:             reasonBandwidthJobRunning,
@@ -359,11 +359,11 @@ func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, meas
 // measurement, so the cause is visible in status and not only in the controller
 // log. This is deliberately not terminal: a cluster-scoped LogProfile can be
 // created after the run starts, and the next sample picks it up.
-func (r *BandwidthMeasurementReconciler) noteLogProfileUnresolved(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement, cause error) {
+func (r *BandwidthMeasurementReconciler) noteLogProfileUnresolved(ctx context.Context, measurement *crev1alpha1.BandwidthMeasurement, cause error) {
 	message := fmt.Sprintf("LogProfile %q could not be resolved: %v", measurement.Spec.LogProfileRef, cause)
-	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *burninv1alpha1.BandwidthMeasurement) bool {
+	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *crev1alpha1.BandwidthMeasurement) bool {
 		return meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.BandwidthMeasurementMeasuring,
+			Type:               crev1alpha1.BandwidthMeasurementMeasuring,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: m.Generation,
 			Reason:             reasonBandwidthLogProfileMissing,
@@ -375,7 +375,7 @@ func (r *BandwidthMeasurementReconciler) noteLogProfileUnresolved(ctx context.Co
 	}
 }
 
-func (r *BandwidthMeasurementReconciler) handleTerminal(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement, reason, message string) (ctrl.Result, error) {
+func (r *BandwidthMeasurementReconciler) handleTerminal(ctx context.Context, measurement *crev1alpha1.BandwidthMeasurement, reason, message string) (ctrl.Result, error) {
 	now := metav1.Now()
 	measurement.Status.CompletionTime = &now
 
@@ -387,14 +387,14 @@ func (r *BandwidthMeasurementReconciler) handleTerminal(ctx context.Context, mea
 	}
 
 	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
-		Type:               burninv1alpha1.BandwidthMeasurementMeasuring,
+		Type:               crev1alpha1.BandwidthMeasurementMeasuring,
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: measurement.Generation,
 		Reason:             reason,
 		Message:            message,
 	})
 	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
-		Type:               burninv1alpha1.BandwidthMeasurementComplete,
+		Type:               crev1alpha1.BandwidthMeasurementComplete,
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: measurement.Generation,
 		Reason:             reason,
@@ -417,7 +417,7 @@ func (r *BandwidthMeasurementReconciler) handleTerminal(ctx context.Context, mea
 	return ctrl.Result{}, nil
 }
 
-func (r *BandwidthMeasurementReconciler) handleDeletion(ctx context.Context, measurement *burninv1alpha1.BandwidthMeasurement) (ctrl.Result, error) {
+func (r *BandwidthMeasurementReconciler) handleDeletion(ctx context.Context, measurement *crev1alpha1.BandwidthMeasurement) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if controllerutil.ContainsFinalizer(measurement, bandwidthMeasurementFinalizer) {
@@ -452,11 +452,11 @@ func (r *BandwidthMeasurementReconciler) handleDeletion(ctx context.Context, mea
 // The cache is keyed by LogProfile name but validated against its resourceVersion,
 // so editing a LogProfile's patterns takes effect on the next reconcile rather
 // than requiring a controller restart. Only one entry per profile is retained.
-func (r *BandwidthMeasurementReconciler) getOrCreateParser(ctx context.Context, logProfileName string) (*nccl.Parser, *burninv1alpha1.LogProfile, error) {
+func (r *BandwidthMeasurementReconciler) getOrCreateParser(ctx context.Context, logProfileName string) (*nccl.Parser, *crev1alpha1.LogProfile, error) {
 	// The profile is always needed (workerStrategy, containerName) and this Get is
 	// served from the informer cache, so fetch it first and use its resourceVersion
 	// to decide whether the cached parser is still valid.
-	profile := &burninv1alpha1.LogProfile{}
+	profile := &crev1alpha1.LogProfile{}
 	if err := r.Get(ctx, types.NamespacedName{Name: logProfileName}, profile); err != nil {
 		return nil, nil, fmt.Errorf("getting LogProfile %s: %w", logProfileName, err)
 	}
@@ -489,7 +489,7 @@ func (r *BandwidthMeasurementReconciler) getOrCreateParser(ctx context.Context, 
 // mergeBandwidthResults merges new data points into existing results using running averages.
 // For sizes already in existing, the average is updated: newAvg = (oldAvg*oldN + sum(new)) / (oldN + newN).
 // New sizes are appended in the order they appear in the data points.
-func mergeBandwidthResults(existing []burninv1alpha1.BandwidthResult, dataPoints []nccl.BandwidthDataPoint) []burninv1alpha1.BandwidthResult {
+func mergeBandwidthResults(existing []crev1alpha1.BandwidthResult, dataPoints []nccl.BandwidthDataPoint) []crev1alpha1.BandwidthResult {
 	// Index existing results by size for O(1) lookup.
 	idx := make(map[int64]int, len(existing))
 	for i, r := range existing {
@@ -517,7 +517,7 @@ func mergeBandwidthResults(existing []burninv1alpha1.BandwidthResult, dataPoints
 	}
 
 	// Deep-copy existing results so we don't mutate the caller's slice.
-	results := make([]burninv1alpha1.BandwidthResult, len(existing))
+	results := make([]crev1alpha1.BandwidthResult, len(existing))
 	copy(results, existing)
 
 	for _, size := range newOrder {
@@ -533,7 +533,7 @@ func mergeBandwidthResults(existing []burninv1alpha1.BandwidthResult, dataPoints
 			results[i].Samples = totalN
 		} else {
 			// New size — append.
-			results = append(results, burninv1alpha1.BandwidthResult{
+			results = append(results, crev1alpha1.BandwidthResult{
 				SizeBytes: size,
 				AlgBW:     strconv.FormatFloat(a.sumAlgBW/float64(a.count), 'f', 2, 64),
 				BusBW:     strconv.FormatFloat(a.sumBusBW/float64(a.count), 'f', 2, 64),
@@ -548,7 +548,7 @@ func mergeBandwidthResults(existing []burninv1alpha1.BandwidthResult, dataPoints
 // SetupWithManager sets up the controller with the Manager.
 func (r *BandwidthMeasurementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.BandwidthMeasurement{}).
+		For(&crev1alpha1.BandwidthMeasurement{}).
 		Named("bandwidthmeasurement").
 		Complete(r)
 }

--- a/pkg/controller/certification_archfilter_test.go
+++ b/pkg/controller/certification_archfilter_test.go
@@ -11,9 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // TestResolveNodesPerJobAfterArchFilter covers sizing a job on a heterogeneous
@@ -70,8 +70,8 @@ func TestResolveNodesPerJobAfterArchFilter(t *testing.T) {
 			}}
 		}
 
-		opts := burninv1alpha1.CategoryOptions{NodesPerJob: input.NodesPerJob}
-		cat := burninv1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+		opts := crev1alpha1.CategoryOptions{NodesPerJob: input.NodesPerJob}
+		cat := crev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
 
 		// The two steps the Certification controller performs, in order.
 		gpuArch, archNodes := detectGPUArchConsistent(nodes)

--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -21,16 +21,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/naming"
 )
 
 // waitingForNodesMessage explains a wait that is otherwise invisible: which
 // selector matched nothing, and how much of the discovery window is left. Note
 // that discoverTargetNodes filters unschedulable nodes before counting, so this
 // covers a cordoned fleet as well as a selector that matches nothing at all.
-func waitingForNodesMessage(cert *burninv1alpha1.Certification) string {
+func waitingForNodesMessage(cert *crev1alpha1.Certification) string {
 	remaining := max((nodeDiscoveryTimeout - time.Since(cert.CreationTimestamp.Time)).Round(time.Second), 0)
 	sel := "any node"
 	if len(cert.Spec.Target.NodeSelector) > 0 {
@@ -91,7 +91,7 @@ type CertificationReconciler struct {
 func (r *CertificationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	certification := &burninv1alpha1.Certification{}
+	certification := &crev1alpha1.Certification{}
 	if err := r.Get(ctx, req.NamespacedName, certification); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Certification resource not found, likely deleted")
@@ -117,7 +117,7 @@ func (r *CertificationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // reconcileWorkflows ensures Workflows are created sequentially for each category
 // and their status is reflected on the Certification.
-func (r *CertificationReconciler) reconcileWorkflows(ctx context.Context, certification *burninv1alpha1.Certification) (ctrl.Result, error) {
+func (r *CertificationReconciler) reconcileWorkflows(ctx context.Context, certification *crev1alpha1.Certification) (ctrl.Result, error) {
 	if r.isTerminal(certification) {
 		// Verify child Workflows are actually terminal. A Workflow with repeatCount
 		// may restart after a failed iteration, making the Certification's terminal
@@ -139,7 +139,7 @@ func (r *CertificationReconciler) reconcileWorkflows(ctx context.Context, certif
 
 // initializeCategoryStatuses validates all categories, initializes their statuses as Pending,
 // and creates the Workflow for the first category.
-func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context, certification *burninv1alpha1.Certification) (ctrl.Result, error) {
+func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context, certification *crev1alpha1.Certification) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	// Validate all categories in the catalog upfront (fail-fast on unknown category)
@@ -155,9 +155,9 @@ func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context
 	}
 
 	// Initialize all categories as Pending
-	categoryStatuses := make([]burninv1alpha1.CertificationCategoryStatus, 0, len(certification.Spec.Categories))
+	categoryStatuses := make([]crev1alpha1.CertificationCategoryStatus, 0, len(certification.Spec.Categories))
 	for _, category := range certification.Spec.Categories {
-		categoryStatuses = append(categoryStatuses, burninv1alpha1.CertificationCategoryStatus{
+		categoryStatuses = append(categoryStatuses, crev1alpha1.CertificationCategoryStatus{
 			Domain:  category.Domain,
 			Variant: category.Variant,
 			Status:  categoryStatusPending,
@@ -187,7 +187,7 @@ func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context
 	}
 
 	categoryStatuses[0].Status = categoryStatusInProgress
-	categoryStatuses[0].WorkflowRef = &burninv1alpha1.WorkflowReference{
+	categoryStatuses[0].WorkflowRef = &crev1alpha1.WorkflowReference{
 		Name:      workflowName,
 		Namespace: certification.Namespace,
 	}
@@ -204,7 +204,7 @@ func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context
 // processNextCategory finds the first non-terminal category and either checks its
 // active Workflow or creates the next Workflow. When all categories are terminal,
 // it finalizes the Certification.
-func (r *CertificationReconciler) processNextCategory(ctx context.Context, certification *burninv1alpha1.Certification) (ctrl.Result, error) {
+func (r *CertificationReconciler) processNextCategory(ctx context.Context, certification *crev1alpha1.Certification) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	// Find the first non-terminal category
@@ -251,7 +251,7 @@ func (r *CertificationReconciler) processNextCategory(ctx context.Context, certi
 	}
 
 	catStatus.Status = categoryStatusInProgress
-	catStatus.WorkflowRef = &burninv1alpha1.WorkflowReference{
+	catStatus.WorkflowRef = &crev1alpha1.WorkflowReference{
 		Name:      workflowName,
 		Namespace: certification.Namespace,
 	}
@@ -268,10 +268,10 @@ func (r *CertificationReconciler) processNextCategory(ctx context.Context, certi
 // checkActiveWorkflow fetches the active Workflow and updates the category status
 // based on its conditions. If the Workflow is terminal, it requeues immediately
 // to advance to the next category.
-func (r *CertificationReconciler) checkActiveWorkflow(ctx context.Context, certification *burninv1alpha1.Certification, idx int) (ctrl.Result, error) {
+func (r *CertificationReconciler) checkActiveWorkflow(ctx context.Context, certification *crev1alpha1.Certification, idx int) (ctrl.Result, error) {
 	catStatus := &certification.Status.CategoryStatuses[idx]
 
-	workflow := &burninv1alpha1.Workflow{}
+	workflow := &crev1alpha1.Workflow{}
 	ns := catStatus.WorkflowRef.Namespace
 	if ns == "" {
 		ns = certification.Namespace
@@ -297,7 +297,7 @@ func (r *CertificationReconciler) checkActiveWorkflow(ctx context.Context, certi
 	}
 
 	// Check for terminal Workflow conditions
-	if cond := meta.FindStatusCondition(workflow.Status.Conditions, burninv1alpha1.WorkflowFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(workflow.Status.Conditions, crev1alpha1.WorkflowFailed); cond != nil && cond.Status == metav1.ConditionTrue {
 		catStatus.Status = categoryStatusFailed
 		if err := r.setCertificationInProgress(ctx, certification, ReasonWorkflowRunning,
 			fmt.Sprintf("Workflow for category %s/%s failed, advancing to next category", catStatus.Domain, catStatus.Variant)); err != nil {
@@ -306,7 +306,7 @@ func (r *CertificationReconciler) checkActiveWorkflow(ctx context.Context, certi
 		return ctrl.Result{RequeueAfter: requeueImmediate}, nil
 	}
 
-	if cond := meta.FindStatusCondition(workflow.Status.Conditions, burninv1alpha1.WorkflowSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(workflow.Status.Conditions, crev1alpha1.WorkflowSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
 		catStatus.Status = categoryStatusSucceeded
 		if err := r.setCertificationInProgress(ctx, certification, ReasonWorkflowRunning,
 			fmt.Sprintf("Workflow for category %s/%s succeeded, advancing to next category", catStatus.Domain, catStatus.Variant)); err != nil {
@@ -325,7 +325,7 @@ func (r *CertificationReconciler) checkActiveWorkflow(ctx context.Context, certi
 
 // finalizeCertification aggregates results when all categories are terminal and sets
 // the final Certification status.
-func (r *CertificationReconciler) finalizeCertification(ctx context.Context, certification *burninv1alpha1.Certification) (ctrl.Result, error) {
+func (r *CertificationReconciler) finalizeCertification(ctx context.Context, certification *crev1alpha1.Certification) (ctrl.Result, error) {
 	anyFailed := false
 	for _, catStatus := range certification.Status.CategoryStatuses {
 		if catStatus.Status == categoryStatusFailed {
@@ -354,7 +354,7 @@ func (r *CertificationReconciler) finalizeCertification(ctx context.Context, cer
 // createWorkflowForCategory creates a single Workflow for the given category.
 // It performs full resolution: discovers nodes, detects platform/GPU, resolves
 // options, renders templates, applies overlays, and prunes applied overlays.
-func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context, certification *burninv1alpha1.Certification, category burninv1alpha1.CertificateCategory) (string, error) {
+func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context, certification *crev1alpha1.Certification, category crev1alpha1.CertificateCategory) (string, error) {
 	log := logf.FromContext(ctx)
 
 	entry := catalog.Lookup(category.Domain, category.Variant)
@@ -450,7 +450,7 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 	}
 
 	// --- 4. Apply overlays (best-effort, prune applied) ---
-	orch := &burninv1alpha1.OrchestrationStatus{
+	orch := &crev1alpha1.OrchestrationStatus{
 		DetectedPlatform:        platform,
 		DetectedGPUArchitecture: gpuArch,
 	}
@@ -469,7 +469,7 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 
 	// --- 5. Create Workflow ---
 	workflowName := r.getWorkflowName(certification, category)
-	workflow := &burninv1alpha1.Workflow{
+	workflow := &crev1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workflowName,
 			Namespace: certification.Namespace,
@@ -515,7 +515,7 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 
 // ResolveOptions merges per-category overrides with global defaults.
 // Returns a flat CategoryOptions with all values resolved.
-func ResolveOptions(global *burninv1alpha1.CategoryOptions, override *burninv1alpha1.CategoryOptions) burninv1alpha1.CategoryOptions {
+func ResolveOptions(global *crev1alpha1.CategoryOptions, override *crev1alpha1.CategoryOptions) crev1alpha1.CategoryOptions {
 	resolved := *global
 	if override == nil {
 		return resolved
@@ -600,7 +600,7 @@ func ResolveOptions(global *burninv1alpha1.CategoryOptions, override *burninv1al
 // Otherwise auto-selects the largest valid node count <= available nodes.
 // "Valid" means satisfying the entry's constraints (minGPUs, TP×PP divisibility).
 // When no constraints are defined, uses all available nodes.
-func resolveNodesPerJob(nodes []corev1.Node, cat burninv1alpha1.CertificateCategory, opts burninv1alpha1.CategoryOptions, entry *catalog.Entry, gpusPerNode int32, gpuArch string) (int32, error) {
+func resolveNodesPerJob(nodes []corev1.Node, cat crev1alpha1.CertificateCategory, opts crev1alpha1.CategoryOptions, entry *catalog.Entry, gpusPerNode int32, gpuArch string) (int32, error) {
 	n := int32(len(nodes))
 	if n == 0 {
 		return 0, fmt.Errorf("no matching nodes for %s/%s", cat.Domain, cat.Variant)
@@ -627,7 +627,7 @@ func resolveNodesPerJob(nodes []corev1.Node, cat burninv1alpha1.CertificateCateg
 
 // pruneAppliedOverrides removes applied overlays from the spec, keeping
 // only unresolved ones for the WorkflowController to handle.
-func pruneAppliedOverrides(spec *burninv1alpha1.WorkflowSpec, applied []burninv1alpha1.AppliedOverride) {
+func pruneAppliedOverrides(spec *crev1alpha1.WorkflowSpec, applied []crev1alpha1.AppliedOverride) {
 	if len(applied) == 0 {
 		return
 	}
@@ -635,7 +635,7 @@ func pruneAppliedOverrides(spec *burninv1alpha1.WorkflowSpec, applied []burninv1
 	for _, a := range applied {
 		appliedSet[a.Index] = true
 	}
-	remaining := make([]burninv1alpha1.OverrideSpec, 0, len(spec.Overrides)-len(applied))
+	remaining := make([]crev1alpha1.OverrideSpec, 0, len(spec.Overrides)-len(applied))
 	for i, o := range spec.Overrides {
 		if !appliedSet[i] {
 			remaining = append(remaining, o)
@@ -647,8 +647,8 @@ func pruneAppliedOverrides(spec *burninv1alpha1.WorkflowSpec, applied []burninv1
 // pruneUnmatchableOverrides removes overrides whose when conditions cannot
 // match the detected platform and GPU architecture. Since these are known at
 // Certification build time, non-matching overrides are noise in the Workflow.
-func pruneUnmatchableOverrides(spec *burninv1alpha1.WorkflowSpec, octx OverrideContext) {
-	remaining := make([]burninv1alpha1.OverrideSpec, 0, len(spec.Overrides))
+func pruneUnmatchableOverrides(spec *crev1alpha1.WorkflowSpec, octx OverrideContext) {
+	remaining := make([]crev1alpha1.OverrideSpec, 0, len(spec.Overrides))
 	for _, o := range spec.Overrides {
 		matches, err := matchesWhen(o.When, octx)
 		if err != nil || matches {
@@ -667,15 +667,15 @@ func derefBool(p *bool) bool {
 }
 
 // setCertificationInProgress sets the Certification to InProgress state.
-func (r *CertificationReconciler) setCertificationInProgress(ctx context.Context, certification *burninv1alpha1.Certification, reason, message string) error {
-	return r.setExclusiveCondition(ctx, certification, burninv1alpha1.CertificationInProgress, reason, message)
+func (r *CertificationReconciler) setCertificationInProgress(ctx context.Context, certification *crev1alpha1.Certification, reason, message string) error {
+	return r.setExclusiveCondition(ctx, certification, crev1alpha1.CertificationInProgress, reason, message)
 }
 
 // recoverIfWorkflowStillRunning checks child Workflows of a terminal Certification.
 // If any Workflow is still running (e.g., restarted after a failed iteration with
 // repeatCount), it resets the Certification and category status back to InProgress
 // so reconciliation continues. Returns true if recovery occurred.
-func (r *CertificationReconciler) recoverIfWorkflowStillRunning(ctx context.Context, certification *burninv1alpha1.Certification) bool {
+func (r *CertificationReconciler) recoverIfWorkflowStillRunning(ctx context.Context, certification *crev1alpha1.Certification) bool {
 	log := logf.FromContext(ctx)
 
 	for i := range certification.Status.CategoryStatuses {
@@ -684,7 +684,7 @@ func (r *CertificationReconciler) recoverIfWorkflowStillRunning(ctx context.Cont
 			continue
 		}
 
-		wf := &burninv1alpha1.Workflow{}
+		wf := &crev1alpha1.Workflow{}
 		ns := catStatus.WorkflowRef.Namespace
 		if ns == "" {
 			ns = certification.Namespace
@@ -695,8 +695,8 @@ func (r *CertificationReconciler) recoverIfWorkflowStillRunning(ctx context.Cont
 
 		// If the Workflow is not terminal (InProgress), the Certification's Failed
 		// state is stale — the Workflow restarted a new iteration.
-		wfFailed := meta.FindStatusCondition(wf.Status.Conditions, burninv1alpha1.WorkflowFailed)
-		wfSucceeded := meta.FindStatusCondition(wf.Status.Conditions, burninv1alpha1.WorkflowSucceeded)
+		wfFailed := meta.FindStatusCondition(wf.Status.Conditions, crev1alpha1.WorkflowFailed)
+		wfSucceeded := meta.FindStatusCondition(wf.Status.Conditions, crev1alpha1.WorkflowSucceeded)
 		wfTerminal := (wfFailed != nil && wfFailed.Status == metav1.ConditionTrue) ||
 			(wfSucceeded != nil && wfSucceeded.Status == metav1.ConditionTrue)
 
@@ -717,34 +717,34 @@ func (r *CertificationReconciler) recoverIfWorkflowStillRunning(ctx context.Cont
 
 // isTerminal returns true if the Certification is in a terminal state
 // (Succeeded or Failed). Matches the pattern used by Workflow and Job controllers.
-func (r *CertificationReconciler) isTerminal(certification *burninv1alpha1.Certification) bool {
-	if cond := meta.FindStatusCondition(certification.Status.Conditions, burninv1alpha1.CertificationSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+func (r *CertificationReconciler) isTerminal(certification *crev1alpha1.Certification) bool {
+	if cond := meta.FindStatusCondition(certification.Status.Conditions, crev1alpha1.CertificationSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
 		return true
 	}
-	if cond := meta.FindStatusCondition(certification.Status.Conditions, burninv1alpha1.CertificationFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(certification.Status.Conditions, crev1alpha1.CertificationFailed); cond != nil && cond.Status == metav1.ConditionTrue {
 		return true
 	}
 	return false
 }
 
 // setCertificationSucceeded sets the Certification to Succeeded state.
-func (r *CertificationReconciler) setCertificationSucceeded(ctx context.Context, certification *burninv1alpha1.Certification, reason, message string) error {
-	return r.setExclusiveCondition(ctx, certification, burninv1alpha1.CertificationSucceeded, reason, message)
+func (r *CertificationReconciler) setCertificationSucceeded(ctx context.Context, certification *crev1alpha1.Certification, reason, message string) error {
+	return r.setExclusiveCondition(ctx, certification, crev1alpha1.CertificationSucceeded, reason, message)
 }
 
 // setCertificationFailed sets the Certification to Failed state.
-func (r *CertificationReconciler) setCertificationFailed(ctx context.Context, certification *burninv1alpha1.Certification, reason, message string) error {
-	return r.setExclusiveCondition(ctx, certification, burninv1alpha1.CertificationFailed, reason, message)
+func (r *CertificationReconciler) setCertificationFailed(ctx context.Context, certification *crev1alpha1.Certification, reason, message string) error {
+	return r.setExclusiveCondition(ctx, certification, crev1alpha1.CertificationFailed, reason, message)
 }
 
 // setExclusiveCondition sets one condition True and all others False (mutually exclusive).
-func (r *CertificationReconciler) setExclusiveCondition(ctx context.Context, certification *burninv1alpha1.Certification, conditionType, reason, message string) error {
+func (r *CertificationReconciler) setExclusiveCondition(ctx context.Context, certification *crev1alpha1.Certification, conditionType, reason, message string) error {
 	changed, err := setExclusiveStatusCondition(ctx, r.Client, certification,
-		func(c *burninv1alpha1.Certification) *[]metav1.Condition { return &c.Status.Conditions },
+		func(c *crev1alpha1.Certification) *[]metav1.Condition { return &c.Status.Conditions },
 		[]string{
-			burninv1alpha1.CertificationInProgress,
-			burninv1alpha1.CertificationSucceeded,
-			burninv1alpha1.CertificationFailed,
+			crev1alpha1.CertificationInProgress,
+			crev1alpha1.CertificationSucceeded,
+			crev1alpha1.CertificationFailed,
 		},
 		conditionType, reason, message,
 	)
@@ -760,7 +760,7 @@ func (r *CertificationReconciler) setExclusiveCondition(ctx context.Context, cer
 // getWorkflowName returns the name for the Workflow created for a given category.
 // When per-category options are set, a deterministic suffix is appended so that
 // duplicate domain/variant entries with different options get unique Workflows.
-func (r *CertificationReconciler) getWorkflowName(certification *burninv1alpha1.Certification, category burninv1alpha1.CertificateCategory) string {
+func (r *CertificationReconciler) getWorkflowName(certification *crev1alpha1.Certification, category crev1alpha1.CertificateCategory) string {
 	raw := fmt.Sprintf("%s-%s-%s", certification.Name, category.Domain, category.Variant)
 	if opts := category.Options; opts != nil {
 		raw += categoryOptionsSuffix(opts)
@@ -771,7 +771,7 @@ func (r *CertificationReconciler) getWorkflowName(certification *burninv1alpha1.
 // categoryOptionsSuffix returns a deterministic string from the category options
 // that distinguishes duplicate domain/variant entries. Uses short human-readable
 // tokens where possible; Truncate() hashes if the result is too long.
-func categoryOptionsSuffix(opts *burninv1alpha1.CategoryOptions) string {
+func categoryOptionsSuffix(opts *crev1alpha1.CategoryOptions) string {
 	var parts []string
 	if opts.NodesPerJob != nil {
 		parts = append(parts, fmt.Sprintf("n%d", *opts.NodesPerJob))
@@ -813,7 +813,7 @@ func (r *CertificationReconciler) getRequeueInterval() time.Duration {
 }
 
 // handleDeletion handles the cleanup when a Certification is being deleted.
-func (r *CertificationReconciler) handleDeletion(ctx context.Context, certification *burninv1alpha1.Certification) (ctrl.Result, error) {
+func (r *CertificationReconciler) handleDeletion(ctx context.Context, certification *crev1alpha1.Certification) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(certification, certificationFinalizer) {
@@ -831,7 +831,7 @@ func (r *CertificationReconciler) handleDeletion(ctx context.Context, certificat
 		if ns == "" {
 			ns = certification.Namespace
 		}
-		workflow := &burninv1alpha1.Workflow{}
+		workflow := &crev1alpha1.Workflow{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: catStatus.WorkflowRef.Name}, workflow); err == nil {
 			log.Info("Deleting owned Workflow", "name", catStatus.WorkflowRef.Name)
 			if err := r.Delete(ctx, workflow); err != nil && !apierrors.IsNotFound(err) {
@@ -862,8 +862,8 @@ func derefInt32(p *int32) int32 {
 // SetupWithManager sets up the controller with the Manager.
 func (r *CertificationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.Certification{}).
-		Owns(&burninv1alpha1.Workflow{}).
+		For(&crev1alpha1.Certification{}).
+		Owns(&crev1alpha1.Workflow{}).
 		Named("certification").
 		Complete(r)
 }

--- a/pkg/controller/discover_cordoned_test.go
+++ b/pkg/controller/discover_cordoned_test.go
@@ -12,8 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // Discovery drops cordoned nodes because they cannot run workload pods. It used
@@ -61,7 +61,7 @@ func TestDiscoverCordonedNodes(t *testing.T) {
 
 		nodes, cordoned, err := discoverTargetNodes(context.Background(),
 			unorderedReader{nodes: given},
-			&burninv1alpha1.TargetSpec{})
+			&crev1alpha1.TargetSpec{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/discover_node_order_test.go
+++ b/pkg/controller/discover_node_order_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // unorderedReader hands nodes back in the order given. The controller-runtime
@@ -63,7 +63,7 @@ func TestDiscoverNodeOrder(t *testing.T) {
 
 		nodes, _, err := discoverTargetNodes(context.Background(),
 			unorderedReader{nodes: given},
-			&burninv1alpha1.TargetSpec{
+			&crev1alpha1.TargetSpec{
 				NodeSelector: map[string]string{"nvidia.com/gpu.present": "true"},
 			})
 		if err != nil {

--- a/pkg/controller/exclusion_summary_test.go
+++ b/pkg/controller/exclusion_summary_test.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // A node can be left uncertified for more than one reason at once, and the

--- a/pkg/controller/failure_log_test.go
+++ b/pkg/controller/failure_log_test.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nodemonitor"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // The stored tail was 30 lines, right for a workload whose last line is the
@@ -78,7 +78,7 @@ func TestFailureLogCapture(t *testing.T) {
 		}
 
 		scheme := runtime.NewScheme()
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 		if err := corev1.AddToScheme(scheme); err != nil {
@@ -102,7 +102,7 @@ func TestFailureLogCapture(t *testing.T) {
 			objs = append(objs, pod)
 		}
 
-		job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		job := &crev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 			WithIndex(&corev1.Pod{}, nodemonitor.PodCREJobIndexField, func(obj client.Object) []string {
 				pod, ok := obj.(*corev1.Pod)

--- a/pkg/controller/goodput_final_sample_test.go
+++ b/pkg/controller/goodput_final_sample_test.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // handleSucceeded and handleFailed build from the stored status and never read
@@ -42,18 +42,18 @@ func TestGoodputFinalSample(t *testing.T) {
 		}
 
 		scheme := runtime.NewScheme()
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 
-		m := &burninv1alpha1.GoodputMeasurement{
+		m := &crev1alpha1.GoodputMeasurement{
 			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
-			Spec: burninv1alpha1.GoodputMeasurementSpec{
+			Spec: crev1alpha1.GoodputMeasurementSpec{
 				JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 				LogProfileRef: "does-not-resolve",
 			},
 		}
-		job := &burninv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		job := &crev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).
 			WithObjects(m, job).WithStatusSubresource(m, job).Build()

--- a/pkg/controller/goodputmeasurement_controller.go
+++ b/pkg/controller/goodputmeasurement_controller.go
@@ -20,11 +20,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/goodput"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/numstr"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/goodput"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/numstr"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podutil"
 )
 
 const (
@@ -84,7 +84,7 @@ func (r *GoodputMeasurementReconciler) getLogFetcher() podlogs.PodLogFetcher {
 func (r *GoodputMeasurementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	measurement := &burninv1alpha1.GoodputMeasurement{}
+	measurement := &crev1alpha1.GoodputMeasurement{}
 	if err := r.Get(ctx, req.NamespacedName, measurement); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("GoodputMeasurement resource not found, likely deleted")
@@ -109,7 +109,7 @@ func (r *GoodputMeasurementReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 // reconcileMeasurement watches the referenced Job and drives goodput computation.
-func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	// If no JobRef is set, nothing to measure.
@@ -119,12 +119,12 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 	}
 
 	// If measurement is already complete, nothing to do.
-	if cond := meta.FindStatusCondition(measurement.Status.Conditions, burninv1alpha1.GoodputMeasurementComplete); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(measurement.Status.Conditions, crev1alpha1.GoodputMeasurementComplete); cond != nil && cond.Status == metav1.ConditionTrue {
 		return ctrl.Result{}, nil
 	}
 
-	// Fetch the referenced burnin Job.
-	job := &burninv1alpha1.Job{}
+	// Fetch the referenced CRE Job.
+	job := &crev1alpha1.Job{}
 	jobKey := types.NamespacedName{
 		Name:      measurement.Spec.JobRef.Name,
 		Namespace: measurement.Namespace,
@@ -138,15 +138,15 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 	}
 
 	// Determine Job phase from conditions.
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
 		r.finalSample(ctx, measurement, job)
 		return r.handleSucceeded(ctx, measurement, job)
 	}
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobFailed); cond != nil && cond.Status == metav1.ConditionTrue {
 		r.finalSample(ctx, measurement, job)
 		return r.handleFailed(ctx, measurement, job)
 	}
-	if cond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobInProgress); cond != nil && cond.Status == metav1.ConditionTrue {
 		return r.handleRunning(ctx, measurement, job)
 	}
 
@@ -167,7 +167,7 @@ func (r *GoodputMeasurementReconciler) reconcileMeasurement(ctx context.Context,
 // read, and would usually skip this one, so the sample time is cleared first.
 // Best effort: a failure here leaves the previous status in place, which is
 // what would have happened anyway.
-func (r *GoodputMeasurementReconciler) finalSample(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, job *burninv1alpha1.Job) {
+func (r *GoodputMeasurementReconciler) finalSample(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) {
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
 	r.mu.Lock()
@@ -181,7 +181,7 @@ func (r *GoodputMeasurementReconciler) finalSample(ctx context.Context, measurem
 }
 
 // handleRunning processes a running job: reads logs, parses them, computes goodput.
-func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, job *burninv1alpha1.Job) (ctrl.Result, error) { //nolint:gocyclo
+func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) { //nolint:gocyclo
 	log := logf.FromContext(ctx)
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 	interval := r.getSampleInterval(measurement)
@@ -478,7 +478,7 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 		measurement.Status.StartTime = &now
 	}
 	meta.SetStatusCondition(&measurement.Status.Conditions, metav1.Condition{
-		Type:               burninv1alpha1.GoodputMeasurementMeasuring,
+		Type:               crev1alpha1.GoodputMeasurementMeasuring,
 		Status:             metav1.ConditionTrue,
 		Reason:             "JobRunning",
 		Message:            "Referenced Job is running, measurement in progress",
@@ -576,7 +576,7 @@ func (r *GoodputMeasurementReconciler) handleRunning(ctx context.Context, measur
 }
 
 // handleSucceeded processes a succeeded job.
-func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
@@ -629,7 +629,7 @@ func (r *GoodputMeasurementReconciler) handleSucceeded(ctx context.Context, meas
 }
 
 // handleFailed processes a failed job by recording an interruption event.
-func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) handleFailed(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, job *crev1alpha1.Job) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	key := fmt.Sprintf("%s/%s", measurement.Namespace, measurement.Name)
 
@@ -772,7 +772,7 @@ func (r *GoodputMeasurementReconciler) completeInterruption(state *goodput.JobSt
 // interruption to Status so it survives controller restarts.
 //
 // The caller must hold state's lock.
-func (r *GoodputMeasurementReconciler) recordInterruptionFromRestart(ctx context.Context, state *goodput.JobState, measurement *burninv1alpha1.GoodputMeasurement, workflow string) {
+func (r *GoodputMeasurementReconciler) recordInterruptionFromRestart(ctx context.Context, state *goodput.JobState, measurement *crev1alpha1.GoodputMeasurement, workflow string) {
 	log := logf.FromContext(ctx)
 
 	interruptTime := state.ApplicationStopTime
@@ -817,8 +817,8 @@ func (r *GoodputMeasurementReconciler) recordInterruptionFromRestart(ctx context
 }
 
 // getLogProfile fetches a cluster-scoped LogProfile by name.
-func (r *GoodputMeasurementReconciler) getLogProfile(ctx context.Context, name string) (*burninv1alpha1.LogProfile, error) {
-	profile := &burninv1alpha1.LogProfile{}
+func (r *GoodputMeasurementReconciler) getLogProfile(ctx context.Context, name string) (*crev1alpha1.LogProfile, error) {
+	profile := &crev1alpha1.LogProfile{}
 	if err := r.Get(ctx, types.NamespacedName{Name: name}, profile); err != nil {
 		return nil, fmt.Errorf("failed to get LogProfile %s: %w", name, err)
 	}
@@ -830,7 +830,7 @@ func (r *GoodputMeasurementReconciler) getLogProfile(ctx context.Context, name s
 // The cache is keyed by LogProfile name but validated against its resourceVersion,
 // so editing a LogProfile's patterns takes effect on the next reconcile rather
 // than requiring a controller restart. Only one entry per profile is retained.
-func (r *GoodputMeasurementReconciler) getOrCreateParser(profile *burninv1alpha1.LogProfile) (*goodput.ProfileParser, error) {
+func (r *GoodputMeasurementReconciler) getOrCreateParser(profile *crev1alpha1.LogProfile) (*goodput.ProfileParser, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -856,7 +856,7 @@ func (r *GoodputMeasurementReconciler) getOrCreateParser(profile *burninv1alpha1
 // getOrCreateState returns the in-memory job state, creating it if needed.
 // When creating a new state, it recovers from the measurement's persisted Status
 // so that state survives controller restarts.
-func (r *GoodputMeasurementReconciler) getOrCreateState(key string, measurement *burninv1alpha1.GoodputMeasurement) *goodput.JobState {
+func (r *GoodputMeasurementReconciler) getOrCreateState(key string, measurement *crev1alpha1.GoodputMeasurement) *goodput.JobState {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -943,7 +943,7 @@ func (r *GoodputMeasurementReconciler) cleanupState(key string) {
 }
 
 // buildCumulativeFromStatus reconstructs CumulativeMetrics from the measurement status.
-func (r *GoodputMeasurementReconciler) buildCumulativeFromStatus(measurement *burninv1alpha1.GoodputMeasurement) *goodput.CumulativeMetrics {
+func (r *GoodputMeasurementReconciler) buildCumulativeFromStatus(measurement *crev1alpha1.GoodputMeasurement) *goodput.CumulativeMetrics {
 	cm := goodput.NewCumulativeMetrics()
 
 	cm.CurrentStep = measurement.Status.CurrentStep
@@ -983,7 +983,7 @@ func (r *GoodputMeasurementReconciler) buildCumulativeFromStatus(measurement *bu
 }
 
 // writeStatusFromCumulative writes CumulativeMetrics back to the measurement status.
-func (r *GoodputMeasurementReconciler) writeStatusFromCumulative(measurement *burninv1alpha1.GoodputMeasurement, cm *goodput.CumulativeMetrics) {
+func (r *GoodputMeasurementReconciler) writeStatusFromCumulative(measurement *crev1alpha1.GoodputMeasurement, cm *goodput.CumulativeMetrics) {
 	measurement.Status.Result = formatFloat(cm.Goodput)
 	measurement.Status.CurrentStep = cm.CurrentStep
 	measurement.Status.HighestStep = cm.HighestStep
@@ -998,7 +998,7 @@ func (r *GoodputMeasurementReconciler) writeStatusFromCumulative(measurement *bu
 	// Persist pending interruption so it survives controller restarts.
 	if cm.PendingInterruption != nil {
 		pi := cm.PendingInterruption
-		pending := &burninv1alpha1.PendingInterruptionStatus{
+		pending := &crev1alpha1.PendingInterruptionStatus{
 			CheckpointStep: pi.CheckpointStep,
 			LastStep:       pi.LastStep,
 			TCh:            formatFloat(pi.TCh),
@@ -1022,11 +1022,11 @@ func (r *GoodputMeasurementReconciler) writeStatusFromCumulative(measurement *bu
 // measurement, so the cause is visible in status and not only in the controller
 // log. This is deliberately not terminal: a cluster-scoped LogProfile can be
 // created after the run starts, and the next sample picks it up.
-func (r *GoodputMeasurementReconciler) noteLogProfileUnresolved(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, cause error) {
+func (r *GoodputMeasurementReconciler) noteLogProfileUnresolved(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, cause error) {
 	message := fmt.Sprintf("LogProfile %q could not be resolved: %v", measurement.Spec.LogProfileRef, cause)
-	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *burninv1alpha1.GoodputMeasurement) bool {
+	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *crev1alpha1.GoodputMeasurement) bool {
 		return meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.GoodputMeasurementMeasuring,
+			Type:               crev1alpha1.GoodputMeasurementMeasuring,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: m.Generation,
 			Reason:             reasonGoodputLogProfileMissing,
@@ -1039,27 +1039,27 @@ func (r *GoodputMeasurementReconciler) noteLogProfileUnresolved(ctx context.Cont
 }
 
 // setComplete sets the Complete condition, records CompletionTime, and stores the result.
-func (r *GoodputMeasurementReconciler) setComplete(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement, reason, message string) error {
+func (r *GoodputMeasurementReconciler) setComplete(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement, reason, message string) error {
 	// The computed status payload is carried over on retry: a conflicting write
 	// only means the object moved on, not that this measurement's result changed.
 	status := measurement.Status.DeepCopy()
 	now := metav1.Now()
 
-	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *burninv1alpha1.GoodputMeasurement) bool {
+	err := updateStatusWithRetry(ctx, r.Client, measurement, func(m *crev1alpha1.GoodputMeasurement) bool {
 		conditions := m.Status.Conditions
 		status.DeepCopyInto(&m.Status)
 		m.Status.Conditions = conditions
 		m.Status.CompletionTime = &now
 
 		meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.GoodputMeasurementComplete,
+			Type:               crev1alpha1.GoodputMeasurementComplete,
 			Status:             metav1.ConditionTrue,
 			Reason:             reason,
 			Message:            message,
 			ObservedGeneration: m.Generation,
 		})
 		meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.GoodputMeasurementMeasuring,
+			Type:               crev1alpha1.GoodputMeasurementMeasuring,
 			Status:             metav1.ConditionFalse,
 			Reason:             reason,
 			Message:            "Measurement completed",
@@ -1077,7 +1077,7 @@ func (r *GoodputMeasurementReconciler) setComplete(ctx context.Context, measurem
 }
 
 // handleDeletion handles the cleanup when a GoodputMeasurement is being deleted.
-func (r *GoodputMeasurementReconciler) handleDeletion(ctx context.Context, measurement *burninv1alpha1.GoodputMeasurement) (ctrl.Result, error) {
+func (r *GoodputMeasurementReconciler) handleDeletion(ctx context.Context, measurement *crev1alpha1.GoodputMeasurement) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(measurement, goodputMeasurementFinalizer) {
@@ -1090,7 +1090,7 @@ func (r *GoodputMeasurementReconciler) handleDeletion(ctx context.Context, measu
 	// Fetch the Job to read the workflow label for metric cleanup.
 	var workflow string
 	if measurement.Spec.JobRef.Name != "" {
-		job := &burninv1alpha1.Job{}
+		job := &crev1alpha1.Job{}
 		jobKey := types.NamespacedName{Name: measurement.Spec.JobRef.Name, Namespace: measurement.Namespace}
 		if err := r.Get(ctx, jobKey, job); err == nil {
 			workflow = job.Labels["cre.nvidia.com/workflow"]
@@ -1107,7 +1107,7 @@ func (r *GoodputMeasurementReconciler) handleDeletion(ctx context.Context, measu
 }
 
 // getSampleInterval returns the configured sample interval or the default.
-func (r *GoodputMeasurementReconciler) getSampleInterval(measurement *burninv1alpha1.GoodputMeasurement) time.Duration {
+func (r *GoodputMeasurementReconciler) getSampleInterval(measurement *crev1alpha1.GoodputMeasurement) time.Duration {
 	if measurement.Spec.SampleInterval != nil {
 		return measurement.Spec.SampleInterval.Duration
 	}
@@ -1115,7 +1115,7 @@ func (r *GoodputMeasurementReconciler) getSampleInterval(measurement *burninv1al
 }
 
 // getWorkerStrategy returns the worker strategy type from the profile.
-func getWorkerStrategy(profile *burninv1alpha1.LogProfile) string {
+func getWorkerStrategy(profile *crev1alpha1.LogProfile) string {
 	if profile.Spec.WorkerStrategy != nil {
 		return profile.Spec.WorkerStrategy.Type
 	}
@@ -1237,7 +1237,7 @@ func formatFloat(f float64) string {
 // SetupWithManager sets up the controller with the Manager.
 func (r *GoodputMeasurementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.GoodputMeasurement{}).
+		For(&crev1alpha1.GoodputMeasurement{}).
 		Named("goodputmeasurement").
 		Complete(r)
 }

--- a/pkg/controller/goodputmeasurement_controller_test.go
+++ b/pkg/controller/goodputmeasurement_controller_test.go
@@ -7,10 +7,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/goodput"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/goodput"
 )
 
 func TestComputeAvgTFLOPS(t *testing.T) {

--- a/pkg/controller/gpu_arch_exclusion_test.go
+++ b/pkg/controller/gpu_arch_exclusion_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // A certification reports PASSED after excluding nodes whose GPU architecture

--- a/pkg/controller/group_completion_persist_test.go
+++ b/pkg/controller/group_completion_persist_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // A group whose Job has gone terminal must have its phase written to the
@@ -41,57 +41,57 @@ func TestGroupCompletionPersists(t *testing.T) {
 		}
 
 		scheme := runtime.NewScheme()
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 
-		groups := make([]burninv1alpha1.GroupStatus, 0, in.Groups)
-		jobs := make([]*burninv1alpha1.Job, 0, in.Groups)
+		groups := make([]crev1alpha1.GroupStatus, 0, in.Groups)
+		jobs := make([]*crev1alpha1.Job, 0, in.Groups)
 		for i := 0; i < in.Groups; i++ {
 			name := []string{"g0", "g1", "g2"}[i]
-			job := &burninv1alpha1.Job{
+			job := &crev1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: name + "-job", Namespace: "ns"},
-				Status: burninv1alpha1.JobStatus{Conditions: []metav1.Condition{{
+				Status: crev1alpha1.JobStatus{Conditions: []metav1.Condition{{
 					Type: in.JobCondition, Status: metav1.ConditionTrue,
 					Reason: "WorkloadCompleted", LastTransitionTime: metav1.Now(),
 				}}},
 			}
 			jobs = append(jobs, job)
-			groups = append(groups, burninv1alpha1.GroupStatus{
+			groups = append(groups, crev1alpha1.GroupStatus{
 				Name:   name,
-				Phase:  burninv1alpha1.GroupRunning,
+				Phase:  crev1alpha1.GroupRunning,
 				Nodes:  []string{"node" + name},
-				JobRef: &burninv1alpha1.WorkloadReference{Name: name + "-job", Namespace: "ns"},
+				JobRef: &crev1alpha1.WorkloadReference{Name: name + "-job", Namespace: "ns"},
 			})
 		}
 
-		wf := &burninv1alpha1.Workflow{
+		wf := &crev1alpha1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "ns", Generation: 1},
-			Spec: burninv1alpha1.WorkflowSpec{
-				Orchestration: burninv1alpha1.OrchestrationSpec{Iterations: 1},
+			Spec: crev1alpha1.WorkflowSpec{
+				Orchestration: crev1alpha1.OrchestrationSpec{Iterations: 1},
 			},
-			Status: burninv1alpha1.WorkflowStatus{
+			Status: crev1alpha1.WorkflowStatus{
 				// Seed every condition exactly as the reconcile will recompute them,
 				// ObservedGeneration included. Without that the condition write
 				// reports a change for an unrelated reason and masks the bug.
 				Conditions: []metav1.Condition{
 					{
-						Type: burninv1alpha1.WorkflowInProgress, Status: metav1.ConditionTrue,
+						Type: crev1alpha1.WorkflowInProgress, Status: metav1.ConditionTrue,
 						Reason: ReasonJobRunning, Message: in.PreexistingConditionMessage,
 						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
 					},
 					{
-						Type: burninv1alpha1.WorkflowSucceeded, Status: metav1.ConditionFalse,
+						Type: crev1alpha1.WorkflowSucceeded, Status: metav1.ConditionFalse,
 						Reason: ReasonNotApplicable, Message: "",
 						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
 					},
 					{
-						Type: burninv1alpha1.WorkflowFailed, Status: metav1.ConditionFalse,
+						Type: crev1alpha1.WorkflowFailed, Status: metav1.ConditionFalse,
 						Reason: ReasonNotApplicable, Message: "",
 						ObservedGeneration: 1, LastTransitionTime: metav1.Now(),
 					},
 				},
-				Orchestration: &burninv1alpha1.OrchestrationStatus{
+				Orchestration: &crev1alpha1.OrchestrationStatus{
 					CurrentIteration: 1,
 					Groups:           groups,
 				},
@@ -109,7 +109,7 @@ func TestGroupCompletionPersists(t *testing.T) {
 			return err
 		}
 
-		got := &burninv1alpha1.Workflow{}
+		got := &crev1alpha1.Workflow{}
 		if err := c.Get(context.Background(), types.NamespacedName{Name: "wf", Namespace: "ns"}, got); err != nil {
 			return err
 		}

--- a/pkg/controller/indexes.go
+++ b/pkg/controller/indexes.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nodemonitor"
 )
 
 // Field index names. Reads that filter on these fields must use
@@ -75,9 +75,9 @@ func RegisterFieldIndexes(ctx context.Context, indexer client.FieldIndexer) erro
 		return fmt.Errorf("registering PersistentVolume claimRef index: %w", err)
 	}
 
-	if err := indexer.IndexField(ctx, &burninv1alpha1.GoodputMeasurement{}, measurementJobRefIndexField,
+	if err := indexer.IndexField(ctx, &crev1alpha1.GoodputMeasurement{}, measurementJobRefIndexField,
 		func(obj client.Object) []string {
-			m, ok := obj.(*burninv1alpha1.GoodputMeasurement)
+			m, ok := obj.(*crev1alpha1.GoodputMeasurement)
 			if !ok || m.Spec.JobRef.Name == "" {
 				return nil
 			}
@@ -86,9 +86,9 @@ func RegisterFieldIndexes(ctx context.Context, indexer client.FieldIndexer) erro
 		return fmt.Errorf("registering GoodputMeasurement jobRef index: %w", err)
 	}
 
-	if err := indexer.IndexField(ctx, &burninv1alpha1.BandwidthMeasurement{}, measurementJobRefIndexField,
+	if err := indexer.IndexField(ctx, &crev1alpha1.BandwidthMeasurement{}, measurementJobRefIndexField,
 		func(obj client.Object) []string {
-			m, ok := obj.(*burninv1alpha1.BandwidthMeasurement)
+			m, ok := obj.(*crev1alpha1.BandwidthMeasurement)
 			if !ok || m.Spec.JobRef.Name == "" {
 				return nil
 			}

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -31,14 +31,14 @@ import (
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor/cel"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/naming"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nodemonitor"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nodemonitor/cel"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/threshold"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workload"
 )
 
 const (
@@ -104,7 +104,7 @@ func (r *JobReconciler) getWorkloadRequeueInterval() time.Duration {
 
 // getMeasurementTimeout returns the effective timeout for waiting on measurement data
 // after a Job has succeeded. Priority: Job.Spec > reconciler field > default (5m).
-func (r *JobReconciler) getMeasurementTimeout(job *burninv1alpha1.Job) time.Duration {
+func (r *JobReconciler) getMeasurementTimeout(job *crev1alpha1.Job) time.Duration {
 	if job.Spec.MeasurementTimeout != nil && job.Spec.MeasurementTimeout.Duration > 0 {
 		return job.Spec.MeasurementTimeout.Duration
 	}
@@ -132,7 +132,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	log.V(1).Info("Starting reconciliation")
 
 	// Fetch the Job instance
-	job := &burninv1alpha1.Job{}
+	job := &crev1alpha1.Job{}
 	if err := r.Get(ctx, req.NamespacedName, job); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Job resource not found, likely deleted")
@@ -199,7 +199,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 // handleDeletion handles the cleanup when a Job is being deleted
-func (r *JobReconciler) handleDeletion(ctx context.Context, job *burninv1alpha1.Job) (ctrl.Result, error) { //nolint:unparam
+func (r *JobReconciler) handleDeletion(ctx context.Context, job *crev1alpha1.Job) (ctrl.Result, error) { //nolint:unparam
 	log := logf.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(job, jobFinalizer) {
@@ -230,7 +230,7 @@ func (r *JobReconciler) handleDeletion(ctx context.Context, job *burninv1alpha1.
 
 // deleteWorkloadByRef deletes the workload referenced by the Job's status.
 // Returns nil if the workload is already gone or the adapter cannot be resolved.
-func (r *JobReconciler) deleteWorkloadByRef(ctx context.Context, job *burninv1alpha1.Job) error {
+func (r *JobReconciler) deleteWorkloadByRef(ctx context.Context, job *crev1alpha1.Job) error {
 	ref := job.Status.WorkloadRef
 	if ref == nil {
 		return nil
@@ -261,7 +261,7 @@ func (r *JobReconciler) deleteWorkloadByRef(ctx context.Context, job *burninv1al
 }
 
 // reconcileWorkload ensures the workload exists and is up to date
-func (r *JobReconciler) reconcileWorkload(ctx context.Context, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *JobReconciler) reconcileWorkload(ctx context.Context, job *crev1alpha1.Job) (ctrl.Result, error) {
 	// If the Job is already in a terminal state, preserve the workload and
 	// its pods for log inspection (both success and failure). Cleanup
 	// happens via owner reference cascade when the Certification is deleted.
@@ -299,7 +299,7 @@ func (r *JobReconciler) reconcileWorkload(ctx context.Context, job *burninv1alph
 }
 
 // createWorkloadFromSpec creates a new workload resource from the Job's inline workload spec.
-func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *crev1alpha1.Job) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	adapter, err := workload.ForSpec(&job.Spec.Workload)
@@ -311,7 +311,7 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *burninv
 		return ctrl.Result{}, fmt.Errorf("failed to resolve workload adapter: %w", err)
 	}
 
-	// Deep-copy the spec and inject the burnin pod label automatically
+	// Deep-copy the spec and inject the CRE pod label automatically
 	specCopy := job.Spec.Workload.DeepCopy()
 	adapter.InjectPodLabel(specCopy, "cre.nvidia.com/job", job.Name)
 
@@ -356,7 +356,7 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *burninv
 	log.Info("Workload created successfully", "kind", gvk.Kind, "name", workloadName)
 
 	// Store workload reference in status
-	job.Status.WorkloadRef = &burninv1alpha1.WorkloadReference{
+	job.Status.WorkloadRef = &crev1alpha1.WorkloadReference{
 		APIVersion: gvk.GroupVersion().String(),
 		Kind:       gvk.Kind,
 		Name:       workloadName,
@@ -373,7 +373,7 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *burninv
 }
 
 // updateStatusFromWorkload updates the Job status based on the workload status conditions
-func (r *JobReconciler) updateStatusFromWorkload(ctx context.Context, job *burninv1alpha1.Job) (ctrl.Result, error) {
+func (r *JobReconciler) updateStatusFromWorkload(ctx context.Context, job *crev1alpha1.Job) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	ref := job.Status.WorkloadRef
 
@@ -467,7 +467,7 @@ func (r *JobReconciler) updateStatusFromWorkload(ctx context.Context, job *burni
 
 // shouldRestart checks whether a failed Job should be restarted from checkpoint.
 // It returns true only if the Job has a Checkpoint config, restarts remain, and a checkpoint exists.
-func (r *JobReconciler) shouldRestart(ctx context.Context, job *burninv1alpha1.Job) bool {
+func (r *JobReconciler) shouldRestart(ctx context.Context, job *crev1alpha1.Job) bool {
 	if job.Spec.Checkpoint == nil {
 		return false
 	}
@@ -483,9 +483,9 @@ func (r *JobReconciler) shouldRestart(ctx context.Context, job *burninv1alpha1.J
 
 // hasCheckpoint returns true if there is a GoodputMeasurement for this Job that has recorded
 // at least one checkpoint step (LastCheckpointStep > 0).
-func (r *JobReconciler) hasCheckpoint(ctx context.Context, job *burninv1alpha1.Job) bool {
+func (r *JobReconciler) hasCheckpoint(ctx context.Context, job *crev1alpha1.Job) bool {
 	log := logf.FromContext(ctx)
-	var measurements burninv1alpha1.GoodputMeasurementList
+	var measurements crev1alpha1.GoodputMeasurementList
 	if err := r.List(ctx, &measurements, matchingJobRef(job.Namespace, job.Name)...); err != nil {
 		log.Error(err, "Failed to list GoodputMeasurements")
 		return false
@@ -513,7 +513,7 @@ func (r *JobReconciler) hasCheckpoint(ctx context.Context, job *burninv1alpha1.J
 // for log parsing lag: LastStepTimestamp reflects the last step the GM parsed,
 // not the last step the workload produced. Without this buffer, the stall
 // detector fires false positives when the GM hasn't read logs recently.
-func (r *JobReconciler) checkStallTimeout(ctx context.Context, job *burninv1alpha1.Job) (bool, string) {
+func (r *JobReconciler) checkStallTimeout(ctx context.Context, job *crev1alpha1.Job) (bool, string) {
 	if job.Spec.StallMultiplier == nil {
 		return false, ""
 	}
@@ -603,7 +603,7 @@ func parseStallFloat(s string) float64 {
 
 // maxBusBandwidth returns the maximum bus bandwidth across all message sizes in the results.
 // Returns 0 if no results are present.
-func maxBusBandwidth(results []burninv1alpha1.BandwidthResult) float64 {
+func maxBusBandwidth(results []crev1alpha1.BandwidthResult) float64 {
 	var max float64
 	for _, r := range results {
 		bw := parseStallFloat(r.BusBW)
@@ -619,7 +619,7 @@ func maxBusBandwidth(results []burninv1alpha1.BandwidthResult) float64 {
 // collected from BandwidthMeasurement and GoodputMeasurement status fields.
 // If any threshold is violated, the ValidationFailed condition is set on the Job.
 // Returns true if measurements are pending and the caller should requeue.
-func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *burninv1alpha1.Job) bool {
+func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *crev1alpha1.Job) bool {
 	if len(job.Spec.Thresholds) == 0 {
 		return false
 	}
@@ -659,8 +659,8 @@ func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *bur
 
 // measurementTimedOut returns true if the Job has been in Succeeded state longer
 // than the measurement timeout, meaning we've waited long enough for data.
-func (r *JobReconciler) measurementTimedOut(job *burninv1alpha1.Job) bool {
-	succeededCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded)
+func (r *JobReconciler) measurementTimedOut(job *crev1alpha1.Job) bool {
+	succeededCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded)
 	if succeededCond == nil || succeededCond.Status != metav1.ConditionTrue {
 		return false
 	}
@@ -668,7 +668,7 @@ func (r *JobReconciler) measurementTimedOut(job *burninv1alpha1.Job) bool {
 }
 
 // maxAlgBandwidth returns the maximum algorithm bandwidth across all message sizes.
-func maxAlgBandwidth(results []burninv1alpha1.BandwidthResult) float64 {
+func maxAlgBandwidth(results []crev1alpha1.BandwidthResult) float64 {
 	var m float64
 	for _, r := range results {
 		bw := parseStallFloat(r.AlgBW)
@@ -681,14 +681,14 @@ func maxAlgBandwidth(results []burninv1alpha1.BandwidthResult) float64 {
 
 // setJobValidationFailed sets the ValidationFailed condition independently of execution state.
 // This mirrors setJobHardwareFailed — the condition is additive, not exclusive.
-func (r *JobReconciler) setJobValidationStatus(ctx context.Context, job *burninv1alpha1.Job, status metav1.ConditionStatus, reason, message string) error {
+func (r *JobReconciler) setJobValidationStatus(ctx context.Context, job *crev1alpha1.Job, status metav1.ConditionStatus, reason, message string) error {
 	changed := false
-	err := updateStatusWithRetry(ctx, r.Client, job, func(j *burninv1alpha1.Job) bool {
+	err := updateStatusWithRetry(ctx, r.Client, job, func(j *crev1alpha1.Job) bool {
 		if status == metav1.ConditionTrue && len(j.Status.FailedNodes) == 0 {
 			j.Status.FailedNodes = noderesults.NodesWithFailureDetails(groupNodeNames(j), ReasonThresholdViolation, message)
 		}
 		c := meta.SetStatusCondition(&j.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.JobValidationFailed,
+			Type:               crev1alpha1.JobValidationFailed,
 			Status:             status,
 			Reason:             reason,
 			Message:            message,
@@ -709,7 +709,7 @@ func (r *JobReconciler) setJobValidationStatus(ctx context.Context, job *burninv
 // restartFromCheckpoint deletes the failed workload, increments the restart count,
 // clears the workload reference, and requeues so that reconcileWorkload() will
 // create a fresh workload from spec on the next loop.
-func (r *JobReconciler) restartFromCheckpoint(ctx context.Context, job *burninv1alpha1.Job, ref *burninv1alpha1.WorkloadReference, adapter workload.Adapter) (ctrl.Result, error) {
+func (r *JobReconciler) restartFromCheckpoint(ctx context.Context, job *crev1alpha1.Job, ref *crev1alpha1.WorkloadReference, adapter workload.Adapter) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	// Delete the failed workload
@@ -770,13 +770,13 @@ func (r *JobReconciler) restartFromCheckpoint(ctx context.Context, job *burninv1
 }
 
 // setJobInProgress sets the Job status to InProgress
-func (r *JobReconciler) setJobInProgress(ctx context.Context, job *burninv1alpha1.Job, reason, message string) error {
-	return r.setExclusiveCondition(ctx, job, burninv1alpha1.JobInProgress, reason, message)
+func (r *JobReconciler) setJobInProgress(ctx context.Context, job *crev1alpha1.Job, reason, message string) error {
+	return r.setExclusiveCondition(ctx, job, crev1alpha1.JobInProgress, reason, message)
 }
 
 // setJobSucceeded sets the Job status to Succeeded
-func (r *JobReconciler) setJobSucceeded(ctx context.Context, job *burninv1alpha1.Job, reason, message string) error {
-	return r.setExclusiveCondition(ctx, job, burninv1alpha1.JobSucceeded, reason, message)
+func (r *JobReconciler) setJobSucceeded(ctx context.Context, job *crev1alpha1.Job, reason, message string) error {
+	return r.setExclusiveCondition(ctx, job, crev1alpha1.JobSucceeded, reason, message)
 }
 
 // setJobFailed sets the Job status to Failed and captures failure logs.
@@ -786,16 +786,16 @@ func (r *JobReconciler) setJobSucceeded(ctx context.Context, job *burninv1alpha1
 // on a 409 conflict the retry re-applies them to the freshly-fetched object.
 // Setting them on the stale object before the closure would cause them to be
 // silently discarded whenever the API server returns a conflict.
-func (r *JobReconciler) setJobFailed(ctx context.Context, job *burninv1alpha1.Job, reason, message string) error {
+func (r *JobReconciler) setJobFailed(ctx context.Context, job *crev1alpha1.Job, reason, message string) error {
 	changed, err := setExclusiveStatusCondition(ctx, r.Client, job,
-		func(j *burninv1alpha1.Job) *[]metav1.Condition { return &j.Status.Conditions },
+		func(j *crev1alpha1.Job) *[]metav1.Condition { return &j.Status.Conditions },
 		[]string{
-			burninv1alpha1.JobInProgress,
-			burninv1alpha1.JobSucceeded,
-			burninv1alpha1.JobFailed,
+			crev1alpha1.JobInProgress,
+			crev1alpha1.JobSucceeded,
+			crev1alpha1.JobFailed,
 		},
-		burninv1alpha1.JobFailed, reason, message,
-		func(j *burninv1alpha1.Job) bool {
+		crev1alpha1.JobFailed, reason, message,
+		func(j *crev1alpha1.Job) bool {
 			c := false
 			if j.Status.FailureLog == nil {
 				r.captureFailureLog(ctx, j)
@@ -813,7 +813,7 @@ func (r *JobReconciler) setJobFailed(ctx context.Context, job *burninv1alpha1.Jo
 	}
 	if changed {
 		recordJobStatus(job.Namespace, job.Name, job.Labels["cre.nvidia.com/workflow"], "failed")
-		logf.FromContext(ctx).Info("Job status updated", "status", burninv1alpha1.JobFailed, "reason", reason)
+		logf.FromContext(ctx).Info("Job status updated", "status", crev1alpha1.JobFailed, "reason", reason)
 	}
 	return nil
 }
@@ -859,7 +859,7 @@ func readLogTail(r io.Reader, max int) (string, error) {
 
 // captureFailureLog finds the pod that caused the failure and stores its last
 // N log lines in job.Status.FailureLog. Best-effort: errors are logged, not returned.
-func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alpha1.Job) {
+func (r *JobReconciler) captureFailureLog(ctx context.Context, job *crev1alpha1.Job) {
 	log := logf.FromContext(ctx)
 	if r.Clientset == nil {
 		return
@@ -903,12 +903,12 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 			reason = "PodNotFound"
 			tail = "no pods for this Job were found when the failure was recorded; the pod was most likely deleted before its logs could be read"
 		}
-		job.Status.FailureLog = &burninv1alpha1.FailureLog{Reason: reason, Tail: tail}
+		job.Status.FailureLog = &crev1alpha1.FailureLog{Reason: reason, Tail: tail}
 		log.Info("No failed pod available for failure log capture", "reason", reason)
 		return
 	}
 
-	fl := &burninv1alpha1.FailureLog{
+	fl := &crev1alpha1.FailureLog{
 		PodName:  failedPod.Name,
 		NodeName: failedPod.Spec.NodeName,
 		ExitCode: failedContainer.State.Terminated.ExitCode,
@@ -942,21 +942,21 @@ func (r *JobReconciler) captureFailureLog(ctx context.Context, job *burninv1alph
 
 // setJobHardwareFailed sets the HardwareFailed condition and records the failed nodes.
 // This condition is independent of job execution state (InProgress/Succeeded/Failed).
-func (r *JobReconciler) setJobHardwareFailed(ctx context.Context, job *burninv1alpha1.Job, reason, message string, failedNodes []burninv1alpha1.FailedNode) error {
+func (r *JobReconciler) setJobHardwareFailed(ctx context.Context, job *crev1alpha1.Job, reason, message string, failedNodes []crev1alpha1.FailedNode) error {
 	log := logf.FromContext(ctx)
 
 	// Whether this is the first hardware failure is evaluated against the state
 	// this attempt observed, so it is recomputed inside the retry rather than
 	// captured from a possibly-stale read.
 	var isFirstFailure, changed bool
-	err := updateStatusWithRetry(ctx, r.Client, job, func(j *burninv1alpha1.Job) bool {
+	err := updateStatusWithRetry(ctx, r.Client, job, func(j *crev1alpha1.Job) bool {
 		isFirstFailure = len(j.Status.FailedNodes) == 0 && len(failedNodes) > 0
 		j.Status.FailedNodes = failedNodes
 
 		// Set HardwareFailed independently — it is not exclusive with the
 		// InProgress/Succeeded/Failed set.
 		c := meta.SetStatusCondition(&j.Status.Conditions, metav1.Condition{
-			Type:               burninv1alpha1.JobHardwareFailed,
+			Type:               crev1alpha1.JobHardwareFailed,
 			Status:             metav1.ConditionTrue,
 			Reason:             reason,
 			Message:            message,
@@ -987,13 +987,13 @@ func (r *JobReconciler) setJobHardwareFailed(ctx context.Context, job *burninv1a
 
 // isTerminalState checks if the job is in a terminal state (Succeeded or Failed).
 // Note: HardwareFailed is NOT a terminal state - job execution continues regardless of hardware failures.
-func (r *JobReconciler) isTerminalState(job *burninv1alpha1.Job) bool {
-	succeededCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded)
+func (r *JobReconciler) isTerminalState(job *crev1alpha1.Job) bool {
+	succeededCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded)
 	if succeededCond != nil && succeededCond.Status == metav1.ConditionTrue {
 		return true
 	}
 
-	failedCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobFailed)
+	failedCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobFailed)
 	if failedCond != nil && failedCond.Status == metav1.ConditionTrue {
 		return true
 	}
@@ -1004,7 +1004,7 @@ func (r *JobReconciler) isTerminalState(job *burninv1alpha1.Job) bool {
 // checkNodeHealth evaluates node health for the job using the configured detector.
 // Node health evaluation is parallelized for performance with large node counts.
 // The failed nodes list is additive - nodes that recover are NOT removed from the list.
-func (r *JobReconciler) checkNodeHealth(ctx context.Context, job *burninv1alpha1.Job) (ctrl.Result, error) { //nolint:unparam
+func (r *JobReconciler) checkNodeHealth(ctx context.Context, job *crev1alpha1.Job) (ctrl.Result, error) { //nolint:unparam
 	startTime := time.Now()
 	log := logf.FromContext(ctx)
 
@@ -1137,7 +1137,7 @@ func (r *JobReconciler) checkNodeHealth(ctx context.Context, job *burninv1alpha1
 // (nodes are never removed from the list). Returns the merged list and a boolean
 // indicating whether any new (name, reason) attribution was added — so a new
 // reason for an already-listed node still counts as a new failure.
-func mergeFailedNodes(existing []burninv1alpha1.FailedNode, newNames []string, reason burninv1alpha1.NodeFailureReason, message string) ([]burninv1alpha1.FailedNode, bool) {
+func mergeFailedNodes(existing []crev1alpha1.FailedNode, newNames []string, reason crev1alpha1.NodeFailureReason, message string) ([]crev1alpha1.FailedNode, bool) {
 	existingSet := make(map[[2]string]struct{}, len(existing))
 	for _, fn := range existing {
 		existingSet[[2]string{fn.Name, string(fn.Reason)}] = struct{}{}
@@ -1159,7 +1159,7 @@ func mergeFailedNodes(existing []burninv1alpha1.FailedNode, newNames []string, r
 
 // groupNodeNames reads the group-nodes Job annotation and returns the deduped,
 // sorted node names.
-func groupNodeNames(job *burninv1alpha1.Job) []string {
+func groupNodeNames(job *crev1alpha1.Job) []string {
 	raw := job.Annotations["cre.nvidia.com/group-nodes"]
 	if raw == "" {
 		return nil
@@ -1185,15 +1185,15 @@ func groupNodeNames(job *burninv1alpha1.Job) []string {
 // setExclusiveCondition sets a job execution condition to True and all other execution conditions to False.
 // This ensures only one of InProgress/Succeeded/Failed is True at any given time.
 // Note: HardwareFailed is NOT part of this exclusive set - it's independent.
-func (r *JobReconciler) setExclusiveCondition(ctx context.Context, job *burninv1alpha1.Job, conditionType, reason, message string) error {
+func (r *JobReconciler) setExclusiveCondition(ctx context.Context, job *crev1alpha1.Job, conditionType, reason, message string) error {
 	// Only job execution states are mutually exclusive; HardwareFailed is set
 	// independently and must not be cleared here.
 	changed, err := setExclusiveStatusCondition(ctx, r.Client, job,
-		func(j *burninv1alpha1.Job) *[]metav1.Condition { return &j.Status.Conditions },
+		func(j *crev1alpha1.Job) *[]metav1.Condition { return &j.Status.Conditions },
 		[]string{
-			burninv1alpha1.JobInProgress,
-			burninv1alpha1.JobSucceeded,
-			burninv1alpha1.JobFailed,
+			crev1alpha1.JobInProgress,
+			crev1alpha1.JobSucceeded,
+			crev1alpha1.JobFailed,
 		},
 		conditionType, reason, message,
 	)
@@ -1205,11 +1205,11 @@ func (r *JobReconciler) setExclusiveCondition(ctx context.Context, job *burninv1
 		// Record job status metric
 		var metricStatus string
 		switch conditionType {
-		case burninv1alpha1.JobInProgress:
+		case crev1alpha1.JobInProgress:
 			metricStatus = "in_progress"
-		case burninv1alpha1.JobSucceeded:
+		case crev1alpha1.JobSucceeded:
 			metricStatus = "succeeded"
-		case burninv1alpha1.JobFailed:
+		case crev1alpha1.JobFailed:
 			metricStatus = "failed"
 		}
 		recordJobStatus(job.Namespace, job.Name, job.Labels["cre.nvidia.com/workflow"], metricStatus)
@@ -1219,21 +1219,21 @@ func (r *JobReconciler) setExclusiveCondition(ctx context.Context, job *burninv1
 }
 
 // getWorkloadName returns the name of the workload for a given Job
-func (r *JobReconciler) getWorkloadName(job *burninv1alpha1.Job) string {
+func (r *JobReconciler) getWorkloadName(job *crev1alpha1.Job) string {
 	return naming.Truncate(job.Name+"-workload", naming.MaxWorkloadNameLen)
 }
 
 // getGoodputMeasurementName returns the name of the auto-created GoodputMeasurement for a given Job
-func (r *JobReconciler) getGoodputMeasurementName(job *burninv1alpha1.Job) string {
+func (r *JobReconciler) getGoodputMeasurementName(job *crev1alpha1.Job) string {
 	return naming.Truncate(job.Name+"-goodput", naming.MaxK8sNameLen)
 }
 
 // getOwnerWorkflow returns the parent Workflow for a Job by looking up its OwnerReference.
 // Measurements are owned by the Workflow (not the Job) so they survive iteration restarts.
-func (r *JobReconciler) getOwnerWorkflow(ctx context.Context, job *burninv1alpha1.Job) *burninv1alpha1.Workflow {
+func (r *JobReconciler) getOwnerWorkflow(ctx context.Context, job *crev1alpha1.Job) *crev1alpha1.Workflow {
 	for _, ref := range job.OwnerReferences {
 		if ref.Kind == "Workflow" {
-			wf := &burninv1alpha1.Workflow{}
+			wf := &crev1alpha1.Workflow{}
 			if err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: job.Namespace}, wf); err == nil {
 				return wf
 			}
@@ -1244,7 +1244,7 @@ func (r *JobReconciler) getOwnerWorkflow(ctx context.Context, job *burninv1alpha
 
 // ensureGoodputMeasurement creates a GoodputMeasurement child resource if the Job has
 // spec.goodputMeasurement configured and the resource doesn't already exist.
-func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *burninv1alpha1.Job) error {
+func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *crev1alpha1.Job) error {
 	if job.Spec.GoodputMeasurement == nil {
 		return nil
 	}
@@ -1253,13 +1253,13 @@ func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *burni
 	gmName := r.getGoodputMeasurementName(job)
 
 	// Check if already exists
-	existing := &burninv1alpha1.GoodputMeasurement{}
+	existing := &crev1alpha1.GoodputMeasurement{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: job.Namespace, Name: gmName}, existing); err == nil {
 		return nil // already exists
 	}
 
 	apiGroup := "cre.nvidia.com"
-	gm := &burninv1alpha1.GoodputMeasurement{
+	gm := &crev1alpha1.GoodputMeasurement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gmName,
 			Namespace: job.Namespace,
@@ -1268,7 +1268,7 @@ func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *burni
 				"cre.nvidia.com/job":           job.Name,
 			},
 		},
-		Spec: burninv1alpha1.GoodputMeasurementSpec{
+		Spec: crev1alpha1.GoodputMeasurementSpec{
 			JobRef: corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
 				Kind:     "Job",
@@ -1302,7 +1302,7 @@ func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *burni
 	return nil
 }
 
-func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *burninv1alpha1.Job) error {
+func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *crev1alpha1.Job) error {
 	if job.Spec.BandwidthMeasurement == nil {
 		return nil
 	}
@@ -1311,13 +1311,13 @@ func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *bur
 	bmName := naming.Truncate(job.Name+"-bandwidth", naming.MaxK8sNameLen)
 
 	// Check if already exists
-	existing := &burninv1alpha1.BandwidthMeasurement{}
+	existing := &crev1alpha1.BandwidthMeasurement{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: job.Namespace, Name: bmName}, existing); err == nil {
 		return nil // already exists
 	}
 
 	apiGroup := "cre.nvidia.com"
-	bm := &burninv1alpha1.BandwidthMeasurement{
+	bm := &crev1alpha1.BandwidthMeasurement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bmName,
 			Namespace: job.Namespace,
@@ -1326,7 +1326,7 @@ func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *bur
 				"cre.nvidia.com/job":           job.Name,
 			},
 		},
-		Spec: burninv1alpha1.BandwidthMeasurementSpec{
+		Spec: crev1alpha1.BandwidthMeasurementSpec{
 			JobRef: corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
 				Kind:     "Job",
@@ -1380,10 +1380,10 @@ func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	b := ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.Job{}).
+		For(&crev1alpha1.Job{}).
 		// Watch owned workload resources for status changes (event-driven reconciliation)
 		Owns(&trainerv1alpha1.TrainJob{}).
-		Owns(&burninv1alpha1.GoodputMeasurement{})
+		Owns(&crev1alpha1.GoodputMeasurement{})
 
 	return b.
 		// Watch Nodes for health changes - maps node events to jobs via pod lookups
@@ -1403,7 +1403,7 @@ func (r *JobReconciler) nodeToJobRequests(ctx context.Context, obj client.Object
 		return nil
 	}
 
-	// Find all pods running on this node that have the burnin job label.
+	// Find all pods running on this node that have the CRE job label.
 	//
 	// This runs in the watch path for every Node event in the cluster, so it must
 	// stay a keyed lookup. The index is registered unconditionally at manager

--- a/pkg/controller/job_event_test.go
+++ b/pkg/controller/job_event_test.go
@@ -8,7 +8,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // TestJobWarnfNilRecorder pins that warnf tolerates an unset Recorder.
@@ -19,7 +19,7 @@ func TestJobWarnfNilRecorder(t *testing.T) {
 	t.Parallel()
 
 	r := &JobReconciler{} // Recorder deliberately unset
-	job := &burninv1alpha1.Job{
+	job := &crev1alpha1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"},
 	}
 

--- a/pkg/controller/job_threshold_helpers.go
+++ b/pkg/controller/job_threshold_helpers.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // missingJobThresholdKeys returns threshold keys that have no corresponding measured value.
@@ -26,8 +26,8 @@ func missingJobThresholdKeys(thresholds map[string]string, measured map[string]f
 
 // findJobGoodputMeasurement returns the first GoodputMeasurement in the namespace
 // that references this Job, or nil if none exists.
-func findJobGoodputMeasurement(ctx context.Context, c client.Reader, job *burninv1alpha1.Job) *burninv1alpha1.GoodputMeasurement {
-	var measurements burninv1alpha1.GoodputMeasurementList
+func findJobGoodputMeasurement(ctx context.Context, c client.Reader, job *crev1alpha1.Job) *crev1alpha1.GoodputMeasurement {
+	var measurements crev1alpha1.GoodputMeasurementList
 	if err := c.List(ctx, &measurements, matchingJobRef(job.Namespace, job.Name)...); err != nil {
 		return nil
 	}
@@ -39,8 +39,8 @@ func findJobGoodputMeasurement(ctx context.Context, c client.Reader, job *burnin
 
 // findJobBandwidthMeasurement returns the first BandwidthMeasurement in the namespace
 // that references this Job, or nil if none exists.
-func findJobBandwidthMeasurement(ctx context.Context, c client.Reader, job *burninv1alpha1.Job) *burninv1alpha1.BandwidthMeasurement {
-	var measurements burninv1alpha1.BandwidthMeasurementList
+func findJobBandwidthMeasurement(ctx context.Context, c client.Reader, job *crev1alpha1.Job) *crev1alpha1.BandwidthMeasurement {
+	var measurements crev1alpha1.BandwidthMeasurementList
 	if err := c.List(ctx, &measurements, matchingJobRef(job.Namespace, job.Name)...); err != nil {
 		return nil
 	}
@@ -52,7 +52,7 @@ func findJobBandwidthMeasurement(ctx context.Context, c client.Reader, job *burn
 
 // collectJobMeasuredValues gathers metric values from BandwidthMeasurement and
 // GoodputMeasurement status fields. Keys match the threshold registry.
-func collectJobMeasuredValues(ctx context.Context, c client.Reader, job *burninv1alpha1.Job) map[string]float64 {
+func collectJobMeasuredValues(ctx context.Context, c client.Reader, job *crev1alpha1.Job) map[string]float64 {
 	values := make(map[string]float64)
 
 	if bm := findJobBandwidthMeasurement(ctx, c, job); bm != nil && len(bm.Status.Results) > 0 {
@@ -78,13 +78,13 @@ func collectJobMeasuredValues(ctx context.Context, c client.Reader, job *burninv
 // thresholds configured but the Job controller has not yet recorded the outcome.
 // The Job controller sets ValidationFailed=True on violation or ValidationFailed=False
 // when all thresholds pass. Workflow should keep groups running until one is set.
-func isJobAwaitingThresholdEvaluation(job *burninv1alpha1.Job) bool {
+func isJobAwaitingThresholdEvaluation(job *crev1alpha1.Job) bool {
 	if len(job.Spec.Thresholds) == 0 {
 		return false
 	}
-	succeededCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded)
+	succeededCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded)
 	if succeededCond == nil || succeededCond.Status != metav1.ConditionTrue {
 		return false
 	}
-	return meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobValidationFailed) == nil
+	return meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobValidationFailed) == nil
 }

--- a/pkg/controller/job_threshold_helpers_test.go
+++ b/pkg/controller/job_threshold_helpers_test.go
@@ -8,7 +8,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func TestMissingJobThresholdKeys(t *testing.T) {
@@ -26,14 +26,14 @@ func TestMissingJobThresholdKeys(t *testing.T) {
 func TestIsJobAwaitingThresholdEvaluation(t *testing.T) {
 	t.Parallel()
 
-	job := &burninv1alpha1.Job{
+	job := &crev1alpha1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"},
-		Spec: burninv1alpha1.JobSpec{
+		Spec: crev1alpha1.JobSpec{
 			Thresholds: map[string]string{"busBandwidthGBps": "value >= 900"},
 		},
-		Status: burninv1alpha1.JobStatus{
+		Status: crev1alpha1.JobStatus{
 			Conditions: []metav1.Condition{{
-				Type:   burninv1alpha1.JobSucceeded,
+				Type:   crev1alpha1.JobSucceeded,
 				Status: metav1.ConditionTrue,
 			}},
 		},
@@ -44,7 +44,7 @@ func TestIsJobAwaitingThresholdEvaluation(t *testing.T) {
 	}
 
 	job.Status.Conditions = append(job.Status.Conditions, metav1.Condition{
-		Type:   burninv1alpha1.JobValidationFailed,
+		Type:   crev1alpha1.JobValidationFailed,
 		Status: metav1.ConditionFalse,
 	})
 	if isJobAwaitingThresholdEvaluation(job) {

--- a/pkg/controller/merge_test.go
+++ b/pkg/controller/merge_test.go
@@ -7,10 +7,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
 )
 
 func TestMergeFailedNodes(t *testing.T) {

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -19,13 +19,13 @@ const (
 )
 
 var (
-	// jobStatusGauge tracks the current status of burnin jobs.
+	// jobStatusGauge tracks the current status of CRE jobs.
 	// Values: 1 for the current status, 0 for other statuses.
 	// Status can be: "in_progress", "succeeded", "failed"
 	jobStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cre_job_status",
-			Help: "Current status of burnin jobs (1 = current status, 0 = not current status)",
+			Help: "Current status of CRE jobs (1 = current status, 0 = not current status)",
 		},
 		[]string{labelNamespace, labelJob, labelWorkflow, labelStatus},
 	)

--- a/pkg/controller/metrics_cleanup_test.go
+++ b/pkg/controller/metrics_cleanup_test.go
@@ -12,7 +12,7 @@ import (
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // TestCleanupJobMetricsRemovesEveryJobScopedSeries pins the cardinality

--- a/pkg/controller/metrics_test.go
+++ b/pkg/controller/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/controller/node_health_predicate_test.go
+++ b/pkg/controller/node_health_predicate_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // TestNodeHealthChangePredicate verifies that nodeHealthChangePredicate triggers

--- a/pkg/controller/node_results.go
+++ b/pkg/controller/node_results.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	gzip "github.com/NVIDIA/cluster-readiness-engine/pkg/controller/compress"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	gzip "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller/compress"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 
 // succeededNodesForWorkflow returns the full set of nodes that passed for a Workflow
 // that has reached terminal success.
-func succeededNodesForWorkflow(workflow *burninv1alpha1.Workflow) []string {
+func succeededNodesForWorkflow(workflow *crev1alpha1.Workflow) []string {
 	orch := workflow.Status.Orchestration
 	if orch == nil {
 		return nil
@@ -37,7 +37,7 @@ func succeededNodesForWorkflow(workflow *burninv1alpha1.Workflow) []string {
 	}
 	var nodes []string
 	for _, g := range orch.Groups {
-		if g.Phase == burninv1alpha1.GroupSucceeded {
+		if g.Phase == crev1alpha1.GroupSucceeded {
 			nodes = append(nodes, g.Nodes...)
 		}
 	}
@@ -47,10 +47,10 @@ func succeededNodesForWorkflow(workflow *burninv1alpha1.Workflow) []string {
 // sortMergedFailedNodes merges incoming FailedNode entries into existing,
 // deduplicating by the (name, reason) pair and sorting the result by name then
 // reason.
-func sortMergedFailedNodes(existing, incoming []burninv1alpha1.FailedNode) []burninv1alpha1.FailedNode {
+func sortMergedFailedNodes(existing, incoming []crev1alpha1.FailedNode) []crev1alpha1.FailedNode {
 	seen := make(map[[2]string]struct{}, len(existing)+len(incoming))
-	merged := make([]burninv1alpha1.FailedNode, 0, len(existing)+len(incoming))
-	add := func(nodes []burninv1alpha1.FailedNode) {
+	merged := make([]crev1alpha1.FailedNode, 0, len(existing)+len(incoming))
+	add := func(nodes []crev1alpha1.FailedNode) {
 		for _, fn := range nodes {
 			if fn.Name == "" {
 				continue
@@ -86,12 +86,12 @@ func nodeResultsCMName(prefix string, workflowUID string) string {
 
 // recordSucceededNodes merges the given nodes into the Workflow's succeeded-nodes
 // ConfigMap and sets workflow.Status.SucceededNodesRef.
-func (r *WorkflowReconciler) recordSucceededNodes(ctx context.Context, workflow *burninv1alpha1.Workflow, nodes []string) error {
+func (r *WorkflowReconciler) recordSucceededNodes(ctx context.Context, workflow *crev1alpha1.Workflow, nodes []string) error {
 	return recordNodeResults(ctx, r, workflow, nodeResultsTarget[string]{
 		namePrefix: succeededNodesPrefix,
 		dataKey:    noderesults.SucceededNodesConfigMapKey,
 		merge:      mergeSucceededNodesCSV,
-		setRef: func(w *burninv1alpha1.Workflow, ref *corev1.TypedLocalObjectReference) {
+		setRef: func(w *crev1alpha1.Workflow, ref *corev1.TypedLocalObjectReference) {
 			w.Status.SucceededNodesRef = ref
 		},
 	}, nodes)
@@ -99,12 +99,12 @@ func (r *WorkflowReconciler) recordSucceededNodes(ctx context.Context, workflow 
 
 // recordFailedNodes merges the given failed nodes (name, reason, message) into the
 // Workflow's failed-nodes ConfigMap and sets workflow.Status.FailedNodesRef.
-func (r *WorkflowReconciler) recordFailedNodes(ctx context.Context, workflow *burninv1alpha1.Workflow, nodes []burninv1alpha1.FailedNode) error {
-	return recordNodeResults(ctx, r, workflow, nodeResultsTarget[burninv1alpha1.FailedNode]{
+func (r *WorkflowReconciler) recordFailedNodes(ctx context.Context, workflow *crev1alpha1.Workflow, nodes []crev1alpha1.FailedNode) error {
+	return recordNodeResults(ctx, r, workflow, nodeResultsTarget[crev1alpha1.FailedNode]{
 		namePrefix: failedNodesPrefix,
 		dataKey:    noderesults.FailedNodesConfigMapKey,
 		merge:      mergeFailedNodesJSON,
-		setRef:     func(w *burninv1alpha1.Workflow, ref *corev1.TypedLocalObjectReference) { w.Status.FailedNodesRef = ref },
+		setRef:     func(w *crev1alpha1.Workflow, ref *corev1.TypedLocalObjectReference) { w.Status.FailedNodesRef = ref },
 	}, nodes)
 }
 
@@ -118,7 +118,7 @@ type nodeResultsTarget[T any] struct {
 	// merge folds newEntries into the existing encoded payload (which may be
 	// empty) and returns the re-encoded bytes.
 	merge  func(existing []byte, newEntries []T) ([]byte, error)
-	setRef func(*burninv1alpha1.Workflow, *corev1.TypedLocalObjectReference)
+	setRef func(*crev1alpha1.Workflow, *corev1.TypedLocalObjectReference)
 }
 
 // recordNodeResults merges entries into the Workflow's node-result ConfigMap,
@@ -130,7 +130,7 @@ type nodeResultsTarget[T any] struct {
 func recordNodeResults[T any](
 	ctx context.Context,
 	r *WorkflowReconciler,
-	workflow *burninv1alpha1.Workflow,
+	workflow *crev1alpha1.Workflow,
 	target nodeResultsTarget[T],
 	entries []T,
 ) error {
@@ -200,8 +200,8 @@ func mergeSucceededNodesCSV(existing []byte, newNodes []string) ([]byte, error) 
 // mergeFailedNodesJSON decodes the existing gzip-compressed failed-nodes JSON (may be
 // empty), unions in newNodes (deduping by the (name, reason) pair via
 // SortMergedFailedNodes), and returns the re-encoded gzip-JSON bytes.
-func mergeFailedNodesJSON(existing []byte, newNodes []burninv1alpha1.FailedNode) ([]byte, error) {
-	var existingNodes []burninv1alpha1.FailedNode
+func mergeFailedNodesJSON(existing []byte, newNodes []crev1alpha1.FailedNode) ([]byte, error) {
+	var existingNodes []crev1alpha1.FailedNode
 	if len(existing) > 0 {
 		decoded, err := gzip.GunzipString(existing)
 		if err != nil {

--- a/pkg/controller/node_results_test.go
+++ b/pkg/controller/node_results_test.go
@@ -15,9 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	gzip "github.com/NVIDIA/cluster-readiness-engine/pkg/controller/compress"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	gzip "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller/compress"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
 )
 
 func decodeOrFail(t *testing.T, b []byte) []string {
@@ -35,8 +35,8 @@ func decodeOrFail(t *testing.T, b []byte) []string {
 func newNodeResultsScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
-	if err := burninv1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("add burnin scheme: %v", err)
+	if err := crev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add CRE scheme: %v", err)
 	}
 	if err := corev1.AddToScheme(s); err != nil {
 		t.Fatalf("add corev1 scheme: %v", err)
@@ -44,8 +44,8 @@ func newNodeResultsScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func testWorkflow(name string) *burninv1alpha1.Workflow {
-	return &burninv1alpha1.Workflow{
+func testWorkflow(name string) *crev1alpha1.Workflow {
+	return &crev1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid")},
 	}
 }
@@ -62,7 +62,7 @@ func getCMByRef(t *testing.T, c client.Client, ref *corev1.TypedLocalObjectRefer
 	return cm
 }
 
-func readSucceededNodes(t *testing.T, c client.Client, wf *burninv1alpha1.Workflow) []string {
+func readSucceededNodes(t *testing.T, c client.Client, wf *crev1alpha1.Workflow) []string {
 	t.Helper()
 	cm := getCMByRef(t, c, wf.Status.SucceededNodesRef)
 	decoded, err := gzip.GunzipString(cm.BinaryData[noderesults.SucceededNodesConfigMapKey])
@@ -75,7 +75,7 @@ func readSucceededNodes(t *testing.T, c client.Client, wf *burninv1alpha1.Workfl
 	return strings.Split(decoded, ",")
 }
 
-func readFailedNodes(t *testing.T, c client.Client, wf *burninv1alpha1.Workflow) []burninv1alpha1.FailedNode {
+func readFailedNodes(t *testing.T, c client.Client, wf *crev1alpha1.Workflow) []crev1alpha1.FailedNode {
 	t.Helper()
 	cm := getCMByRef(t, c, wf.Status.FailedNodesRef)
 	nodes, err := noderesults.DecodeFailedNodesFromConfigMap(cm)
@@ -132,7 +132,7 @@ func TestMergeSucceededNodesCSV(t *testing.T) {
 }
 
 func TestMergeFailedNodesJSON(t *testing.T) {
-	enc := func(nodes []burninv1alpha1.FailedNode) []byte {
+	enc := func(nodes []crev1alpha1.FailedNode) []byte {
 		jsonBytes, err := noderesults.FailedNodesToJSON(nodes)
 		if err != nil {
 			t.Fatalf("FailedNodesToJSON: %v", err)
@@ -145,41 +145,41 @@ func TestMergeFailedNodesJSON(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		existing []burninv1alpha1.FailedNode // nil => no existing entry
-		incoming []burninv1alpha1.FailedNode
-		want     []burninv1alpha1.FailedNode
+		existing []crev1alpha1.FailedNode // nil => no existing entry
+		incoming []crev1alpha1.FailedNode
+		want     []crev1alpha1.FailedNode
 	}{
 		"empty existing": {
-			incoming: []burninv1alpha1.FailedNode{{Name: "gpu-02", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
-			want:     []burninv1alpha1.FailedNode{{Name: "gpu-02", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
+			incoming: []crev1alpha1.FailedNode{{Name: "gpu-02", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
+			want:     []crev1alpha1.FailedNode{{Name: "gpu-02", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
 		},
 		"union sort and dedupe by name+reason": {
-			existing: []burninv1alpha1.FailedNode{{Name: "gpu-03", Reason: burninv1alpha1.NodeFailureWorkloadFailed}},
-			incoming: []burninv1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-03", Reason: burninv1alpha1.NodeFailureWorkloadFailed},
+			existing: []crev1alpha1.FailedNode{{Name: "gpu-03", Reason: crev1alpha1.NodeFailureWorkloadFailed}},
+			incoming: []crev1alpha1.FailedNode{
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureHardwareDetected},
+				{Name: "gpu-03", Reason: crev1alpha1.NodeFailureWorkloadFailed},
 			},
-			want: []burninv1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-03", Reason: burninv1alpha1.NodeFailureWorkloadFailed},
+			want: []crev1alpha1.FailedNode{
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureHardwareDetected},
+				{Name: "gpu-03", Reason: crev1alpha1.NodeFailureWorkloadFailed},
 			},
 		},
 		"same node two reasons kept": {
-			incoming: []burninv1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureThresholdViolation},
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureHardwareDetected},
+			incoming: []crev1alpha1.FailedNode{
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureThresholdViolation},
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureHardwareDetected},
 			},
-			want: []burninv1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureThresholdViolation},
+			want: []crev1alpha1.FailedNode{
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureHardwareDetected},
+				{Name: "gpu-01", Reason: crev1alpha1.NodeFailureThresholdViolation},
 			},
 		},
 		"message with comma and quote preserved": {
-			incoming: []burninv1alpha1.FailedNode{
-				{Name: "gpu-09", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: `exited 1, signal "kill"`},
+			incoming: []crev1alpha1.FailedNode{
+				{Name: "gpu-09", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: `exited 1, signal "kill"`},
 			},
-			want: []burninv1alpha1.FailedNode{
-				{Name: "gpu-09", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: `exited 1, signal "kill"`},
+			want: []crev1alpha1.FailedNode{
+				{Name: "gpu-09", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: `exited 1, signal "kill"`},
 			},
 		},
 	}
@@ -249,8 +249,8 @@ func TestRecordFailedNodes(t *testing.T) {
 	wf := testWorkflow("test-cert-training-hello")
 	ctx := context.Background()
 
-	if err := r.recordFailedNodes(ctx, wf, []burninv1alpha1.FailedNode{
-		{Name: "gpu-02", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
+	if err := r.recordFailedNodes(ctx, wf, []crev1alpha1.FailedNode{
+		{Name: "gpu-02", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
 	}); err != nil {
 		t.Fatalf("recordFailedNodes (1): %v", err)
 	}
@@ -263,9 +263,9 @@ func TestRecordFailedNodes(t *testing.T) {
 		t.Fatalf("after first write got %+v", got)
 	}
 
-	if err := r.recordFailedNodes(ctx, wf, []burninv1alpha1.FailedNode{
-		{Name: "gpu-02", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
-		{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureHardwareDetected},
+	if err := r.recordFailedNodes(ctx, wf, []crev1alpha1.FailedNode{
+		{Name: "gpu-02", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
+		{Name: "gpu-01", Reason: crev1alpha1.NodeFailureHardwareDetected},
 	}); err != nil {
 		t.Fatalf("recordFailedNodes (2): %v", err)
 	}

--- a/pkg/controller/parser_cache_test.go
+++ b/pkg/controller/parser_cache_test.go
@@ -13,21 +13,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // logProfile builds a minimal LogProfile carrying the given resourceVersion and
 // trainingStep regex.
-func logProfile(name, resourceVersion, regex string) *burninv1alpha1.LogProfile {
-	return &burninv1alpha1.LogProfile{
+func logProfile(name, resourceVersion, regex string) *crev1alpha1.LogProfile {
+	return &crev1alpha1.LogProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			ResourceVersion: resourceVersion,
 		},
-		Spec: burninv1alpha1.LogProfileSpec{
-			Timestamp: burninv1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05"},
-			Patterns: burninv1alpha1.LogPatternSet{
-				TrainingStep: &burninv1alpha1.EventPattern{Regex: regex},
+		Spec: crev1alpha1.LogProfileSpec{
+			Timestamp: crev1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05"},
+			Patterns: crev1alpha1.LogPatternSet{
+				TrainingStep: &crev1alpha1.EventPattern{Regex: regex},
 			},
 		},
 	}
@@ -39,7 +39,7 @@ func logProfile(name, resourceVersion, regex string) *burninv1alpha1.LogProfile 
 func TestGoodputParserCacheInvalidatesOnResourceVersion(t *testing.T) {
 	tests := []struct {
 		name          string
-		second        *burninv1alpha1.LogProfile
+		second        *crev1alpha1.LogProfile
 		wantSameCache bool
 	}{
 		{
@@ -84,9 +84,9 @@ func TestGoodputParserCacheInvalidatesOnResourceVersion(t *testing.T) {
 // TestBandwidthParserCacheInvalidatesOnResourceVersion is the BandwidthMeasurement
 // counterpart: the same cache-keying bug existed in both controllers.
 func TestBandwidthParserCacheInvalidatesOnResourceVersion(t *testing.T) {
-	ncclProfile := func(resourceVersion, regex string) *burninv1alpha1.LogProfile {
+	ncclProfile := func(resourceVersion, regex string) *crev1alpha1.LogProfile {
 		p := logProfile("nccl", resourceVersion, `iteration (?P<globalStep>\d+)`)
-		p.Spec.Patterns.BandwidthResult = &burninv1alpha1.EventPattern{Regex: regex}
+		p.Spec.Patterns.BandwidthResult = &crev1alpha1.EventPattern{Regex: regex}
 		return p
 	}
 
@@ -120,7 +120,7 @@ func TestBandwidthParserCacheInvalidatesOnResourceVersion(t *testing.T) {
 			ctx := context.Background()
 
 			scheme := runtime.NewScheme()
-			require.NoError(t, burninv1alpha1.AddToScheme(scheme))
+			require.NoError(t, crev1alpha1.AddToScheme(scheme))
 
 			c := fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(ncclProfile("", regexV1)).Build()
@@ -131,7 +131,7 @@ func TestBandwidthParserCacheInvalidatesOnResourceVersion(t *testing.T) {
 			require.NotNil(t, p1)
 
 			if tt.editProfile {
-				stored := &burninv1alpha1.LogProfile{}
+				stored := &crev1alpha1.LogProfile{}
 				require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "nccl"}, stored))
 				stored.Spec.Patterns.BandwidthResult.Regex = regexV2
 				require.NoError(t, c.Update(ctx, stored))

--- a/pkg/controller/status_test.go
+++ b/pkg/controller/status_test.go
@@ -19,13 +19,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func newWorkflowScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
-	require.NoError(t, burninv1alpha1.AddToScheme(s))
+	require.NoError(t, crev1alpha1.AddToScheme(s))
 	return s
 }
 
@@ -48,7 +48,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			wf := &burninv1alpha1.Workflow{
+			wf := &crev1alpha1.Workflow{
 				ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "default"},
 			}
 
@@ -58,7 +58,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 			c := fake.NewClientBuilder().
 				WithScheme(newWorkflowScheme(t)).
 				WithObjects(wf).
-				WithStatusSubresource(&burninv1alpha1.Workflow{}).
+				WithStatusSubresource(&crev1alpha1.Workflow{}).
 				WithInterceptorFuncs(interceptor.Funcs{
 					SubResourceUpdate: func(
 						ctx context.Context, cl client.Client, subResourceName string,
@@ -68,7 +68,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 						if remaining > 0 {
 							remaining--
 							return apierrors.NewConflict(
-								schema.GroupResource{Group: burninv1alpha1.GroupVersion.Group, Resource: "workflows"},
+								schema.GroupResource{Group: crev1alpha1.GroupVersion.Group, Resource: "workflows"},
 								obj.GetName(), errors.New("simulated stale write"))
 						}
 						return cl.Status().Update(ctx, obj, opts...)
@@ -76,14 +76,14 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 				}).
 				Build()
 
-			obj := &burninv1alpha1.Workflow{}
+			obj := &crev1alpha1.Workflow{}
 			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, obj))
 
 			mutations := 0
-			err := updateStatusWithRetry(ctx, c, obj, func(w *burninv1alpha1.Workflow) bool {
+			err := updateStatusWithRetry(ctx, c, obj, func(w *crev1alpha1.Workflow) bool {
 				mutations++
 				return meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
-					Type:    burninv1alpha1.WorkflowInProgress,
+					Type:    crev1alpha1.WorkflowInProgress,
 					Status:  metav1.ConditionTrue,
 					Reason:  ReasonJobRunning,
 					Message: "running",
@@ -100,9 +100,9 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 			require.GreaterOrEqual(t, writes, tt.wantMinWrites)
 
 			// The condition must actually be persisted, not merely applied in memory.
-			stored := &burninv1alpha1.Workflow{}
+			stored := &crev1alpha1.Workflow{}
 			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, stored))
-			require.True(t, CondIsTrue(stored.Status.Conditions, burninv1alpha1.WorkflowInProgress))
+			require.True(t, CondIsTrue(stored.Status.Conditions, crev1alpha1.WorkflowInProgress))
 		})
 	}
 }
@@ -113,7 +113,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 func TestUpdateStatusWithRetrySkipsWriteWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
 
-	wf := &burninv1alpha1.Workflow{
+	wf := &crev1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "default"},
 	}
 
@@ -121,7 +121,7 @@ func TestUpdateStatusWithRetrySkipsWriteWhenUnchanged(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(newWorkflowScheme(t)).
 		WithObjects(wf).
-		WithStatusSubresource(&burninv1alpha1.Workflow{}).
+		WithStatusSubresource(&crev1alpha1.Workflow{}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceUpdate: func(
 				ctx context.Context, cl client.Client, subResourceName string,
@@ -133,10 +133,10 @@ func TestUpdateStatusWithRetrySkipsWriteWhenUnchanged(t *testing.T) {
 		}).
 		Build()
 
-	obj := &burninv1alpha1.Workflow{}
+	obj := &crev1alpha1.Workflow{}
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, obj))
 
-	require.NoError(t, updateStatusWithRetry(ctx, c, obj, func(*burninv1alpha1.Workflow) bool {
+	require.NoError(t, updateStatusWithRetry(ctx, c, obj, func(*crev1alpha1.Workflow) bool {
 		return false
 	}))
 	require.Zero(t, writes, "a no-op mutation must not issue a status write")

--- a/pkg/controller/unresolved_log_profile_test.go
+++ b/pkg/controller/unresolved_log_profile_test.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 type conditionOut struct {
@@ -50,7 +50,7 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		}
 
 		scheme := runtime.NewScheme()
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 
@@ -58,21 +58,21 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		// found and simply parse nothing, which is different from the profile being
 		// missing, and reaches a different branch now that the final sample runs
 		// before the terminal handling.
-		profile := &burninv1alpha1.LogProfile{
+		profile := &crev1alpha1.LogProfile{
 			ObjectMeta: metav1.ObjectMeta{Name: "megatron-training"},
-			Spec: burninv1alpha1.LogProfileSpec{
-				Timestamp: burninv1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05.999999"},
-				Patterns: burninv1alpha1.LogPatternSet{
-					TrainingStep: &burninv1alpha1.EventPattern{
+			Spec: crev1alpha1.LogProfileSpec{
+				Timestamp: crev1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05.999999"},
+				Patterns: crev1alpha1.LogPatternSet{
+					TrainingStep: &crev1alpha1.EventPattern{
 						Regex: `iteration\s+(?P<iteration>\d+)`,
 					},
 				},
 			},
 		}
 
-		job := &burninv1alpha1.Job{
+		job := &crev1alpha1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
-			Status: burninv1alpha1.JobStatus{Conditions: []metav1.Condition{{
+			Status: crev1alpha1.JobStatus{Conditions: []metav1.Condition{{
 				Type: in.JobCondition, Status: metav1.ConditionTrue,
 				Reason: "Test", LastTransitionTime: metav1.Now(),
 			}}},
@@ -85,19 +85,19 @@ func TestUnresolvedLogProfile(t *testing.T) {
 
 		switch in.Measurement {
 		case "bandwidth":
-			m := &burninv1alpha1.BandwidthMeasurement{
+			m := &crev1alpha1.BandwidthMeasurement{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "m", Namespace: "ns",
 					Finalizers: []string{bandwidthMeasurementFinalizer},
 				},
-				Spec: burninv1alpha1.BandwidthMeasurementSpec{
+				Spec: crev1alpha1.BandwidthMeasurementSpec{
 					JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 					LogProfileRef: in.LogProfileRef,
 				},
 			}
 			for i := 0; i < in.ExistingResults; i++ {
 				m.Status.Results = append(m.Status.Results,
-					burninv1alpha1.BandwidthResult{SizeBytes: 1024, AlgBW: "10", BusBW: "20"})
+					crev1alpha1.BandwidthResult{SizeBytes: 1024, AlgBW: "10", BusBW: "20"})
 			}
 			c := fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(job, m).WithStatusSubresource(job, m).Build()
@@ -105,18 +105,18 @@ func TestUnresolvedLogProfile(t *testing.T) {
 			if _, err := r.Reconcile(context.Background(), req); err != nil {
 				return err
 			}
-			got := &burninv1alpha1.BandwidthMeasurement{}
+			got := &crev1alpha1.BandwidthMeasurement{}
 			if err := c.Get(context.Background(), key, got); err != nil {
 				return err
 			}
 			conds, results = got.Status.Conditions, len(got.Status.Results)
 		default:
-			m := &burninv1alpha1.GoodputMeasurement{
+			m := &crev1alpha1.GoodputMeasurement{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "m", Namespace: "ns",
 					Finalizers: []string{goodputMeasurementFinalizer},
 				},
-				Spec: burninv1alpha1.GoodputMeasurementSpec{
+				Spec: crev1alpha1.GoodputMeasurementSpec{
 					JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 					LogProfileRef: in.LogProfileRef,
 				},
@@ -131,7 +131,7 @@ func TestUnresolvedLogProfile(t *testing.T) {
 			if _, err := r.Reconcile(context.Background(), req); err != nil {
 				return err
 			}
-			got := &burninv1alpha1.GoodputMeasurement{}
+			got := &crev1alpha1.GoodputMeasurement{}
 			if err := c.Get(context.Background(), key, got); err != nil {
 				return err
 			}

--- a/pkg/controller/waiting_for_nodes_test.go
+++ b/pkg/controller/waiting_for_nodes_test.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // A Certification that finds no schedulable nodes retries for up to
@@ -44,19 +44,19 @@ func TestWaitingForNodes(t *testing.T) {
 		if err := clientgoscheme.AddToScheme(scheme); err != nil {
 			return err
 		}
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 
-		cert := &burninv1alpha1.Certification{
+		cert := &crev1alpha1.Certification{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "c", Namespace: "ns",
 				CreationTimestamp: metav1.Now(),
 				Finalizers:        []string{certificationFinalizer},
 			},
-			Spec: burninv1alpha1.CertificationSpec{
-				Target: burninv1alpha1.TargetSpec{NodeSelector: in.NodeSelector},
-				Categories: []burninv1alpha1.CertificateCategory{
+			Spec: crev1alpha1.CertificationSpec{
+				Target: crev1alpha1.TargetSpec{NodeSelector: in.NodeSelector},
+				Categories: []crev1alpha1.CertificateCategory{
 					{Domain: "communication", Variant: "nccl-all-reduce"},
 				},
 			},
@@ -72,7 +72,7 @@ func TestWaitingForNodes(t *testing.T) {
 		r := &CertificationReconciler{Client: c, Scheme: scheme}
 		_, _ = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c", Namespace: "ns"}})
 
-		got := &burninv1alpha1.Certification{}
+		got := &crev1alpha1.Certification{}
 		if err := c.Get(context.Background(), types.NamespacedName{Name: "c", Namespace: "ns"}, got); err != nil {
 			return err
 		}

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -28,13 +28,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/orchestration"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/naming"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/orchestration"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/threshold"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workload"
 )
 
 const (
@@ -91,7 +91,7 @@ type WorkflowReconciler struct {
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	workflow := &burninv1alpha1.Workflow{}
+	workflow := &crev1alpha1.Workflow{}
 	if err := r.Get(ctx, req.NamespacedName, workflow); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Workflow resource not found, likely deleted")
@@ -116,7 +116,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 // reconcileJob manages the multi-group iteration state machine.
-func (r *WorkflowReconciler) reconcileJob(ctx context.Context, workflow *burninv1alpha1.Workflow) (ctrl.Result, error) {
+func (r *WorkflowReconciler) reconcileJob(ctx context.Context, workflow *crev1alpha1.Workflow) (ctrl.Result, error) {
 	// Guard: if already terminal, do nothing
 	if r.isTerminal(workflow) {
 		return ctrl.Result{}, nil
@@ -237,7 +237,7 @@ func notEnoughNodesMessage(needed, found int, gpuArch string, archExcluded []str
 }
 
 // discoverAndPartition discovers target nodes, auto-detects nodesPerJob, and partitions nodes into groups.
-func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow *burninv1alpha1.Workflow, orch *burninv1alpha1.OrchestrationStatus) (ctrl.Result, error) {
+func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow *crev1alpha1.Workflow, orch *crev1alpha1.OrchestrationStatus) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	target := workflow.Spec.Orchestration.Target
 
@@ -425,7 +425,7 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	return ctrl.Result{RequeueAfter: requeueImmediate}, nil
 }
 
-func (r *WorkflowReconciler) logOverrideResults(ctx context.Context, workflow *burninv1alpha1.Workflow, applied []burninv1alpha1.AppliedOverride, octx OverrideContext) {
+func (r *WorkflowReconciler) logOverrideResults(ctx context.Context, workflow *crev1alpha1.Workflow, applied []crev1alpha1.AppliedOverride, octx OverrideContext) {
 	log := logf.FromContext(ctx)
 	for _, a := range applied {
 		if a.NoOp {
@@ -454,7 +454,7 @@ func (r *WorkflowReconciler) logOverrideResults(ctx context.Context, workflow *b
 // dropped for being cordoned. Callers that record coverage need it: a cordoned
 // node was targeted and never tested, and without the names the run reports a
 // clean PASSED over a fleet it only partly certified.
-func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burninv1alpha1.TargetSpec) ([]corev1.Node, []string, error) {
+func discoverTargetNodes(ctx context.Context, reader client.Reader, target *crev1alpha1.TargetSpec) ([]corev1.Node, []string, error) {
 	nodeList := &corev1.NodeList{}
 	var opts []client.ListOption
 
@@ -553,7 +553,7 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *burn
 }
 
 // nodeMatchesTaints returns true if the node has ALL of the specified taints.
-func nodeMatchesTaints(node corev1.Node, selectors []burninv1alpha1.TaintSelector) bool {
+func nodeMatchesTaints(node corev1.Node, selectors []crev1alpha1.TaintSelector) bool {
 	for _, sel := range selectors {
 		if !nodeHasTaint(node, sel) {
 			return false
@@ -563,7 +563,7 @@ func nodeMatchesTaints(node corev1.Node, selectors []burninv1alpha1.TaintSelecto
 }
 
 // nodeHasTaint returns true if the node has a taint matching the selector.
-func nodeHasTaint(node corev1.Node, sel burninv1alpha1.TaintSelector) bool {
+func nodeHasTaint(node corev1.Node, sel crev1alpha1.TaintSelector) bool {
 	for _, taint := range node.Spec.Taints {
 		if taint.Key != sel.Key {
 			continue
@@ -613,7 +613,7 @@ func convertOperator(op corev1.NodeSelectorOperator) (selection.Operator, error)
 }
 
 // buildTolerations creates tolerations from taint selectors.
-func buildTolerations(selectors []burninv1alpha1.TaintSelector) []corev1.Toleration {
+func buildTolerations(selectors []crev1alpha1.TaintSelector) []corev1.Toleration {
 	tolerations := make([]corev1.Toleration, len(selectors))
 	for i, sel := range selectors {
 		t := corev1.Toleration{
@@ -639,7 +639,7 @@ func buildTolerations(selectors []burninv1alpha1.TaintSelector) []corev1.Tolerat
 //   - pending=true means to requeue and try again later (BM absent or has no results yet)
 //   - err!=nil means the gate could not be evaluated; the caller should fail closed
 func (r *WorkflowReconciler) isBelowBandwidthThreshold(ctx context.Context, jobName, namespace, expr string) (below bool, pending bool, err error) {
-	var bwList burninv1alpha1.BandwidthMeasurementList
+	var bwList crev1alpha1.BandwidthMeasurementList
 	if listErr := r.List(ctx, &bwList, matchingJobRef(namespace, jobName)...); listErr != nil {
 		return false, false, fmt.Errorf("list BandwidthMeasurements: %w", listErr)
 	}
@@ -664,7 +664,7 @@ func (r *WorkflowReconciler) isBelowBandwidthThreshold(ctx context.Context, jobN
 
 // deleteWorkloadForJob deletes the workload (e.g., TrainJob) referenced by a Job
 // to free GPU resources. The Job object itself is preserved.
-func (r *WorkflowReconciler) deleteWorkloadForJob(ctx context.Context, job *burninv1alpha1.Job) {
+func (r *WorkflowReconciler) deleteWorkloadForJob(ctx context.Context, job *crev1alpha1.Job) {
 	ref := job.Status.WorkloadRef
 	if ref == nil {
 		return
@@ -681,7 +681,7 @@ func (r *WorkflowReconciler) deleteWorkloadForJob(ctx context.Context, job *burn
 }
 
 // isJobTimedOut returns true if the group's job has exceeded timeoutPerJob.
-func (r *WorkflowReconciler) isJobTimedOut(workflow *burninv1alpha1.Workflow, g *burninv1alpha1.GroupStatus) bool {
+func (r *WorkflowReconciler) isJobTimedOut(workflow *crev1alpha1.Workflow, g *crev1alpha1.GroupStatus) bool {
 	timeout := workflow.Spec.Orchestration.Execution.TimeoutPerJob
 	if timeout == nil || g.StartTime == nil {
 		return false
@@ -689,9 +689,9 @@ func (r *WorkflowReconciler) isJobTimedOut(workflow *burninv1alpha1.Workflow, g 
 	return time.Since(g.StartTime.Time) > timeout.Duration
 }
 
-func (r *WorkflowReconciler) hasRunningGroups(orch *burninv1alpha1.OrchestrationStatus) bool {
+func (r *WorkflowReconciler) hasRunningGroups(orch *crev1alpha1.OrchestrationStatus) bool {
 	for _, g := range orch.Groups {
-		if g.Phase == burninv1alpha1.GroupRunning {
+		if g.Phase == crev1alpha1.GroupRunning {
 			return true
 		}
 	}
@@ -699,9 +699,9 @@ func (r *WorkflowReconciler) hasRunningGroups(orch *burninv1alpha1.Orchestration
 }
 
 // allGroupsTerminal returns true if all groups have reached Succeeded or Failed phase.
-func (r *WorkflowReconciler) allGroupsTerminal(orch *burninv1alpha1.OrchestrationStatus) bool {
+func (r *WorkflowReconciler) allGroupsTerminal(orch *crev1alpha1.OrchestrationStatus) bool {
 	for _, g := range orch.Groups {
-		if g.Phase != burninv1alpha1.GroupSucceeded && g.Phase != burninv1alpha1.GroupFailed {
+		if g.Phase != crev1alpha1.GroupSucceeded && g.Phase != crev1alpha1.GroupFailed {
 			return false
 		}
 	}
@@ -709,10 +709,10 @@ func (r *WorkflowReconciler) allGroupsTerminal(orch *burninv1alpha1.Orchestratio
 }
 
 // countRunningGroups returns the number of groups with Running phase.
-func countRunningGroups(orch *burninv1alpha1.OrchestrationStatus) int {
+func countRunningGroups(orch *crev1alpha1.OrchestrationStatus) int {
 	count := 0
 	for _, g := range orch.Groups {
-		if g.Phase == burninv1alpha1.GroupRunning {
+		if g.Phase == crev1alpha1.GroupRunning {
 			count++
 		}
 	}
@@ -722,10 +722,10 @@ func countRunningGroups(orch *burninv1alpha1.OrchestrationStatus) int {
 // hasNodeOverlap returns true if any node in the candidate group is
 // already used by a Running group. This prevents scheduling conflicts
 // where concurrent jobs compete for GPU resources on the same node.
-func hasNodeOverlap(candidate *burninv1alpha1.GroupStatus, allGroups []burninv1alpha1.GroupStatus) bool {
+func hasNodeOverlap(candidate *crev1alpha1.GroupStatus, allGroups []crev1alpha1.GroupStatus) bool {
 	runningNodes := make(map[string]bool)
 	for _, g := range allGroups {
-		if g.Phase == burninv1alpha1.GroupRunning && g.Name != candidate.Name {
+		if g.Phase == crev1alpha1.GroupRunning && g.Name != candidate.Name {
 			for _, node := range g.Nodes {
 				runningNodes[node] = true
 			}
@@ -740,14 +740,14 @@ func hasNodeOverlap(candidate *burninv1alpha1.GroupStatus, allGroups []burninv1a
 }
 
 // launchPendingGroups creates Jobs for pending groups, respecting maxConcurrent and overflow constraints.
-func (r *WorkflowReconciler) launchPendingGroups(ctx context.Context, workflow *burninv1alpha1.Workflow, orch *burninv1alpha1.OrchestrationStatus) (ctrl.Result, error) {
+func (r *WorkflowReconciler) launchPendingGroups(ctx context.Context, workflow *crev1alpha1.Workflow, orch *crev1alpha1.OrchestrationStatus) (ctrl.Result, error) {
 	maxConcurrent := workflow.Spec.Orchestration.Execution.MaxConcurrent
 	running := countRunningGroups(orch)
 
 	launched := false
 	for i := range orch.Groups {
 		g := &orch.Groups[i]
-		if g.Phase != burninv1alpha1.GroupPending {
+		if g.Phase != crev1alpha1.GroupPending {
 			continue
 		}
 
@@ -786,7 +786,7 @@ func (r *WorkflowReconciler) launchPendingGroups(ctx context.Context, workflow *
 }
 
 // createJobForGroup creates a Job for a specific group, pinned to that group's nodes.
-func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *burninv1alpha1.Workflow, group *burninv1alpha1.GroupStatus, orch *burninv1alpha1.OrchestrationStatus) error {
+func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *crev1alpha1.Workflow, group *crev1alpha1.GroupStatus, orch *crev1alpha1.OrchestrationStatus) error {
 	log := logf.FromContext(ctx)
 
 	jobName := r.getGroupJobName(workflow, group.Name, orch.CurrentIteration)
@@ -818,7 +818,7 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *bu
 		// handles AlreadyExists on re-create and re-adds the refs.
 	}
 
-	job := &burninv1alpha1.Job{
+	job := &crev1alpha1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: workflow.Namespace,
@@ -871,8 +871,8 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *bu
 
 	// Set default node health monitor if not already configured
 	if job.Spec.NodeHealthMonitor == nil {
-		job.Spec.NodeHealthMonitor = &burninv1alpha1.NodeHealthMonitor{
-			CEL: &burninv1alpha1.CELNodeHealthCheck{
+		job.Spec.NodeHealthMonitor = &crev1alpha1.NodeHealthMonitor{
+			CEL: &crev1alpha1.CELNodeHealthCheck{
 				Expression: `node.spec.unschedulable == true`,
 			},
 		}
@@ -941,8 +941,8 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *bu
 
 	// Update group status
 	now := metav1.Now()
-	group.Phase = burninv1alpha1.GroupRunning
-	group.JobRef = &burninv1alpha1.WorkloadReference{
+	group.Phase = crev1alpha1.GroupRunning
+	group.JobRef = &crev1alpha1.WorkloadReference{
 		APIVersion: "cre.nvidia.com/v1alpha1",
 		Kind:       "Job",
 		Name:       jobName,
@@ -954,7 +954,7 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *bu
 }
 
 // updateStatusFromJobs checks all running groups and updates their status from their Jobs.
-func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow *burninv1alpha1.Workflow) (ctrl.Result, error) {
+func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow *crev1alpha1.Workflow) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	orch := r.ensureOrchestrationStatus(workflow)
 	retryLimit := workflow.Spec.Orchestration.Execution.RetryFailedGroups
@@ -964,12 +964,12 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 
 	for i := range orch.Groups {
 		g := &orch.Groups[i]
-		if g.Phase != burninv1alpha1.GroupRunning || g.JobRef == nil {
+		if g.Phase != crev1alpha1.GroupRunning || g.JobRef == nil {
 			continue
 		}
 
 		ref := g.JobRef
-		job := &burninv1alpha1.Job{}
+		job := &crev1alpha1.Job{}
 		ns := ref.Namespace
 		if ns == "" {
 			ns = workflow.Namespace
@@ -980,7 +980,7 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 				log.Info("Job was deleted, marking group as failed", "group", g.Name, "job", ref.Name)
 				r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
 				now := metav1.Now()
-				g.Phase = burninv1alpha1.GroupFailed
+				g.Phase = crev1alpha1.GroupFailed
 				g.CompletionTime = &now
 				g.JobRef = nil
 				statusChanged = true
@@ -995,7 +995,7 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 			log.Info("Job is being deleted, marking group as failed", "group", g.Name, "job", ref.Name)
 			r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
 			now := metav1.Now()
-			g.Phase = burninv1alpha1.GroupFailed
+			g.Phase = crev1alpha1.GroupFailed
 			g.CompletionTime = &now
 			g.JobRef = nil
 			statusChanged = true
@@ -1014,7 +1014,7 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 				r.captureTimeoutLog(ctx, job)
 				// Mark Job as failed. The Job object stays for the report.
 				meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
-					Type:    burninv1alpha1.JobFailed,
+					Type:    crev1alpha1.JobFailed,
 					Status:  metav1.ConditionTrue,
 					Reason:  "JobTimedOut",
 					Message: "Job exceeded timeoutPerJob",
@@ -1027,7 +1027,7 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 				r.deleteWorkloadForJob(ctx, job)
 				r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
 				now := metav1.Now()
-				g.Phase = burninv1alpha1.GroupFailed
+				g.Phase = crev1alpha1.GroupFailed
 				g.CompletionTime = &now
 				statusChanged = true
 				continue
@@ -1067,7 +1067,7 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 				// Clean up job-scoped deps after Job deletion
 				r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
 				g.Retries++
-				g.Phase = burninv1alpha1.GroupPending
+				g.Phase = crev1alpha1.GroupPending
 				g.JobRef = nil
 				g.StartTime = nil
 				g.CompletionTime = nil
@@ -1076,13 +1076,13 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 				r.deleteWorkloadForJob(ctx, job)
 				// Clean up job-scoped deps on terminal failure
 				r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
-				g.Phase = burninv1alpha1.GroupFailed
+				g.Phase = crev1alpha1.GroupFailed
 				r.updateTopologyMetric(ctx, workflow)
 			}
 		} else {
 			// Clean up job-scoped deps on success
 			r.cleanupScopedDependencies(ctx, workflow, "job", g.Name, orch.CurrentIteration)
-			g.Phase = burninv1alpha1.GroupSucceeded
+			g.Phase = crev1alpha1.GroupSucceeded
 			r.updateTopologyMetric(ctx, workflow)
 		}
 
@@ -1099,9 +1099,9 @@ func (r *WorkflowReconciler) updateStatusFromJobs(ctx context.Context, workflow 
 		// and refetches on conflict, so status mutated outside the callback is
 		// dropped on both paths. That left a completed group stuck Running and the
 		// Workflow never finished — a passing run reported as a timeout.
-		want := make([]burninv1alpha1.GroupStatus, len(orch.Groups))
+		want := make([]crev1alpha1.GroupStatus, len(orch.Groups))
 		copy(want, orch.Groups)
-		applyGroups := func(w *burninv1alpha1.Workflow) bool {
+		applyGroups := func(w *crev1alpha1.Workflow) bool {
 			if w.Status.Orchestration == nil || !statusChanged {
 				return false
 			}
@@ -1126,11 +1126,11 @@ type jobTerminalState struct {
 }
 
 // getJobTerminalState inspects Job conditions and returns a summary of its terminal state.
-func getJobTerminalState(job *burninv1alpha1.Job) jobTerminalState {
-	hwFailedCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobHardwareFailed)
-	jobFailedCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobFailed)
-	jobSucceededCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobSucceeded)
-	validationFailedCond := meta.FindStatusCondition(job.Status.Conditions, burninv1alpha1.JobValidationFailed)
+func getJobTerminalState(job *crev1alpha1.Job) jobTerminalState {
+	hwFailedCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobHardwareFailed)
+	jobFailedCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobFailed)
+	jobSucceededCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobSucceeded)
+	validationFailedCond := meta.FindStatusCondition(job.Status.Conditions, crev1alpha1.JobValidationFailed)
 
 	s := jobTerminalState{
 		hwFailed:         hwFailedCond != nil && hwFailedCond.Status == metav1.ConditionTrue,
@@ -1143,7 +1143,7 @@ func getJobTerminalState(job *burninv1alpha1.Job) jobTerminalState {
 }
 
 // handleIterationComplete handles the transition when all groups in the current iteration are terminal.
-func (r *WorkflowReconciler) handleIterationComplete(ctx context.Context, workflow *burninv1alpha1.Workflow, orch *burninv1alpha1.OrchestrationStatus) (ctrl.Result, error) {
+func (r *WorkflowReconciler) handleIterationComplete(ctx context.Context, workflow *crev1alpha1.Workflow, orch *crev1alpha1.OrchestrationStatus) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	orch.CompletedIterations++
@@ -1166,7 +1166,7 @@ func (r *WorkflowReconciler) handleIterationComplete(ctx context.Context, workfl
 			if g.JobRef == nil {
 				continue
 			}
-			job := &burninv1alpha1.Job{}
+			job := &crev1alpha1.Job{}
 			job.Name = g.JobRef.Name
 			job.Namespace = g.JobRef.Namespace
 			log.Info("Deleting completed iteration Job", "job", g.JobRef.Name, "iteration", orch.CompletedIterations)
@@ -1183,7 +1183,7 @@ func (r *WorkflowReconciler) handleIterationComplete(ctx context.Context, workfl
 		// More iterations to go — reset all group phases to Pending
 		orch.CurrentIteration = orch.CompletedIterations + 1
 		for i := range orch.Groups {
-			orch.Groups[i].Phase = burninv1alpha1.GroupPending
+			orch.Groups[i].Phase = crev1alpha1.GroupPending
 			orch.Groups[i].JobRef = nil
 			orch.Groups[i].StartTime = nil
 			orch.Groups[i].CompletionTime = nil
@@ -1203,7 +1203,7 @@ func (r *WorkflowReconciler) handleIterationComplete(ctx context.Context, workfl
 }
 
 // initDiagnose creates screening groups for adaptive fault isolation.
-func initDiagnose(nodeInfos []orchestration.NodeInfo, spec *burninv1alpha1.DiagnoseSpec, orch *burninv1alpha1.OrchestrationStatus) ([]orchestration.Group, int, error) {
+func initDiagnose(nodeInfos []orchestration.NodeInfo, spec *crev1alpha1.DiagnoseSpec, orch *crev1alpha1.OrchestrationStatus) ([]orchestration.Group, int, error) {
 	groups, err := orchestration.ScreenGroups(orchestration.DiagnoseScreenInput{
 		Nodes:       nodeInfos,
 		TopologyKey: spec.TopologyKey,
@@ -1215,15 +1215,15 @@ func initDiagnose(nodeInfos []orchestration.NodeInfo, spec *burninv1alpha1.Diagn
 	if len(groups) > 0 {
 		nodesPerJob = len(groups[0].Nodes)
 	}
-	orch.Diagnose = &burninv1alpha1.DiagnoseStatus{
-		Stage: burninv1alpha1.DiagnoseStageIntraScreening,
+	orch.Diagnose = &crev1alpha1.DiagnoseStatus{
+		Stage: crev1alpha1.DiagnoseStageIntraScreening,
 	}
 	return groups, nodesPerJob, nil
 }
 
 // handleDiagnoseRoundComplete advances the diagnose algorithm through its stages:
 // intra-screening → intra-screening-no-nvl → inter-screening → bisection → confirmation → done.
-func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, workflow *burninv1alpha1.Workflow, orch *burninv1alpha1.OrchestrationStatus) (ctrl.Result, error) {
+func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, workflow *crev1alpha1.Workflow, orch *crev1alpha1.OrchestrationStatus) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	diag := orch.Diagnose
 	spec := workflow.Spec.Orchestration.Diagnose
@@ -1241,14 +1241,14 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 	switch diag.Stage {
 
 	// --- Stage 1a complete: re-run intra-clique without NVLink ---
-	case burninv1alpha1.DiagnoseStageIntraScreening:
+	case crev1alpha1.DiagnoseStageIntraScreening:
 		recordScreeningResults(orch, diag, failedGroups)
 		// Skip the no-NVL stage if MNNVL is already disabled in the base job template —
 		// the intra-screening already ran without NVLink, so re-testing would be identical.
 		if isMNNVLEnabledInJobTemplate(&workflow.Spec.JobTemplate) {
 			noNVLGroups := buildNoNVLGroups(diag)
 			if len(noNVLGroups) > 0 {
-				diag.Stage = burninv1alpha1.DiagnoseStageIntraScreeningNoNVL
+				diag.Stage = crev1alpha1.DiagnoseStageIntraScreeningNoNVL
 				return r.diagnoseSetGroups(ctx, workflow, orch, diag, noNVLGroups,
 					fmt.Sprintf("Intra-screening with NVL done: %d healthy, %d suspect. Re-testing without NVL.",
 						len(diag.HealthyNodes), len(diag.SuspectNodes)))
@@ -1260,8 +1260,8 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 		fallthrough
 
 	// --- Stage 1b complete: build inter-domain test from healthy representatives ---
-	case burninv1alpha1.DiagnoseStageIntraScreeningNoNVL:
-		if diag.Stage == burninv1alpha1.DiagnoseStageIntraScreeningNoNVL {
+	case crev1alpha1.DiagnoseStageIntraScreeningNoNVL:
+		if diag.Stage == crev1alpha1.DiagnoseStageIntraScreeningNoNVL {
 			processNoNVLScreeningResults(orch, diag, failedGroups)
 		}
 
@@ -1283,14 +1283,14 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 			return r.diagnoseNextGroups(ctx, workflow, orch, diag, minGroupSize, perClique)
 		}
 
-		diag.Stage = burninv1alpha1.DiagnoseStageInterScreening
+		diag.Stage = crev1alpha1.DiagnoseStageInterScreening
 		return r.diagnoseSetGroups(ctx, workflow, orch, diag,
 			[]orchestration.Group{interGroup},
 			fmt.Sprintf("Screening done: %d healthy, %d suspect nodes. Testing inter-domain fabric.",
 				len(diag.HealthyNodes), len(diag.SuspectNodes)))
 
 	// --- Stage 1b complete: merge intra + inter failures, start bisection ---
-	case burninv1alpha1.DiagnoseStageInterScreening:
+	case crev1alpha1.DiagnoseStageInterScreening:
 		// Rebuild per-clique groups from stashed suspects (preserve clique boundaries).
 		var toSplit []orchestration.Group
 		if len(diag.SuspectNodes) > 0 {
@@ -1310,15 +1310,15 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 		return r.diagnoseNextGroups(ctx, workflow, orch, diag, minGroupSize, toSplit)
 
 	// --- Bisection round complete: continue splitting or move to confirmation ---
-	case burninv1alpha1.DiagnoseStageBisection:
+	case crev1alpha1.DiagnoseStageBisection:
 		return r.handleDiagnoseBisection(ctx, workflow, orch, diag, minGroupSize, failedGroups)
 
 	// --- Cross-boundary probing complete: record infrastructure faults ---
-	case burninv1alpha1.DiagnoseStageCrossBoundary:
+	case crev1alpha1.DiagnoseStageCrossBoundary:
 		return r.handleDiagnoseCrossBoundary(ctx, workflow, orch, diag, minGroupSize, failedGroups)
 
 	// --- Confirmation complete: report results ---
-	case burninv1alpha1.DiagnoseStageConfirmation:
+	case crev1alpha1.DiagnoseStageConfirmation:
 		var confirmedFaulty []string
 		var cleared []string
 		for _, g := range failedGroups {
@@ -1327,7 +1327,7 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 			}
 		}
 		for _, g := range orch.Groups {
-			if g.Phase == burninv1alpha1.GroupSucceeded && len(g.Nodes) > 0 {
+			if g.Phase == crev1alpha1.GroupSucceeded && len(g.Nodes) > 0 {
 				cleared = append(cleared, g.Nodes[0])
 			}
 		}
@@ -1349,7 +1349,7 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 		if err := r.recordSucceededNodes(ctx, workflow, succeededNodesForWorkflow(workflow)); err != nil {
 			log.Error(err, "Failed to record succeeded nodes to ConfigMap")
 		}
-		diag.Stage = burninv1alpha1.DiagnoseStageComplete
+		diag.Stage = crev1alpha1.DiagnoseStageComplete
 
 		return ctrl.Result{}, r.setWorkflowFailed(ctx, workflow, ReasonIterationsFailed, msg,
 			applySucceededNodesRef(workflow.Status.SucceededNodesRef),
@@ -1362,8 +1362,8 @@ func (r *WorkflowReconciler) handleDiagnoseRoundComplete(ctx context.Context, wo
 
 // handleDiagnoseBisection handles bisection round completion.
 func (r *WorkflowReconciler) handleDiagnoseBisection(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus,
 	minGroupSize int, failedGroups []orchestration.Group,
 ) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -1376,7 +1376,7 @@ func (r *WorkflowReconciler) handleDiagnoseBisection(
 			Name:    g.Name,
 			Nodes:   g.Nodes,
 			Domains: g.Domains,
-			Passed:  g.Phase == burninv1alpha1.GroupSucceeded,
+			Passed:  g.Phase == crev1alpha1.GroupSucceeded,
 		})
 	}
 	// Process failed groups first: move minGroupSize groups to suspects,
@@ -1395,11 +1395,11 @@ func (r *WorkflowReconciler) handleDiagnoseBisection(
 	// that both succeeded indicate an infrastructure fault at the boundary.
 	bhpResults := orchestration.DetectBothHalvesPass(groupResults)
 	if len(bhpResults) > 0 {
-		probes := make([]burninv1alpha1.CrossBoundaryProbe, 0, len(bhpResults))
+		probes := make([]crev1alpha1.CrossBoundaryProbe, 0, len(bhpResults))
 		for _, bhp := range bhpResults {
 			log.Info("Both-halves-pass detected — infrastructure fault candidate",
 				"domain", bhp.Domain, "halfA", len(bhp.HalfA), "halfB", len(bhp.HalfB))
-			probes = append(probes, burninv1alpha1.CrossBoundaryProbe{
+			probes = append(probes, crev1alpha1.CrossBoundaryProbe{
 				Domain: bhp.Domain, HalfA: bhp.HalfA, HalfB: bhp.HalfB, ProbeRound: 0,
 			})
 			// Remove BHP nodes from healthy (they were marked healthy by bisection pass)
@@ -1412,11 +1412,11 @@ func (r *WorkflowReconciler) handleDiagnoseBisection(
 		for i, p := range probes {
 			probeGroups = append(probeGroups, orchestration.BuildCrossBoundaryGroups(p.HalfA, p.HalfB, i)...)
 		}
-		diag.CrossBoundaryState = &burninv1alpha1.CrossBoundaryState{
+		diag.CrossBoundaryState = &crev1alpha1.CrossBoundaryState{
 			PendingProbes: probes,
-			OriginStage:   burninv1alpha1.DiagnoseStageBisection,
+			OriginStage:   crev1alpha1.DiagnoseStageBisection,
 		}
-		diag.Stage = burninv1alpha1.DiagnoseStageCrossBoundary
+		diag.Stage = crev1alpha1.DiagnoseStageCrossBoundary
 		return r.diagnoseSetGroups(ctx, workflow, orch, diag, probeGroups,
 			fmt.Sprintf("Both-halves-pass detected in %d groups. Probing cross-boundary infrastructure.",
 				len(bhpResults)))
@@ -1436,8 +1436,8 @@ func (r *WorkflowReconciler) handleDiagnoseBisection(
 // the boundary. When all probes resolve, results are stored as InfrastructureFaults
 // and the algorithm returns to bisection/confirmation for remaining work.
 func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus,
 	minGroupSize int, failedGroups []orchestration.Group,
 ) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -1452,7 +1452,7 @@ func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
 	}
 
 	// Process each pending probe: check if its mixed groups passed or failed.
-	var nextProbes []burninv1alpha1.CrossBoundaryProbe
+	var nextProbes []crev1alpha1.CrossBoundaryProbe
 	for i, probe := range cbState.PendingProbes {
 		mix0 := fmt.Sprintf("cross-%d-mix0", i)
 		mix1 := fmt.Sprintf("cross-%d-mix1", i)
@@ -1470,7 +1470,7 @@ func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
 		if mix0Failed && mix1Failed {
 			// Both failed — full infrastructure fault across the boundary.
 			log.Info("Infrastructure fault confirmed (full boundary)", "domain", probe.Domain)
-			diag.InfrastructureFaults = append(diag.InfrastructureFaults, burninv1alpha1.InfrastructureFault{
+			diag.InfrastructureFaults = append(diag.InfrastructureFaults, crev1alpha1.InfrastructureFault{
 				Domain: probe.Domain,
 				GroupA: probe.HalfA,
 				GroupB: probe.HalfB,
@@ -1487,7 +1487,7 @@ func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
 			// Max rounds or min size — record as infrastructure fault.
 			log.Info("Infrastructure fault localized", "domain", probe.Domain,
 				"halfA", len(probe.HalfA), "halfB", len(probe.HalfB))
-			diag.InfrastructureFaults = append(diag.InfrastructureFaults, burninv1alpha1.InfrastructureFault{
+			diag.InfrastructureFaults = append(diag.InfrastructureFaults, crev1alpha1.InfrastructureFault{
 				Domain: probe.Domain,
 				GroupA: probe.HalfA,
 				GroupB: probe.HalfB,
@@ -1534,7 +1534,7 @@ func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
 
 	// Check if infrastructure faults were found.
 	if len(diag.InfrastructureFaults) > 0 {
-		diag.Stage = burninv1alpha1.DiagnoseStageComplete
+		diag.Stage = crev1alpha1.DiagnoseStageComplete
 		msg := fmt.Sprintf("Diagnosis complete: %d infrastructure faults detected", len(diag.InfrastructureFaults))
 		log.Info(msg)
 		return ctrl.Result{}, r.setWorkflowFailed(ctx, workflow, ReasonIterationsFailed, msg,
@@ -1546,7 +1546,7 @@ func (r *WorkflowReconciler) handleDiagnoseCrossBoundary(
 }
 
 // failedScreeningGroups rebuilds per-clique groups from screening results.
-func failedScreeningGroups(diag *burninv1alpha1.DiagnoseStatus) []orchestration.Group {
+func failedScreeningGroups(diag *crev1alpha1.DiagnoseStatus) []orchestration.Group {
 	var groups []orchestration.Group
 	for domain, sr := range diag.ScreeningResults {
 		if !sr.Passed {
@@ -1563,8 +1563,8 @@ func failedScreeningGroups(diag *burninv1alpha1.DiagnoseStatus) []orchestration.
 
 // diagnoseNextGroups bisects failed groups or transitions to confirmation if converged.
 func (r *WorkflowReconciler) diagnoseNextGroups(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus,
 	minGroupSize int, failedGroups []orchestration.Group,
 ) (ctrl.Result, error) {
 	result := orchestration.Bisect(orchestration.BisectInput{
@@ -1599,34 +1599,34 @@ func (r *WorkflowReconciler) diagnoseNextGroups(
 			if err := r.recordSucceededNodes(ctx, workflow, succeededNodesForWorkflow(workflow)); err != nil {
 				logf.FromContext(ctx).Error(err, "Failed to record succeeded nodes to ConfigMap")
 			}
-			diag.Stage = burninv1alpha1.DiagnoseStageComplete
+			diag.Stage = crev1alpha1.DiagnoseStageComplete
 			return ctrl.Result{}, r.setWorkflowFailed(ctx, workflow, ReasonIterationsFailed, msg,
 				applySucceededNodesRef(workflow.Status.SucceededNodesRef),
 				applyFailedNodesRef(workflow.Status.FailedNodesRef))
 		}
-		diag.Stage = burninv1alpha1.DiagnoseStageConfirmation
+		diag.Stage = crev1alpha1.DiagnoseStageConfirmation
 		return r.diagnoseSetGroups(ctx, workflow, orch, diag, groups,
 			fmt.Sprintf("Bisection converged: %d suspects, starting confirmation", len(diag.SuspectNodes)))
 	}
 
-	diag.Stage = burninv1alpha1.DiagnoseStageBisection
+	diag.Stage = crev1alpha1.DiagnoseStageBisection
 	return r.diagnoseSetGroups(ctx, workflow, orch, diag, result.Groups,
 		fmt.Sprintf("Bisection round %d: %d groups", diag.Round, len(result.Groups)))
 }
 
 // diagnoseSetGroups replaces the current groups and advances the iteration.
 func (r *WorkflowReconciler) diagnoseSetGroups(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus,
 	groups []orchestration.Group, msg string,
 ) (ctrl.Result, error) {
 	logf.FromContext(ctx).Info(msg, "stage", diag.Stage, "round", diag.Round)
 
-	orch.Groups = make([]burninv1alpha1.GroupStatus, len(groups))
+	orch.Groups = make([]crev1alpha1.GroupStatus, len(groups))
 	for i, g := range groups {
-		orch.Groups[i] = burninv1alpha1.GroupStatus{
+		orch.Groups[i] = crev1alpha1.GroupStatus{
 			Name: g.Name, Nodes: g.Nodes, Domains: g.Domains,
-			Phase: burninv1alpha1.GroupPending,
+			Phase: crev1alpha1.GroupPending,
 		}
 	}
 	orch.TotalGroups = len(groups)
@@ -1640,10 +1640,10 @@ func (r *WorkflowReconciler) diagnoseSetGroups(
 
 // diagnoseDone sets the workflow as succeeded with the given message.
 func (r *WorkflowReconciler) diagnoseDone(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	diag *burninv1alpha1.DiagnoseStatus, msg string,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	diag *crev1alpha1.DiagnoseStatus, msg string,
 ) (ctrl.Result, error) {
-	diag.Stage = burninv1alpha1.DiagnoseStageComplete
+	diag.Stage = crev1alpha1.DiagnoseStageComplete
 	logf.FromContext(ctx).Info(msg, "round", diag.Round,
 		"healthy", len(diag.HealthyNodes), "suspects", len(diag.SuspectNodes))
 
@@ -1654,7 +1654,7 @@ func (r *WorkflowReconciler) diagnoseDone(
 }
 
 // buildInterDomainGroup selects one healthy representative per screening group.
-func buildInterDomainGroup(healthyNodes []string, groups []burninv1alpha1.GroupStatus) orchestration.Group {
+func buildInterDomainGroup(healthyNodes []string, groups []crev1alpha1.GroupStatus) orchestration.Group {
 	healthySet := make(map[string]bool, len(healthyNodes))
 	for _, n := range healthyNodes {
 		healthySet[n] = true
@@ -1677,17 +1677,17 @@ func buildInterDomainGroup(healthyNodes []string, groups []burninv1alpha1.GroupS
 }
 
 // snapshotIteration captures the current group outcomes as an IterationResult.
-func snapshotIteration(orch *burninv1alpha1.OrchestrationStatus) burninv1alpha1.IterationResult {
-	result := burninv1alpha1.IterationResult{
+func snapshotIteration(orch *crev1alpha1.OrchestrationStatus) crev1alpha1.IterationResult {
+	result := crev1alpha1.IterationResult{
 		Iteration: orch.CurrentIteration,
-		Groups:    make([]burninv1alpha1.GroupIterationResult, len(orch.Groups)),
+		Groups:    make([]crev1alpha1.GroupIterationResult, len(orch.Groups)),
 	}
 	for i, g := range orch.Groups {
 		var jobName string
 		if g.JobRef != nil {
 			jobName = g.JobRef.Name
 		}
-		result.Groups[i] = burninv1alpha1.GroupIterationResult{
+		result.Groups[i] = crev1alpha1.GroupIterationResult{
 			Name:           g.Name,
 			Phase:          g.Phase,
 			JobName:        jobName,
@@ -1699,9 +1699,9 @@ func snapshotIteration(orch *burninv1alpha1.OrchestrationStatus) burninv1alpha1.
 }
 
 // ensureOrchestrationStatus initializes the orchestration status if nil.
-func (r *WorkflowReconciler) ensureOrchestrationStatus(workflow *burninv1alpha1.Workflow) *burninv1alpha1.OrchestrationStatus {
+func (r *WorkflowReconciler) ensureOrchestrationStatus(workflow *crev1alpha1.Workflow) *crev1alpha1.OrchestrationStatus {
 	if workflow.Status.Orchestration == nil {
-		workflow.Status.Orchestration = &burninv1alpha1.OrchestrationStatus{}
+		workflow.Status.Orchestration = &crev1alpha1.OrchestrationStatus{}
 	}
 	return workflow.Status.Orchestration
 }
@@ -1711,7 +1711,7 @@ func (r *WorkflowReconciler) ensureOrchestrationStatus(workflow *burninv1alpha1.
 // when the Workflow is eventually deleted by the Certification controller. This preserves
 // GoodputMeasurement and BandwidthMeasurement resources (owned by Workflow via OwnerReference)
 // so the certification report can read metrics across all iterations before teardown.
-func (r *WorkflowReconciler) setFinalStatus(ctx context.Context, workflow *burninv1alpha1.Workflow) (ctrl.Result, error) {
+func (r *WorkflowReconciler) setFinalStatus(ctx context.Context, workflow *crev1alpha1.Workflow) (ctrl.Result, error) {
 	totalIter := effectiveIterations(workflow.Spec.Orchestration)
 
 	// Count failed groups across all iterations
@@ -1750,7 +1750,7 @@ func (r *WorkflowReconciler) setFinalStatus(ctx context.Context, workflow *burni
 }
 
 // countFailedGroups counts groups with Failed phase across all iterations.
-func (r *WorkflowReconciler) countFailedGroups(workflow *burninv1alpha1.Workflow) int {
+func (r *WorkflowReconciler) countFailedGroups(workflow *crev1alpha1.Workflow) int {
 	if workflow.Status.Orchestration == nil {
 		return 0
 	}
@@ -1758,14 +1758,14 @@ func (r *WorkflowReconciler) countFailedGroups(workflow *burninv1alpha1.Workflow
 	// Count from iteration history (completed non-final iterations).
 	for _, iter := range workflow.Status.Orchestration.IterationHistory {
 		for _, g := range iter.Groups {
-			if g.Phase == burninv1alpha1.GroupFailed {
+			if g.Phase == crev1alpha1.GroupFailed {
 				count++
 			}
 		}
 	}
 	// Count from current (final) groups.
 	for _, g := range workflow.Status.Orchestration.Groups {
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			count++
 		}
 	}
@@ -1774,13 +1774,13 @@ func (r *WorkflowReconciler) countFailedGroups(workflow *burninv1alpha1.Workflow
 
 // hasValidationFailures checks if any failed group's Job has the ValidationFailed condition.
 // Used by setFinalStatus to distinguish validation failures from other failure types.
-func (r *WorkflowReconciler) hasValidationFailures(ctx context.Context, workflow *burninv1alpha1.Workflow) bool {
-	return r.anyFailedGroupJobHasCondition(ctx, workflow, burninv1alpha1.JobValidationFailed)
+func (r *WorkflowReconciler) hasValidationFailures(ctx context.Context, workflow *crev1alpha1.Workflow) bool {
+	return r.anyFailedGroupJobHasCondition(ctx, workflow, crev1alpha1.JobValidationFailed)
 }
 
 // hasHardwareFailures checks if any failed group's Job has the HardwareFailed condition.
-func (r *WorkflowReconciler) hasHardwareFailures(ctx context.Context, workflow *burninv1alpha1.Workflow) bool {
-	return r.anyFailedGroupJobHasCondition(ctx, workflow, burninv1alpha1.JobHardwareFailed)
+func (r *WorkflowReconciler) hasHardwareFailures(ctx context.Context, workflow *crev1alpha1.Workflow) bool {
+	return r.anyFailedGroupJobHasCondition(ctx, workflow, crev1alpha1.JobHardwareFailed)
 }
 
 // anyFailedGroupJobHasCondition reports whether the Job behind any failed group
@@ -1791,20 +1791,20 @@ func (r *WorkflowReconciler) hasHardwareFailures(ctx context.Context, workflow *
 // transient read error should leave the generic reason in place rather than
 // assert a cause that was never observed.
 func (r *WorkflowReconciler) anyFailedGroupJobHasCondition(
-	ctx context.Context, workflow *burninv1alpha1.Workflow, conditionType string,
+	ctx context.Context, workflow *crev1alpha1.Workflow, conditionType string,
 ) bool {
 	if workflow.Status.Orchestration == nil {
 		return false
 	}
 	for _, g := range workflow.Status.Orchestration.Groups {
-		if g.Phase != burninv1alpha1.GroupFailed || g.JobRef == nil {
+		if g.Phase != crev1alpha1.GroupFailed || g.JobRef == nil {
 			continue
 		}
 		ns := g.JobRef.Namespace
 		if ns == "" {
 			ns = workflow.Namespace
 		}
-		job := &burninv1alpha1.Job{}
+		job := &crev1alpha1.Job{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: g.JobRef.Name}, job); err != nil {
 			continue
 		}
@@ -1818,7 +1818,7 @@ func (r *WorkflowReconciler) anyFailedGroupJobHasCondition(
 // deleteTerminalJobs deletes all Jobs referenced by the current iteration's groups.
 // The Job controller's finalizer handles workload cleanup and metrics.
 // updateTopologyMetric recomputes the topology validated nodes gauge from all succeeded groups.
-func (r *WorkflowReconciler) updateTopologyMetric(ctx context.Context, workflow *burninv1alpha1.Workflow) {
+func (r *WorkflowReconciler) updateTopologyMetric(ctx context.Context, workflow *crev1alpha1.Workflow) {
 	log := logf.FromContext(ctx)
 	topologyKey := getTopologyKey(workflow)
 	if topologyKey == "" {
@@ -1835,7 +1835,7 @@ func (r *WorkflowReconciler) updateTopologyMetric(ctx context.Context, workflow 
 	failedNodes := make(map[string]bool)
 	failedDomainNodes := make(map[string]map[string]bool) // domain -> set of node names
 	for _, g := range orch.Groups {
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			for _, nodeName := range g.Nodes {
 				failedNodes[nodeName] = true
 				domain := r.getNodeDomain(ctx, nodeName, topologyKey, g.Domains)
@@ -1853,7 +1853,7 @@ func (r *WorkflowReconciler) updateTopologyMetric(ctx context.Context, workflow 
 	// excluding any node that appears in a failed group.
 	domainNodes := make(map[string]map[string]bool) // domain -> set of node names
 	for _, g := range orch.Groups {
-		if g.Phase != burninv1alpha1.GroupSucceeded {
+		if g.Phase != crev1alpha1.GroupSucceeded {
 			continue
 		}
 		for _, nodeName := range g.Nodes {
@@ -1894,7 +1894,7 @@ func (r *WorkflowReconciler) updateTopologyMetric(ctx context.Context, workflow 
 }
 
 // getTopologyKey returns the topology key from the workflow spec, or "" if not set.
-func getTopologyKey(workflow *burninv1alpha1.Workflow) string {
+func getTopologyKey(workflow *crev1alpha1.Workflow) string {
 	if workflow.Spec.Orchestration.Topology != nil {
 		return workflow.Spec.Orchestration.Topology.TopologyKey
 	}
@@ -1918,7 +1918,7 @@ func (r *WorkflowReconciler) getNodeDomain(ctx context.Context, nodeName, topolo
 
 // buildGroupStatuses converts orchestration groups into GroupStatus objects,
 // populating DomainNodeCounts for multi-domain groups using node topology labels.
-func buildGroupStatuses(groups []orchestration.Group, nodeInfos []orchestration.NodeInfo, topo *burninv1alpha1.TopologySpec) []burninv1alpha1.GroupStatus {
+func buildGroupStatuses(groups []orchestration.Group, nodeInfos []orchestration.NodeInfo, topo *crev1alpha1.TopologySpec) []crev1alpha1.GroupStatus {
 	// Build node→domain lookup for DomainNodeCounts.
 	nodeDomainMap := make(map[string]string)
 	if topo != nil && topo.TopologyKey != "" {
@@ -1929,14 +1929,14 @@ func buildGroupStatuses(groups []orchestration.Group, nodeInfos []orchestration.
 		}
 	}
 
-	statuses := make([]burninv1alpha1.GroupStatus, len(groups))
+	statuses := make([]crev1alpha1.GroupStatus, len(groups))
 	for i, g := range groups {
-		statuses[i] = burninv1alpha1.GroupStatus{
+		statuses[i] = crev1alpha1.GroupStatus{
 			Name:     g.Name,
 			Nodes:    g.Nodes,
 			Domains:  g.Domains,
 			Overflow: g.Overflow,
-			Phase:    burninv1alpha1.GroupPending,
+			Phase:    crev1alpha1.GroupPending,
 		}
 		if len(g.Domains) > 1 && len(nodeDomainMap) > 0 {
 			counts := make(map[string]int)
@@ -1954,7 +1954,7 @@ func buildGroupStatuses(groups []orchestration.Group, nodeInfos []orchestration.
 // collectAllDomainNodes returns domain → node list for all groups.
 // Most groups span a single domain, so assigns all nodes to that domain.
 // Multi-domain groups assign each node to every domain (conservative for cleanup).
-func collectAllDomainNodes(groups []burninv1alpha1.GroupStatus) map[string][]string {
+func collectAllDomainNodes(groups []crev1alpha1.GroupStatus) map[string][]string {
 	result := make(map[string][]string)
 	for _, g := range groups {
 		if len(g.Domains) == 1 {
@@ -1969,22 +1969,22 @@ func collectAllDomainNodes(groups []burninv1alpha1.GroupStatus) map[string][]str
 }
 
 // setWorkflowInProgress sets the Workflow to InProgress state.
-func (r *WorkflowReconciler) setWorkflowInProgress(ctx context.Context, workflow *burninv1alpha1.Workflow, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
-	return r.setExclusiveCondition(ctx, workflow, burninv1alpha1.WorkflowInProgress, reason, message, extra...)
+func (r *WorkflowReconciler) setWorkflowInProgress(ctx context.Context, workflow *crev1alpha1.Workflow, reason, message string, extra ...func(*crev1alpha1.Workflow) bool) error {
+	return r.setExclusiveCondition(ctx, workflow, crev1alpha1.WorkflowInProgress, reason, message, extra...)
 }
 
 // setWorkflowSucceeded sets the Workflow to Succeeded state.
 // extra funcs are applied inside the updateStatusWithRetry closure so their
 // status mutations survive 409 conflict re-fetches.
-func (r *WorkflowReconciler) setWorkflowSucceeded(ctx context.Context, workflow *burninv1alpha1.Workflow, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
-	return r.setExclusiveCondition(ctx, workflow, burninv1alpha1.WorkflowSucceeded, reason, message, extra...)
+func (r *WorkflowReconciler) setWorkflowSucceeded(ctx context.Context, workflow *crev1alpha1.Workflow, reason, message string, extra ...func(*crev1alpha1.Workflow) bool) error {
+	return r.setExclusiveCondition(ctx, workflow, crev1alpha1.WorkflowSucceeded, reason, message, extra...)
 }
 
 // setWorkflowFailed sets the Workflow to Failed state.
 // extra funcs are applied inside the updateStatusWithRetry closure so their
 // status mutations survive 409 conflict re-fetches.
-func (r *WorkflowReconciler) setWorkflowFailed(ctx context.Context, workflow *burninv1alpha1.Workflow, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
-	return r.setExclusiveCondition(ctx, workflow, burninv1alpha1.WorkflowFailed, reason, message, extra...)
+func (r *WorkflowReconciler) setWorkflowFailed(ctx context.Context, workflow *crev1alpha1.Workflow, reason, message string, extra ...func(*crev1alpha1.Workflow) bool) error {
+	return r.setExclusiveCondition(ctx, workflow, crev1alpha1.WorkflowFailed, reason, message, extra...)
 }
 
 // applySucceededNodesRef returns an extra func suitable for setWorkflowSucceeded
@@ -1992,11 +1992,11 @@ func (r *WorkflowReconciler) setWorkflowFailed(ctx context.Context, workflow *bu
 // closure. Without this, SucceededNodesRef set on the stale object before the
 // call is silently discarded when the API server returns a 409 conflict and the
 // object is re-fetched.
-func applySucceededNodesRef(ref *corev1.TypedLocalObjectReference) func(*burninv1alpha1.Workflow) bool {
+func applySucceededNodesRef(ref *corev1.TypedLocalObjectReference) func(*crev1alpha1.Workflow) bool {
 	if ref == nil {
 		return nil
 	}
-	return func(w *burninv1alpha1.Workflow) bool {
+	return func(w *crev1alpha1.Workflow) bool {
 		cur := w.Status.SucceededNodesRef
 		if cur != nil && cur.Name == ref.Name && cur.Kind == ref.Kind {
 			return false
@@ -2011,11 +2011,11 @@ func applySucceededNodesRef(ref *corev1.TypedLocalObjectReference) func(*burninv
 // FailedNodesRef set on the stale object before the call (e.g. by
 // recordFailedNodes) is silently discarded when the API server returns a 409
 // conflict and the object is re-fetched.
-func applyFailedNodesRef(ref *corev1.TypedLocalObjectReference) func(*burninv1alpha1.Workflow) bool {
+func applyFailedNodesRef(ref *corev1.TypedLocalObjectReference) func(*crev1alpha1.Workflow) bool {
 	if ref == nil {
 		return nil
 	}
-	return func(w *burninv1alpha1.Workflow) bool {
+	return func(w *crev1alpha1.Workflow) bool {
 		cur := w.Status.FailedNodesRef
 		if cur != nil && cur.Name == ref.Name && cur.Kind == ref.Kind {
 			return false
@@ -2026,13 +2026,13 @@ func applyFailedNodesRef(ref *corev1.TypedLocalObjectReference) func(*burninv1al
 }
 
 // setExclusiveCondition sets one condition True and all others False (mutually exclusive).
-func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow *burninv1alpha1.Workflow, conditionType, reason, message string, extra ...func(*burninv1alpha1.Workflow) bool) error {
+func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow *crev1alpha1.Workflow, conditionType, reason, message string, extra ...func(*crev1alpha1.Workflow) bool) error {
 	changed, err := setExclusiveStatusCondition(ctx, r.Client, workflow,
-		func(w *burninv1alpha1.Workflow) *[]metav1.Condition { return &w.Status.Conditions },
+		func(w *crev1alpha1.Workflow) *[]metav1.Condition { return &w.Status.Conditions },
 		[]string{
-			burninv1alpha1.WorkflowInProgress,
-			burninv1alpha1.WorkflowSucceeded,
-			burninv1alpha1.WorkflowFailed,
+			crev1alpha1.WorkflowInProgress,
+			crev1alpha1.WorkflowSucceeded,
+			crev1alpha1.WorkflowFailed,
 		},
 		conditionType, reason, message, extra...,
 	)
@@ -2046,7 +2046,7 @@ func (r *WorkflowReconciler) setExclusiveCondition(ctx context.Context, workflow
 }
 
 // getGroupJobName returns the name for a Job created for a specific group and iteration.
-func (r *WorkflowReconciler) getGroupJobName(workflow *burninv1alpha1.Workflow, groupName string, iteration int) string {
+func (r *WorkflowReconciler) getGroupJobName(workflow *crev1alpha1.Workflow, groupName string, iteration int) string {
 	var raw string
 	isDiagnose := workflow.Spec.Orchestration.Diagnose != nil
 	if !isDiagnose && !hasMultipleIterations(workflow.Spec.Orchestration) && workflow.Status.Orchestration != nil && workflow.Status.Orchestration.TotalGroups <= 1 {
@@ -2069,7 +2069,7 @@ func (r *WorkflowReconciler) getJobRequeueInterval() time.Duration {
 // is deleted. For MPI tests, targets the launcher pod (which has the actual NCCL
 // output). Falls back to the first running node pod for non-MPI workloads.
 // Best-effort: errors are logged, not returned.
-func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv1alpha1.Job) {
+func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *crev1alpha1.Job) {
 	log := logf.FromContext(ctx)
 	if r.Clientset == nil {
 		return
@@ -2123,7 +2123,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 	stream, err := podlogs.OpenStream(ctx, req)
 	if err != nil {
 		log.V(1).Info("Failed to stream pod logs for timeout capture", "pod", targetPod.Name, "error", err)
-		job.Status.FailureLog = &burninv1alpha1.FailureLog{
+		job.Status.FailureLog = &crev1alpha1.FailureLog{
 			PodName:  targetPod.Name,
 			NodeName: targetPod.Spec.NodeName,
 			Reason:   "Timeout",
@@ -2137,7 +2137,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 		log.V(1).Info("Failed to read pod logs", "pod", targetPod.Name, "error", err)
 	}
 
-	job.Status.FailureLog = &burninv1alpha1.FailureLog{
+	job.Status.FailureLog = &crev1alpha1.FailureLog{
 		PodName:  targetPod.Name,
 		NodeName: targetPod.Spec.NodeName,
 		Reason:   "Timeout",
@@ -2155,7 +2155,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *burninv
 // Jobs must be deleted before dependencies because dependencies (ComputeDomain,
 // ResourceClaimTemplate) provide DRA allocations for GPU interconnects. Deleting
 // them while workload pods are still running causes CUDA failure 719.
-func (r *WorkflowReconciler) handleDeletion(ctx context.Context, workflow *burninv1alpha1.Workflow) (ctrl.Result, error) {
+func (r *WorkflowReconciler) handleDeletion(ctx context.Context, workflow *crev1alpha1.Workflow) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(workflow, workflowFinalizer) {
@@ -2168,7 +2168,7 @@ func (r *WorkflowReconciler) handleDeletion(ctx context.Context, workflow *burni
 	// This is necessary because envtest has no GC controller, and with multiple iterations
 	// there may be completed Jobs from previous iterations that are no longer referenced.
 	// The Job controller's finalizer handles workload (TrainJob) deletion and pod termination.
-	jobList := &burninv1alpha1.JobList{}
+	jobList := &crev1alpha1.JobList{}
 	if err := r.List(ctx, jobList,
 		client.InNamespace(workflow.Namespace),
 		client.MatchingLabels{"cre.nvidia.com/workflow": workflow.Name},
@@ -2247,7 +2247,7 @@ func (r *WorkflowReconciler) handleDeletion(ctx context.Context, workflow *burni
 }
 
 // effectiveIterations returns the number of normal iterations to run, ensuring at least 1.
-func effectiveIterations(orch burninv1alpha1.OrchestrationSpec) int {
+func effectiveIterations(orch crev1alpha1.OrchestrationSpec) int {
 	if orch.Iterations < 1 {
 		return 1
 	}
@@ -2255,7 +2255,7 @@ func effectiveIterations(orch burninv1alpha1.OrchestrationSpec) int {
 }
 
 // hasMultipleIterations returns true if the orchestration uses multiple iterations.
-func hasMultipleIterations(orch burninv1alpha1.OrchestrationSpec) bool {
+func hasMultipleIterations(orch crev1alpha1.OrchestrationSpec) bool {
 	return orch.Iterations > 1
 }
 
@@ -2276,17 +2276,17 @@ func appendUniqueNodes(existing []string, newNodes ...string) []string {
 
 // removeNodes removes specified nodes from a slice.
 // recordScreeningResults saves per-domain screening results and stashes failed nodes.
-func recordScreeningResults(orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus, failedGroups []orchestration.Group) {
+func recordScreeningResults(orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus, failedGroups []orchestration.Group) {
 	failedNames := failedGroupNameSet(failedGroups)
-	diag.ScreeningResults = make(map[string]burninv1alpha1.DomainScreeningResult)
+	diag.ScreeningResults = make(map[string]crev1alpha1.DomainScreeningResult)
 	for _, g := range orch.Groups {
 		domain := g.Name
 		if len(g.Domains) > 0 {
 			domain = g.Domains[0]
 		}
-		diag.ScreeningResults[domain] = burninv1alpha1.DomainScreeningResult{
+		diag.ScreeningResults[domain] = crev1alpha1.DomainScreeningResult{
 			Nodes:  g.Nodes,
-			Passed: g.Phase == burninv1alpha1.GroupSucceeded && !failedNames[g.Name],
+			Passed: g.Phase == crev1alpha1.GroupSucceeded && !failedNames[g.Name],
 		}
 	}
 	for _, g := range failedGroups {
@@ -2308,7 +2308,7 @@ func failedGroupNameSet(failedGroups []orchestration.Group) map[string]bool {
 }
 
 // buildNoNVLGroups rebuilds screening groups for the no-NVL stage.
-func buildNoNVLGroups(diag *burninv1alpha1.DiagnoseStatus) []orchestration.Group {
+func buildNoNVLGroups(diag *crev1alpha1.DiagnoseStatus) []orchestration.Group {
 	groups := make([]orchestration.Group, 0, len(diag.ScreeningResults))
 	for domain, result := range diag.ScreeningResults {
 		groups = append(groups, orchestration.Group{
@@ -2323,17 +2323,17 @@ func buildNoNVLGroups(diag *burninv1alpha1.DiagnoseStatus) []orchestration.Group
 // failedGroups carries the threshold-aware verdict from collectDiagnoseRoundResults
 // so groups that passed by phase but fell below the bandwidth threshold are still
 // recorded as not-passed and routed into the suspect set for follow-up.
-func processNoNVLScreeningResults(orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus, failedGroups []orchestration.Group) {
+func processNoNVLScreeningResults(orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus, failedGroups []orchestration.Group) {
 	failedNames := failedGroupNameSet(failedGroups)
-	diag.NoNVLScreeningResults = make(map[string]burninv1alpha1.DomainScreeningResult)
+	diag.NoNVLScreeningResults = make(map[string]crev1alpha1.DomainScreeningResult)
 	for _, g := range orch.Groups {
 		domain := g.Name
 		if len(g.Domains) > 0 {
 			domain = g.Domains[0]
 		}
-		result := burninv1alpha1.DomainScreeningResult{
+		result := crev1alpha1.DomainScreeningResult{
 			Nodes:  g.Nodes,
-			Passed: g.Phase == burninv1alpha1.GroupSucceeded && !failedNames[g.Name],
+			Passed: g.Phase == crev1alpha1.GroupSucceeded && !failedNames[g.Name],
 		}
 		diag.NoNVLScreeningResults[domain] = result
 		if !result.Passed {
@@ -2362,8 +2362,8 @@ func removeNodes(existing []string, toRemove []string) []string {
 // round, applying bandwidth threshold reclassification. Returns failed groups and
 // whether any bandwidth measurements are still pending (caller should requeue).
 func (r *WorkflowReconciler) collectDiagnoseRoundResults(
-	ctx context.Context, workflow *burninv1alpha1.Workflow,
-	orch *burninv1alpha1.OrchestrationStatus, diag *burninv1alpha1.DiagnoseStatus,
+	ctx context.Context, workflow *crev1alpha1.Workflow,
+	orch *crev1alpha1.OrchestrationStatus, diag *crev1alpha1.DiagnoseStatus,
 ) ([]orchestration.Group, bool) {
 	log := logf.FromContext(ctx)
 
@@ -2376,7 +2376,7 @@ func (r *WorkflowReconciler) collectDiagnoseRoundResults(
 	var failedGroups []orchestration.Group
 	for _, g := range orch.Groups {
 		switch g.Phase {
-		case burninv1alpha1.GroupSucceeded:
+		case crev1alpha1.GroupSucceeded:
 			if bwThresholdExpr != "" && g.JobRef != nil {
 				below, pending, bwErr := r.isBelowBandwidthThreshold(ctx, g.JobRef.Name, workflow.Namespace, bwThresholdExpr)
 				if bwErr != nil {
@@ -2400,7 +2400,7 @@ func (r *WorkflowReconciler) collectDiagnoseRoundResults(
 				}
 			}
 			diag.HealthyNodes = appendUniqueNodes(diag.HealthyNodes, g.Nodes...)
-		case burninv1alpha1.GroupFailed:
+		case crev1alpha1.GroupFailed:
 			failedGroups = append(failedGroups, orchestration.Group{
 				Name: g.Name, Nodes: g.Nodes, Domains: g.Domains,
 			})
@@ -2412,16 +2412,16 @@ func (r *WorkflowReconciler) collectDiagnoseRoundResults(
 // applyDiagnoseMNNVLOverride disables MNNVL for diagnose stages that require it:
 // no-NVL screening, cross-boundary probing (when origin stage ran without NVL),
 // and bisection/confirmation when the group contains no-NVL suspects.
-func applyDiagnoseMNNVLOverride(spec *burninv1alpha1.WorkloadSpec, diag *burninv1alpha1.DiagnoseStatus, nodes []string) {
+func applyDiagnoseMNNVLOverride(spec *crev1alpha1.WorkloadSpec, diag *crev1alpha1.DiagnoseStatus, nodes []string) {
 	switch diag.Stage {
-	case burninv1alpha1.DiagnoseStageIntraScreeningNoNVL:
+	case crev1alpha1.DiagnoseStageIntraScreeningNoNVL:
 		overrideMNNVL(spec, "0")
-	case burninv1alpha1.DiagnoseStageCrossBoundary:
+	case crev1alpha1.DiagnoseStageCrossBoundary:
 		if diag.CrossBoundaryState != nil &&
-			diag.CrossBoundaryState.OriginStage != burninv1alpha1.DiagnoseStageIntraScreening {
+			diag.CrossBoundaryState.OriginStage != crev1alpha1.DiagnoseStageIntraScreening {
 			overrideMNNVL(spec, "0")
 		}
-	case burninv1alpha1.DiagnoseStageBisection, burninv1alpha1.DiagnoseStageConfirmation:
+	case crev1alpha1.DiagnoseStageBisection, crev1alpha1.DiagnoseStageConfirmation:
 		if len(diag.NoNVLSuspectNodes) > 0 {
 			noNVLSet := make(map[string]bool, len(diag.NoNVLSuspectNodes))
 			for _, n := range diag.NoNVLSuspectNodes {
@@ -2439,7 +2439,7 @@ func applyDiagnoseMNNVLOverride(spec *burninv1alpha1.WorkloadSpec, diag *burninv
 
 // overrideMNNVL sets NCCL_MNNVL_ENABLE on the trainer. It checks Args first,
 // then Env, and appends as an env var if not found in either.
-func overrideMNNVL(spec *burninv1alpha1.WorkloadSpec, value string) {
+func overrideMNNVL(spec *crev1alpha1.WorkloadSpec, value string) {
 	if spec.TrainJob == nil || spec.TrainJob.Trainer == nil {
 		return
 	}
@@ -2470,7 +2470,7 @@ func overrideMNNVL(spec *burninv1alpha1.WorkloadSpec, value string) {
 // isMNNVLEnabledInJobTemplate checks whether the base job template has
 // NCCL_MNNVL_ENABLE set to a non-zero value in either Trainer.Args or Trainer.Env.
 // Returns false if the env var is absent or set to "0".
-func isMNNVLEnabledInJobTemplate(tmpl *burninv1alpha1.JobTemplateSpec) bool {
+func isMNNVLEnabledInJobTemplate(tmpl *crev1alpha1.JobTemplateSpec) bool {
 	if tmpl.Spec.Workload.TrainJob == nil || tmpl.Spec.Workload.TrainJob.Trainer == nil {
 		return false
 	}
@@ -2496,7 +2496,7 @@ func isMNNVLEnabledInJobTemplate(tmpl *burninv1alpha1.JobTemplateSpec) bool {
 // Dependency refs are accumulated in the workflow object in memory but NOT persisted.
 // The caller's subsequent Status().Update() (e.g. setWorkflowInProgress, job status
 // updates) writes the full status including any new dependency refs.
-func (r *WorkflowReconciler) ensureWorkflowDependencies(ctx context.Context, workflow *burninv1alpha1.Workflow) error {
+func (r *WorkflowReconciler) ensureWorkflowDependencies(ctx context.Context, workflow *crev1alpha1.Workflow) error {
 	// Classify deps by reachability from the job template
 	jobSpecJSON, err := json.Marshal(&workflow.Spec.JobTemplate.Spec)
 	if err != nil {
@@ -2538,7 +2538,7 @@ func (r *WorkflowReconciler) ensureWorkflowDependencies(ctx context.Context, wor
 }
 
 // hasPVCDependency checks if the Workflow has a PVC dependency with the given name.
-func (r *WorkflowReconciler) hasPVCDependency(workflow *burninv1alpha1.Workflow, pvcName string) bool {
+func (r *WorkflowReconciler) hasPVCDependency(workflow *crev1alpha1.Workflow, pvcName string) bool {
 	for _, dep := range workflow.Spec.Dependencies {
 		var obj unstructured.Unstructured
 		if err := json.Unmarshal(dep.Raw, &obj.Object); err != nil {
@@ -2556,7 +2556,7 @@ func (r *WorkflowReconciler) hasPVCDependency(workflow *burninv1alpha1.Workflow,
 // unmarshaling from dep.Raw (used for job-scoped deps with suffixed names).
 // The owner parameter sets an owner reference on the resource for GC cascading.
 // Pass nil to skip owner reference (e.g. for job-scoped deps that get the Job as owner later).
-func (r *WorkflowReconciler) createDependencyResource(ctx context.Context, owner client.Object, workflow *burninv1alpha1.Workflow, dep burninv1alpha1.DependencySpec, prebuilt ...*unstructured.Unstructured) (*burninv1alpha1.DependencyResourceRef, bool, error) {
+func (r *WorkflowReconciler) createDependencyResource(ctx context.Context, owner client.Object, workflow *crev1alpha1.Workflow, dep crev1alpha1.DependencySpec, prebuilt ...*unstructured.Unstructured) (*crev1alpha1.DependencyResourceRef, bool, error) {
 	log := logf.FromContext(ctx)
 
 	var obj *unstructured.Unstructured
@@ -2611,7 +2611,7 @@ func (r *WorkflowReconciler) createDependencyResource(ctx context.Context, owner
 		}
 	}
 
-	return &burninv1alpha1.DependencyResourceRef{
+	return &crev1alpha1.DependencyResourceRef{
 		APIVersion: obj.GetAPIVersion(),
 		Kind:       obj.GetKind(),
 		Name:       obj.GetName(),
@@ -2684,11 +2684,11 @@ func (r *WorkflowReconciler) findPVByClaimRef(ctx context.Context, pvcNamespace,
 }
 
 // isTerminal returns true if the Workflow has reached a terminal state (Succeeded or Failed).
-func (r *WorkflowReconciler) isTerminal(workflow *burninv1alpha1.Workflow) bool {
-	if cond := meta.FindStatusCondition(workflow.Status.Conditions, burninv1alpha1.WorkflowSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
+func (r *WorkflowReconciler) isTerminal(workflow *crev1alpha1.Workflow) bool {
+	if cond := meta.FindStatusCondition(workflow.Status.Conditions, crev1alpha1.WorkflowSucceeded); cond != nil && cond.Status == metav1.ConditionTrue {
 		return true
 	}
-	if cond := meta.FindStatusCondition(workflow.Status.Conditions, burninv1alpha1.WorkflowFailed); cond != nil && cond.Status == metav1.ConditionTrue {
+	if cond := meta.FindStatusCondition(workflow.Status.Conditions, crev1alpha1.WorkflowFailed); cond != nil && cond.Status == metav1.ConditionTrue {
 		return true
 	}
 	return false
@@ -2705,8 +2705,8 @@ func (r *WorkflowReconciler) eventf(obj runtime.Object, eventType, reason, messa
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkflowReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.Workflow{}).
-		Owns(&burninv1alpha1.Job{}).
+		For(&crev1alpha1.Workflow{}).
+		Owns(&crev1alpha1.Job{}).
 		Named("workflow").
 		Complete(r)
 }

--- a/pkg/controller/workflow_controller_test.go
+++ b/pkg/controller/workflow_controller_test.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func TestBuildTolerations(t *testing.T) {
@@ -22,7 +22,7 @@ func TestBuildTolerations(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Selectors []burninv1alpha1.TaintSelector `yaml:"selectors"`
+			Selectors []crev1alpha1.TaintSelector `yaml:"selectors"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -46,8 +46,8 @@ func TestNodeMatchesTaints(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Node      corev1.Node                    `yaml:"node"`
-			Selectors []burninv1alpha1.TaintSelector `yaml:"selectors"`
+			Node      corev1.Node                 `yaml:"node"`
+			Selectors []crev1alpha1.TaintSelector `yaml:"selectors"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -73,8 +73,8 @@ func TestCanLaunchOverflow(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Overflow  burninv1alpha1.GroupStatus   `yaml:"overflow"`
-			AllGroups []burninv1alpha1.GroupStatus `yaml:"allGroups"`
+			Overflow  crev1alpha1.GroupStatus   `yaml:"overflow"`
+			AllGroups []crev1alpha1.GroupStatus `yaml:"allGroups"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -100,8 +100,8 @@ func TestHasNodeOverlap(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Candidate burninv1alpha1.GroupStatus   `yaml:"candidate"`
-			AllGroups []burninv1alpha1.GroupStatus `yaml:"allGroups"`
+			Candidate crev1alpha1.GroupStatus   `yaml:"candidate"`
+			AllGroups []crev1alpha1.GroupStatus `yaml:"allGroups"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -127,13 +127,13 @@ func TestCountRunningGroups(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Groups []burninv1alpha1.GroupStatus `yaml:"groups"`
+			Groups []crev1alpha1.GroupStatus `yaml:"groups"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
-		orch := &burninv1alpha1.OrchestrationStatus{Groups: input.Groups}
+		orch := &crev1alpha1.OrchestrationStatus{Groups: input.Groups}
 		result := countRunningGroups(orch)
 
 		data, err := json.MarshalIndent(struct {
@@ -154,14 +154,14 @@ func TestAllGroupsTerminal(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Groups []burninv1alpha1.GroupStatus `yaml:"groups"`
+			Groups []crev1alpha1.GroupStatus `yaml:"groups"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
 		r := &WorkflowReconciler{}
-		orch := &burninv1alpha1.OrchestrationStatus{Groups: input.Groups}
+		orch := &crev1alpha1.OrchestrationStatus{Groups: input.Groups}
 		result := r.allGroupsTerminal(orch)
 
 		data, err := json.MarshalIndent(struct {
@@ -182,14 +182,14 @@ func TestHasRunningGroups(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Groups []burninv1alpha1.GroupStatus `yaml:"groups"`
+			Groups []crev1alpha1.GroupStatus `yaml:"groups"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
 		r := &WorkflowReconciler{}
-		orch := &burninv1alpha1.OrchestrationStatus{Groups: input.Groups}
+		orch := &crev1alpha1.OrchestrationStatus{Groups: input.Groups}
 		result := r.hasRunningGroups(orch)
 
 		data, err := json.MarshalIndent(struct {
@@ -220,15 +220,15 @@ func TestGetGroupJobName(t *testing.T) {
 			return err
 		}
 
-		workflow := &burninv1alpha1.Workflow{
+		workflow := &crev1alpha1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Name: input.WorkflowName},
-			Spec: burninv1alpha1.WorkflowSpec{
-				Orchestration: burninv1alpha1.OrchestrationSpec{
+			Spec: crev1alpha1.WorkflowSpec{
+				Orchestration: crev1alpha1.OrchestrationSpec{
 					Iterations: input.Iterations,
 				},
 			},
-			Status: burninv1alpha1.WorkflowStatus{
-				Orchestration: &burninv1alpha1.OrchestrationStatus{
+			Status: crev1alpha1.WorkflowStatus{
+				Orchestration: &crev1alpha1.OrchestrationStatus{
 					TotalGroups: input.TotalGroups,
 				},
 			},
@@ -261,7 +261,7 @@ func TestEffectiveIterations(t *testing.T) {
 			return err
 		}
 
-		orch := burninv1alpha1.OrchestrationSpec{Iterations: input.Iterations}
+		orch := crev1alpha1.OrchestrationSpec{Iterations: input.Iterations}
 		result := effectiveIterations(orch)
 
 		data, err := json.MarshalIndent(struct {
@@ -288,7 +288,7 @@ func TestHasMultipleIterations(t *testing.T) {
 			return err
 		}
 
-		orch := burninv1alpha1.OrchestrationSpec{Iterations: input.Iterations}
+		orch := crev1alpha1.OrchestrationSpec{Iterations: input.Iterations}
 		result := hasMultipleIterations(orch)
 
 		data, err := json.MarshalIndent(struct {

--- a/pkg/controller/workflow_deps.go
+++ b/pkg/controller/workflow_deps.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/naming"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/naming"
 )
 
 const (
@@ -39,7 +39,7 @@ var resourceNameRegex = regexp.MustCompile(`^[a-z0-9][-a-z0-9.]*[a-z0-9]$`)
 // metadata.name appears (directly or transitively) as a string value reachable
 // from the job template. Cluster-scoped resources (kind starting with "Cluster")
 // are never job-scoped because per-job copies would collide globally.
-func classifyDependencies(deps []burninv1alpha1.DependencySpec, jobSpecJSON []byte) (workflowDeps, jobDeps []burninv1alpha1.DependencySpec) {
+func classifyDependencies(deps []crev1alpha1.DependencySpec, jobSpecJSON []byte) (workflowDeps, jobDeps []crev1alpha1.DependencySpec) {
 	if len(deps) == 0 {
 		return nil, nil
 	}
@@ -117,7 +117,7 @@ func classifyDependencies(deps []burninv1alpha1.DependencySpec, jobSpecJSON []by
 // detectCrossRefs finds resource-name-shaped strings that appear in 2+ job-scoped
 // deps but aren't any dep's metadata.name. These are internal names (e.g., a
 // ComputeDomain channel template name) that need per-job suffixing.
-func detectCrossRefs(jobDeps []burninv1alpha1.DependencySpec) map[string]bool {
+func detectCrossRefs(jobDeps []crev1alpha1.DependencySpec) map[string]bool {
 	// Collect all dep metadata.names
 	depNames := make(map[string]bool, len(jobDeps))
 	for _, dep := range jobDeps {
@@ -153,7 +153,7 @@ func detectCrossRefs(jobDeps []burninv1alpha1.DependencySpec) map[string]bool {
 // orderDependencies returns dependencies in topological creation order.
 // If dep A's JSON contains dep B's metadata.name, A depends on B (create B first).
 // Dependencies with no inter-references maintain their original order.
-func orderDependencies(deps []burninv1alpha1.DependencySpec) []burninv1alpha1.DependencySpec {
+func orderDependencies(deps []crev1alpha1.DependencySpec) []crev1alpha1.DependencySpec {
 	if len(deps) <= 1 {
 		return deps
 	}
@@ -206,7 +206,7 @@ func orderDependencies(deps []burninv1alpha1.DependencySpec) []burninv1alpha1.De
 	}
 	sort.Ints(queue)
 
-	result := make([]burninv1alpha1.DependencySpec, 0, len(deps))
+	result := make([]crev1alpha1.DependencySpec, 0, len(deps))
 	for len(queue) > 0 {
 		idx := queue[0]
 		queue = queue[1:]
@@ -249,11 +249,11 @@ func orderDependencies(deps []burninv1alpha1.DependencySpec) []burninv1alpha1.De
 // Since DependencyRefs are stored in creation (topological) order by
 // orderDependencies(), reversing gives a safe deletion order: resources
 // that depend on others are deleted first, followed by their dependencies.
-func reverseDependencyRefs(refs []burninv1alpha1.DependencyResourceRef) []burninv1alpha1.DependencyResourceRef {
+func reverseDependencyRefs(refs []crev1alpha1.DependencyResourceRef) []crev1alpha1.DependencyResourceRef {
 	if len(refs) <= 1 {
 		return refs
 	}
-	reversed := make([]burninv1alpha1.DependencyResourceRef, len(refs))
+	reversed := make([]crev1alpha1.DependencyResourceRef, len(refs))
 	for i, ref := range refs {
 		reversed[len(refs)-1-i] = ref
 	}
@@ -277,7 +277,7 @@ func depJobSuffix(totalGroups int, multipleIterations bool, groupName string, it
 // It always includes metadata.name, and also includes auto-detected cross-reference
 // names (shared strings across 2+ deps). Structural names internal to a resource
 // (e.g., replicatedJob names, container names) are NOT suffixed.
-func buildReplacementMap(deps []burninv1alpha1.DependencySpec, suffix string) map[string]string {
+func buildReplacementMap(deps []crev1alpha1.DependencySpec, suffix string) map[string]string {
 	replacements := make(map[string]string)
 
 	// Auto-detect cross-references
@@ -327,7 +327,7 @@ func suffixDependencyObject(raw []byte, replacements map[string]string) (*unstru
 }
 
 // suffixJobSpec applies name replacements to a job spec via JSON round-trip.
-func suffixJobSpec(spec *burninv1alpha1.JobSpec, replacements map[string]string) (*burninv1alpha1.JobSpec, error) {
+func suffixJobSpec(spec *crev1alpha1.JobSpec, replacements map[string]string) (*crev1alpha1.JobSpec, error) {
 	data, err := json.Marshal(spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal job spec: %w", err)
@@ -338,7 +338,7 @@ func suffixJobSpec(spec *burninv1alpha1.JobSpec, replacements map[string]string)
 		s = strings.ReplaceAll(s, `"`+old+`"`, `"`+newVal+`"`)
 	}
 
-	result := &burninv1alpha1.JobSpec{}
+	result := &crev1alpha1.JobSpec{}
 	if err := json.Unmarshal([]byte(s), result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal suffixed job spec: %w", err)
 	}
@@ -350,11 +350,11 @@ func suffixJobSpec(spec *burninv1alpha1.JobSpec, replacements map[string]string)
 // and only patches the job spec with the name replacements.
 func (r *WorkflowReconciler) ensureJobDependencies(
 	ctx context.Context,
-	workflow *burninv1alpha1.Workflow,
-	group *burninv1alpha1.GroupStatus,
-	orch *burninv1alpha1.OrchestrationStatus,
-	spec *burninv1alpha1.JobSpec,
-) (*burninv1alpha1.JobSpec, []burninv1alpha1.DependencyResourceRef, error) {
+	workflow *crev1alpha1.Workflow,
+	group *crev1alpha1.GroupStatus,
+	orch *crev1alpha1.OrchestrationStatus,
+	spec *crev1alpha1.JobSpec,
+) (*crev1alpha1.JobSpec, []crev1alpha1.DependencyResourceRef, error) {
 	// Marshal job spec for classification
 	jobSpecJSON, err := json.Marshal(spec)
 	if err != nil {
@@ -387,7 +387,7 @@ func (r *WorkflowReconciler) ensureJobDependencies(
 		}
 	}
 
-	var refs []burninv1alpha1.DependencyResourceRef
+	var refs []crev1alpha1.DependencyResourceRef
 	hasNewComputeDomain := false
 	if !alreadyCreated {
 		// Create suffixed dependency objects
@@ -432,12 +432,12 @@ func (r *WorkflowReconciler) ensureJobDependencies(
 // cleanupScopedDependencies deletes dependency resources matching the given scope, group, and iteration,
 // and removes them from the workflow status. Matching refs are deleted in reverse topological order
 // (reverse of creation order) so that resources depending on others are removed first.
-func (r *WorkflowReconciler) cleanupScopedDependencies(ctx context.Context, workflow *burninv1alpha1.Workflow, scope, groupName string, iteration int) {
+func (r *WorkflowReconciler) cleanupScopedDependencies(ctx context.Context, workflow *crev1alpha1.Workflow, scope, groupName string, iteration int) {
 	log := logf.FromContext(ctx)
 
 	// Partition refs into matching (to delete) and non-matching (to keep).
-	var toDelete []burninv1alpha1.DependencyResourceRef
-	var remaining []burninv1alpha1.DependencyResourceRef
+	var toDelete []crev1alpha1.DependencyResourceRef
+	var remaining []crev1alpha1.DependencyResourceRef
 	for _, ref := range workflow.Status.DependencyRefs {
 		if ref.Scope != scope || ref.GroupName != groupName || ref.Iteration != iteration {
 			remaining = append(remaining, ref)

--- a/pkg/controller/workflow_deps_test.go
+++ b/pkg/controller/workflow_deps_test.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func TestClassifyDependencies(t *testing.T) {
@@ -31,9 +31,9 @@ func TestClassifyDependencies(t *testing.T) {
 			return err
 		}
 
-		var deps []burninv1alpha1.DependencySpec
+		var deps []crev1alpha1.DependencySpec
 		for _, d := range input.Deps {
-			deps = append(deps, burninv1alpha1.DependencySpec{
+			deps = append(deps, crev1alpha1.DependencySpec{
 				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
 			})
 		}
@@ -81,9 +81,9 @@ func TestOrderDependencies(t *testing.T) {
 			return err
 		}
 
-		var deps []burninv1alpha1.DependencySpec
+		var deps []crev1alpha1.DependencySpec
 		for _, d := range input.Deps {
-			deps = append(deps, burninv1alpha1.DependencySpec{
+			deps = append(deps, crev1alpha1.DependencySpec{
 				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
 			})
 		}
@@ -123,9 +123,9 @@ func TestDetectCrossRefs(t *testing.T) {
 			return err
 		}
 
-		var deps []burninv1alpha1.DependencySpec
+		var deps []crev1alpha1.DependencySpec
 		for _, d := range input.Deps {
-			deps = append(deps, burninv1alpha1.DependencySpec{
+			deps = append(deps, crev1alpha1.DependencySpec{
 				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
 			})
 		}
@@ -201,9 +201,9 @@ func TestBuildReplacementMap(t *testing.T) {
 			return err
 		}
 
-		var deps []burninv1alpha1.DependencySpec
+		var deps []crev1alpha1.DependencySpec
 		for _, d := range input.Deps {
-			dep := burninv1alpha1.DependencySpec{
+			dep := crev1alpha1.DependencySpec{
 				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
 			}
 			deps = append(deps, dep)
@@ -277,7 +277,7 @@ func TestSuffixJobSpec(t *testing.T) {
 			return err
 		}
 
-		spec := &burninv1alpha1.JobSpec{}
+		spec := &crev1alpha1.JobSpec{}
 		if err := json.Unmarshal([]byte(input.Spec), spec); err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func TestReverseDependencyRefs(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Refs []burninv1alpha1.DependencyResourceRef `yaml:"refs"`
+			Refs []crev1alpha1.DependencyResourceRef `yaml:"refs"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -366,7 +366,7 @@ func TestReverseDependencyRefs(t *testing.T) {
 		// reversal is verified too, not just ordering.
 		got := reverseDependencyRefs(input.Refs)
 		if got == nil {
-			got = []burninv1alpha1.DependencyResourceRef{}
+			got = []crev1alpha1.DependencyResourceRef{}
 		}
 
 		data, err := json.MarshalIndent(got, "", "  ")

--- a/pkg/controller/workflow_detect.go
+++ b/pkg/controller/workflow_detect.go
@@ -17,8 +17,8 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/gpu"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/gpu"
 )
 
 const (
@@ -168,7 +168,7 @@ type OverrideContext struct {
 
 // buildOverrideContext creates an OverrideContext from available workflow data.
 // Pass nil for nodes when they haven't been discovered yet.
-func buildOverrideContext(spec *burninv1alpha1.WorkflowSpec, orch *burninv1alpha1.OrchestrationStatus, nodes []corev1.Node) OverrideContext {
+func buildOverrideContext(spec *crev1alpha1.WorkflowSpec, orch *crev1alpha1.OrchestrationStatus, nodes []corev1.Node) OverrideContext {
 	octx := OverrideContext{
 		Platform:        orch.DetectedPlatform,
 		GPUArchitecture: orch.DetectedGPUArchitecture,
@@ -183,7 +183,7 @@ func buildOverrideContext(spec *burninv1alpha1.WorkflowSpec, orch *burninv1alpha
 }
 
 // detectWorkloadKind returns the workload kind based on which field is set.
-func detectWorkloadKind(spec *burninv1alpha1.WorkloadSpec) string {
+func detectWorkloadKind(spec *crev1alpha1.WorkloadSpec) string {
 	switch {
 	case spec.TrainJob != nil:
 		return "TrainJob"
@@ -208,7 +208,7 @@ func countDomains(nodes []corev1.Node, topologyKey string) int {
 
 // matchesWhen evaluates a WhenSpec against the override context.
 // An empty WhenSpec always matches. Returns an error if CEL evaluation fails.
-func matchesWhen(when burninv1alpha1.WhenSpec, octx OverrideContext) (bool, error) {
+func matchesWhen(when crev1alpha1.WhenSpec, octx OverrideContext) (bool, error) {
 	if when.Platform != nil && !matchesStringSpec(*when.Platform, octx.Platform) {
 		return false, nil
 	}
@@ -242,7 +242,7 @@ func matchesWhen(when burninv1alpha1.WhenSpec, octx OverrideContext) (bool, erro
 }
 
 // matchesStringSpec evaluates a StringMatchSpec against a value.
-func matchesStringSpec(spec burninv1alpha1.StringMatchSpec, value string) bool {
+func matchesStringSpec(spec crev1alpha1.StringMatchSpec, value string) bool {
 	if spec.Equals != "" && spec.Equals != value {
 		return false
 	}
@@ -261,7 +261,7 @@ func matchesStringSpec(spec burninv1alpha1.StringMatchSpec, value string) bool {
 }
 
 // matchesIntSpec evaluates an IntMatchSpec against a value.
-func matchesIntSpec(spec burninv1alpha1.IntMatchSpec, value int) bool {
+func matchesIntSpec(spec crev1alpha1.IntMatchSpec, value int) bool {
 	if spec.Equals != nil && *spec.Equals != value {
 		return false
 	}
@@ -363,7 +363,7 @@ func evaluateExpression(expr string, octx OverrideContext) (bool, error) {
 // by apiVersion/kind/name are merged using recursive map merge with named array
 // merge (arrays of objects with a "name" field are matched and merged by name);
 // unmatched overrides are appended.
-func applyOverrides(spec *burninv1alpha1.WorkflowSpec, octx OverrideContext) error {
+func applyOverrides(spec *crev1alpha1.WorkflowSpec, octx OverrideContext) error {
 	for i, o := range spec.Overrides {
 		matches, err := matchesWhen(o.When, octx)
 		if err != nil {
@@ -417,7 +417,7 @@ func depKey(raw []byte) (string, string, string) {
 // mergeOrAppendDependency merges an override dependency into a matching base
 // dependency (by apiVersion/kind/name) using recursive map merge with named
 // array merge. If no match is found, the override is appended as a new dependency.
-func mergeOrAppendDependency(spec *burninv1alpha1.WorkflowSpec, override burninv1alpha1.DependencySpec) error {
+func mergeOrAppendDependency(spec *crev1alpha1.WorkflowSpec, override crev1alpha1.DependencySpec) error {
 	oAPI, oKind, oName := depKey(override.Raw)
 
 	for i, base := range spec.Dependencies {
@@ -452,7 +452,7 @@ func mergeOrAppendDependency(spec *burninv1alpha1.WorkflowSpec, override burninv
 // corev1.Container.Env is merged by name). Fields without tags (e.g.,
 // Kubeflow Trainer.Env) fall back to list replacement, matching ADR-012's
 // documented "lists replace" semantics.
-func mergeJobTemplate(base *burninv1alpha1.JobTemplateSpec, override *apiextensionsv1.JSON) error {
+func mergeJobTemplate(base *crev1alpha1.JobTemplateSpec, override *apiextensionsv1.JSON) error {
 	baseJSON, err := json.Marshal(base)
 	if err != nil {
 		return fmt.Errorf("marshal base: %w", err)
@@ -463,14 +463,14 @@ func mergeJobTemplate(base *burninv1alpha1.JobTemplateSpec, override *apiextensi
 	}
 	// Zero out base before unmarshaling so fields deleted by the patch
 	// (via null) don't retain their previous values.
-	*base = burninv1alpha1.JobTemplateSpec{}
+	*base = crev1alpha1.JobTemplateSpec{}
 	return json.Unmarshal(merged, base)
 }
 
 // patchJobTemplate applies an RFC 6902 JSON Patch to the base jobTemplate.
 // This enables precise operations like removing a specific env var by index,
 // testing a precondition before patching, or adding at a specific array position.
-func patchJobTemplate(base *burninv1alpha1.JobTemplateSpec, patch *apiextensionsv1.JSON) error {
+func patchJobTemplate(base *crev1alpha1.JobTemplateSpec, patch *apiextensionsv1.JSON) error {
 	decodedPatch, err := jsonpatch.DecodePatch(patch.Raw)
 	if err != nil {
 		return fmt.Errorf("invalid JSON Patch: %w", err)
@@ -483,7 +483,7 @@ func patchJobTemplate(base *burninv1alpha1.JobTemplateSpec, patch *apiextensions
 	if err != nil {
 		return fmt.Errorf("apply JSON Patch: %w", err)
 	}
-	*base = burninv1alpha1.JobTemplateSpec{}
+	*base = crev1alpha1.JobTemplateSpec{}
 	return json.Unmarshal(patched, base)
 }
 
@@ -578,7 +578,7 @@ func indexByName(items []any) ([]string, map[string]map[string]any) {
 
 // summarizeWhen produces a human-readable summary of a WhenSpec.
 // Example: "gpuArchitecture=h100, platform in [aws,gcp]"
-func summarizeWhen(when burninv1alpha1.WhenSpec) string {
+func summarizeWhen(when crev1alpha1.WhenSpec) string {
 	var parts []string
 	if when.GPUArchitecture != nil {
 		parts = append(parts, "gpuArchitecture="+summarizeStringSpec(*when.GPUArchitecture))
@@ -614,7 +614,7 @@ func summarizeWhen(when burninv1alpha1.WhenSpec) string {
 }
 
 // summarizeStringSpec returns a compact string representation of a StringMatchSpec.
-func summarizeStringSpec(spec burninv1alpha1.StringMatchSpec) string {
+func summarizeStringSpec(spec crev1alpha1.StringMatchSpec) string {
 	if spec.Equals != "" {
 		return spec.Equals
 	}
@@ -628,7 +628,7 @@ func summarizeStringSpec(spec burninv1alpha1.StringMatchSpec) string {
 }
 
 // summarizeIntSpec returns a compact string representation of an IntMatchSpec.
-func summarizeIntSpec(spec burninv1alpha1.IntMatchSpec) string {
+func summarizeIntSpec(spec crev1alpha1.IntMatchSpec) string {
 	var parts []string
 	if spec.Equals != nil {
 		parts = append(parts, fmt.Sprintf("=%d", *spec.Equals))
@@ -645,7 +645,7 @@ func summarizeIntSpec(spec burninv1alpha1.IntMatchSpec) string {
 // applyPreCommands wraps the trainer command in a /bin/bash -c script that
 // runs preCommands in order before exec-ing the original command. Applied after
 // all jobTemplate patches so it always wraps the final resolved command.
-func applyPreCommands(jt *burninv1alpha1.JobTemplateSpec, preCommands []string) {
+func applyPreCommands(jt *crev1alpha1.JobTemplateSpec, preCommands []string) {
 	if len(preCommands) == 0 {
 		return
 	}
@@ -668,7 +668,7 @@ func applyPreCommands(jt *burninv1alpha1.JobTemplateSpec, preCommands []string) 
 
 // summarizePatches returns a compact description of what an override modifies.
 // Example: "jobTemplate, 2 dependencies"
-func summarizePatches(o burninv1alpha1.OverrideSpec) string {
+func summarizePatches(o crev1alpha1.OverrideSpec) string {
 	var parts []string
 	if o.JobTemplate != nil {
 		parts = append(parts, "jobTemplate")
@@ -690,7 +690,7 @@ func summarizePatches(o burninv1alpha1.OverrideSpec) string {
 
 // mergeOrchestration applies non-nil override fields onto the base orchestration spec.
 // Nil fields in the override are skipped (base value preserved).
-func mergeOrchestration(base *burninv1alpha1.OrchestrationSpec, override *burninv1alpha1.OrchestrationOverrideSpec) {
+func mergeOrchestration(base *crev1alpha1.OrchestrationSpec, override *crev1alpha1.OrchestrationOverrideSpec) {
 	if override.Target != nil {
 		base.Target = override.Target
 	}
@@ -707,8 +707,8 @@ func mergeOrchestration(base *burninv1alpha1.OrchestrationSpec, override *burnin
 
 // applyOverridesWithTracking applies overrides and returns tracking info about which overrides matched.
 // This is used by the authoritative call site in discoverAndPartition to populate status and emit events.
-func applyOverridesWithTracking(spec *burninv1alpha1.WorkflowSpec, octx OverrideContext) ([]burninv1alpha1.AppliedOverride, error) {
-	var applied []burninv1alpha1.AppliedOverride
+func applyOverridesWithTracking(spec *crev1alpha1.WorkflowSpec, octx OverrideContext) ([]crev1alpha1.AppliedOverride, error) {
+	var applied []crev1alpha1.AppliedOverride
 	for i, o := range spec.Overrides {
 		matches, err := matchesWhen(o.When, octx)
 		if err != nil {
@@ -746,7 +746,7 @@ func applyOverridesWithTracking(spec *burninv1alpha1.WorkflowSpec, octx Override
 		afterJSON, _ := json.Marshal(spec)
 		noOp := string(beforeJSON) == string(afterJSON)
 
-		applied = append(applied, burninv1alpha1.AppliedOverride{
+		applied = append(applied, crev1alpha1.AppliedOverride{
 			Index:   i,
 			When:    summarizeWhen(o.When),
 			Patches: summarizePatches(o),

--- a/pkg/controller/workflow_detect_aws_gb300_test.go
+++ b/pkg/controller/workflow_detect_aws_gb300_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
 )
 
 // TestAWSGB300EFAStripInvariant asserts that every NCCL-using catalog entry,
@@ -42,7 +42,7 @@ func TestAWSGB300EFAStripInvariant(t *testing.T) {
 		{NodesPerJob: 128, GpusPerNode: 4, GPUArchitecture: "gb300"},
 	}
 
-	target := burninv1alpha1.TargetSpec{
+	target := crev1alpha1.TargetSpec{
 		NodeSelector: map[string]string{
 			"nvidia.com/gpu.product": "NVIDIA-GB300",
 		},
@@ -125,9 +125,9 @@ func mustContain(t *testing.T, set []string, want string) {
 // successful WorkflowSpec. Returns the last build error if every config fails.
 func buildWithFallback(
 	entry *catalog.Entry,
-	target burninv1alpha1.TargetSpec,
+	target crev1alpha1.TargetSpec,
 	configs []catalog.BuildConfig,
-) (burninv1alpha1.WorkflowSpec, error) {
+) (crev1alpha1.WorkflowSpec, error) {
 	var lastErr error
 	for _, cfg := range configs {
 		spec, err := entry.Build(target, cfg)
@@ -136,7 +136,7 @@ func buildWithFallback(
 		}
 		lastErr = err
 	}
-	return burninv1alpha1.WorkflowSpec{}, lastErr
+	return crev1alpha1.WorkflowSpec{}, lastErr
 }
 
 // entryUsesNCCL returns true if the entry's rendered trainer plausibly loads
@@ -147,7 +147,7 @@ func buildWithFallback(
 //     thought about platform-specific behavior, which only matters when
 //     networking/NCCL is involved. This catches Nemotron entries whose base
 //     trainer.args are just "/config/train.sh".
-func entryUsesNCCL(spec burninv1alpha1.WorkflowSpec) bool {
+func entryUsesNCCL(spec crev1alpha1.WorkflowSpec) bool {
 	if spec.JobTemplate.Spec.Workload.TrainJob != nil &&
 		spec.JobTemplate.Spec.Workload.TrainJob.Trainer != nil {
 		trainer := spec.JobTemplate.Spec.Workload.TrainJob.Trainer
@@ -187,7 +187,7 @@ func entryUsesNCCL(spec burninv1alpha1.WorkflowSpec) bool {
 // hasAWSGB300When reports whether a When clause selects (platform=aws,
 // gpuArchitecture=gb300) — used to identify entries that have explicit
 // AWS+GB300 behavior even when the base trainer args do not name NCCL.
-func hasAWSGB300When(w burninv1alpha1.WhenSpec) bool {
+func hasAWSGB300When(w crev1alpha1.WhenSpec) bool {
 	if w.Platform == nil || w.GPUArchitecture == nil {
 		return false
 	}
@@ -221,7 +221,7 @@ func hasNCCLMarker(s string) bool {
 
 // efaStripViolations returns a list of human-readable violations in the
 // trainer container. Empty result means the EFA stack is properly stripped.
-func efaStripViolations(spec burninv1alpha1.WorkflowSpec) []string {
+func efaStripViolations(spec crev1alpha1.WorkflowSpec) []string {
 	var problems []string
 	if spec.JobTemplate.Spec.Workload.TrainJob == nil {
 		return problems
@@ -279,7 +279,7 @@ func efaStripViolations(spec burninv1alpha1.WorkflowSpec) []string {
 // (in TrainingRuntime worker args or ConfigMap data) that contains an
 // EFA-strip preamble. Used by the multi-node comm pattern where strip lives
 // in the sshd worker container's args, not the trainer's args.
-func depsHaveEFAStrip(deps []burninv1alpha1.DependencySpec) bool {
+func depsHaveEFAStrip(deps []crev1alpha1.DependencySpec) bool {
 	for _, dep := range deps {
 		// The strip preamble is plain text in the JSON-encoded RawExtension
 		// regardless of which container/configmap it lives in, so a flat

--- a/pkg/controller/workflow_detect_export.go
+++ b/pkg/controller/workflow_detect_export.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // DetectPlatform is the exported version of detectPlatform for use by CLI tools.
@@ -23,12 +23,12 @@ func DetectGPUArchitecture(nodes []corev1.Node) string {
 }
 
 // BuildOverrideContext is the exported version of buildOverrideContext for use by CLI tools.
-func BuildOverrideContext(spec *burninv1alpha1.WorkflowSpec, orch *burninv1alpha1.OrchestrationStatus, nodes []corev1.Node) OverrideContext {
+func BuildOverrideContext(spec *crev1alpha1.WorkflowSpec, orch *crev1alpha1.OrchestrationStatus, nodes []corev1.Node) OverrideContext {
 	return buildOverrideContext(spec, orch, nodes)
 }
 
 // ApplyOverridesWithTracking is the exported version of applyOverridesWithTracking for use by CLI tools.
-func ApplyOverridesWithTracking(spec *burninv1alpha1.WorkflowSpec, octx OverrideContext) ([]burninv1alpha1.AppliedOverride, error) {
+func ApplyOverridesWithTracking(spec *crev1alpha1.WorkflowSpec, octx OverrideContext) ([]crev1alpha1.AppliedOverride, error) {
 	return applyOverridesWithTracking(spec, octx)
 }
 
@@ -38,7 +38,7 @@ func ApplyOverridesWithTracking(spec *burninv1alpha1.WorkflowSpec, octx Override
 // the Workflow reconciler records coverage on status; CLI callers want the
 // nodes a run would actually use. Widen this if a CLI ever needs to report what
 // was skipped.
-func DiscoverTargetNodes(ctx context.Context, reader client.Reader, target *burninv1alpha1.TargetSpec) ([]corev1.Node, error) {
+func DiscoverTargetNodes(ctx context.Context, reader client.Reader, target *crev1alpha1.TargetSpec) ([]corev1.Node, error) {
 	nodes, _, err := discoverTargetNodes(ctx, reader, target)
 	return nodes, err
 }

--- a/pkg/controller/workflow_detect_test.go
+++ b/pkg/controller/workflow_detect_test.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func TestDetectPlatform(t *testing.T) {
@@ -138,13 +138,13 @@ func TestMatchesWhen(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			When            burninv1alpha1.WhenSpec `yaml:"when"`
-			Platform        string                  `yaml:"platform"`
-			GPUArchitecture string                  `yaml:"gpuArchitecture"`
-			WorkloadKind    string                  `yaml:"workloadKind"`
-			TopologyMode    string                  `yaml:"topologyMode"`
-			DomainCount     int                     `yaml:"domainCount"`
-			Config          *apiextensionsv1.JSON   `yaml:"config"`
+			When            crev1alpha1.WhenSpec  `yaml:"when"`
+			Platform        string                `yaml:"platform"`
+			GPUArchitecture string                `yaml:"gpuArchitecture"`
+			WorkloadKind    string                `yaml:"workloadKind"`
+			TopologyMode    string                `yaml:"topologyMode"`
+			DomainCount     int                   `yaml:"domainCount"`
+			Config          *apiextensionsv1.JSON `yaml:"config"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -181,13 +181,13 @@ func TestApplyOverrides(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Spec            burninv1alpha1.WorkflowSpec `yaml:"spec"`
-			Platform        string                      `yaml:"platform"`
-			GPUArchitecture string                      `yaml:"gpuArchitecture"`
-			WorkloadKind    string                      `yaml:"workloadKind"`
-			TopologyMode    string                      `yaml:"topologyMode"`
-			DomainCount     int                         `yaml:"domainCount"`
-			Config          *apiextensionsv1.JSON       `yaml:"config"`
+			Spec            crev1alpha1.WorkflowSpec `yaml:"spec"`
+			Platform        string                   `yaml:"platform"`
+			GPUArchitecture string                   `yaml:"gpuArchitecture"`
+			WorkloadKind    string                   `yaml:"workloadKind"`
+			TopologyMode    string                   `yaml:"topologyMode"`
+			DomainCount     int                      `yaml:"domainCount"`
+			Config          *apiextensionsv1.JSON    `yaml:"config"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -221,7 +221,7 @@ func TestDetectWorkloadKind(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Workload burninv1alpha1.WorkloadSpec `yaml:"workload"`
+			Workload crev1alpha1.WorkloadSpec `yaml:"workload"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -247,8 +247,8 @@ func TestMatchesIntSpec(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Spec  burninv1alpha1.IntMatchSpec `yaml:"spec"`
-			Value int                         `yaml:"value"`
+			Spec  crev1alpha1.IntMatchSpec `yaml:"spec"`
+			Value int                      `yaml:"value"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -274,7 +274,7 @@ func TestSummarizeWhen(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			When burninv1alpha1.WhenSpec `yaml:"when"`
+			When crev1alpha1.WhenSpec `yaml:"when"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -300,9 +300,9 @@ func TestApplyOverridesWithTracking(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Spec            burninv1alpha1.WorkflowSpec `yaml:"spec"`
-			Platform        string                      `yaml:"platform"`
-			GPUArchitecture string                      `yaml:"gpuArchitecture"`
+			Spec            crev1alpha1.WorkflowSpec `yaml:"spec"`
+			Platform        string                   `yaml:"platform"`
+			GPUArchitecture string                   `yaml:"gpuArchitecture"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -318,7 +318,7 @@ func TestApplyOverridesWithTracking(t *testing.T) {
 		}
 
 		data, err := json.MarshalIndent(struct {
-			Applied []burninv1alpha1.AppliedOverride `json:"applied"`
+			Applied []crev1alpha1.AppliedOverride `json:"applied"`
 		}{Applied: applied}, "", "  ")
 		if err != nil {
 			return err

--- a/pkg/controller/workflow_nodes_ref_test.go
+++ b/pkg/controller/workflow_nodes_ref_test.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 func TestApplySucceededNodesRef(t *testing.T) {
@@ -20,7 +20,7 @@ func TestApplySucceededNodesRef(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *burninv1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {
+		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *crev1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {
 			fn := applySucceededNodesRef(ref)
 			changed := fn != nil && fn(w)
 			return changed, w.Status.SucceededNodesRef
@@ -34,7 +34,7 @@ func TestApplyFailedNodesRef(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *burninv1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {
+		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *crev1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {
 			fn := applyFailedNodesRef(ref)
 			changed := fn != nil && fn(w)
 			return changed, w.Status.FailedNodesRef
@@ -42,10 +42,10 @@ func TestApplyFailedNodesRef(t *testing.T) {
 	})
 }
 
-func runApplyNodesRefCase(tc *testutil.TestCase, apply func(*corev1.TypedLocalObjectReference, *burninv1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference)) error {
+func runApplyNodesRefCase(tc *testutil.TestCase, apply func(*corev1.TypedLocalObjectReference, *crev1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference)) error {
 	var input struct {
 		Ref      *corev1.TypedLocalObjectReference `json:"ref"`
-		Workflow burninv1alpha1.Workflow           `json:"workflow"`
+		Workflow crev1alpha1.Workflow              `json:"workflow"`
 	}
 	if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 		return err

--- a/pkg/controller/workflow_nodeshortfall_test.go
+++ b/pkg/controller/workflow_nodeshortfall_test.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // TestNotEnoughNodesMessage covers the wording of a node shortfall. The bare

--- a/pkg/controller/workloadrun_controller.go
+++ b/pkg/controller/workloadrun_controller.go
@@ -21,10 +21,10 @@ import (
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/platform"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/platform"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workload"
 )
 
 // WorkloadRunReconciler reconciles a WorkloadRun object.
@@ -45,7 +45,7 @@ const workloadRunRequeueInterval = 15 * time.Second
 func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	var run burninv1alpha1.WorkloadRun
+	var run crev1alpha1.WorkloadRun
 	if err := r.Get(ctx, req.NamespacedName, &run); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -54,8 +54,8 @@ func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// If terminal, nothing to do.
-	if condIsTrue(run.Status.Conditions, burninv1alpha1.WorkloadRunSucceeded) ||
-		condIsTrue(run.Status.Conditions, burninv1alpha1.WorkloadRunFailed) {
+	if condIsTrue(run.Status.Conditions, crev1alpha1.WorkloadRunSucceeded) ||
+		condIsTrue(run.Status.Conditions, crev1alpha1.WorkloadRunFailed) {
 		return ctrl.Result{}, nil
 	}
 
@@ -70,14 +70,14 @@ func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Guard: exec is the default framework; spec.framework.exec must be non-nil when
 	// no other framework is configured, or buildJobTemplate will nil-dereference.
 	if run.Spec.Framework.Torch == nil && run.Spec.Framework.MPI == nil && run.Spec.Framework.Exec == nil {
-		r.setWorkloadRunCondition(&run, burninv1alpha1.WorkloadRunFailed, ReasonBuildFailed,
+		r.setWorkloadRunCondition(&run, crev1alpha1.WorkloadRunFailed, ReasonBuildFailed,
 			fmt.Sprintf("workloadrun %s: exec framework selected but spec.framework.exec is nil", run.Name))
 		return ctrl.Result{}, r.Status().Update(ctx, &run)
 	}
 
 	workflowSpec := r.buildWorkflowSpec(ctx, &run)
 
-	workflow := &burninv1alpha1.Workflow{
+	workflow := &crev1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      run.Name,
 			Namespace: run.Namespace,
@@ -101,11 +101,11 @@ func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Update status with workflow ref.
-	run.Status.WorkflowRef = &burninv1alpha1.WorkflowReference{
+	run.Status.WorkflowRef = &crev1alpha1.WorkflowReference{
 		Name:      workflow.Name,
 		Namespace: workflow.Namespace,
 	}
-	r.setWorkloadRunCondition(&run, burninv1alpha1.WorkloadRunInProgress, ReasonWorkflowCreated,
+	r.setWorkloadRunCondition(&run, crev1alpha1.WorkloadRunInProgress, ReasonWorkflowCreated,
 		fmt.Sprintf("Workflow %s created", workflow.Name))
 	if err := r.Status().Update(ctx, &run); err != nil {
 		return ctrl.Result{}, err
@@ -116,12 +116,12 @@ func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 // mirrorWorkflowStatus copies the Workflow's terminal conditions to the WorkloadRun.
-func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *burninv1alpha1.WorkloadRun) (ctrl.Result, error) {
-	var workflow burninv1alpha1.Workflow
+func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *crev1alpha1.WorkloadRun) (ctrl.Result, error) {
+	var workflow crev1alpha1.Workflow
 	key := client.ObjectKey{Name: run.Status.WorkflowRef.Name, Namespace: run.Namespace}
 	if err := r.Get(ctx, key, &workflow); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.setWorkloadRunCondition(run, burninv1alpha1.WorkloadRunFailed, ReasonWorkflowDeleted, "Workflow was deleted")
+			r.setWorkloadRunCondition(run, crev1alpha1.WorkloadRunFailed, ReasonWorkflowDeleted, "Workflow was deleted")
 			return ctrl.Result{}, r.Status().Update(ctx, run)
 		}
 		return ctrl.Result{}, err
@@ -138,21 +138,21 @@ func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *b
 	run.Status.FailedNodesRef = workflow.Status.FailedNodesRef
 
 	// Mirror terminal conditions.
-	if condIsTrue(workflow.Status.Conditions, burninv1alpha1.WorkflowSucceeded) {
-		r.setWorkloadRunCondition(run, burninv1alpha1.WorkloadRunSucceeded, ReasonWorkflowSucceeded, "Workflow completed successfully")
+	if condIsTrue(workflow.Status.Conditions, crev1alpha1.WorkflowSucceeded) {
+		r.setWorkloadRunCondition(run, crev1alpha1.WorkloadRunSucceeded, ReasonWorkflowSucceeded, "Workflow completed successfully")
 		return ctrl.Result{}, r.Status().Update(ctx, run)
 	}
-	if condIsTrue(workflow.Status.Conditions, burninv1alpha1.WorkflowFailed) {
-		msg := condMsg(workflow.Status.Conditions, burninv1alpha1.WorkflowFailed)
-		r.setWorkloadRunCondition(run, burninv1alpha1.WorkloadRunFailed, ReasonWorkflowFailed, msg)
+	if condIsTrue(workflow.Status.Conditions, crev1alpha1.WorkflowFailed) {
+		msg := condMsg(workflow.Status.Conditions, crev1alpha1.WorkflowFailed)
+		r.setWorkloadRunCondition(run, crev1alpha1.WorkloadRunFailed, ReasonWorkflowFailed, msg)
 		return ctrl.Result{}, r.Status().Update(ctx, run)
 	}
 
 	// Mirror validation failed (independent condition).
-	if condIsTrue(workflow.Status.Conditions, burninv1alpha1.WorkflowValidationFailed) {
-		msg := condMsg(workflow.Status.Conditions, burninv1alpha1.WorkflowValidationFailed)
+	if condIsTrue(workflow.Status.Conditions, crev1alpha1.WorkflowValidationFailed) {
+		msg := condMsg(workflow.Status.Conditions, crev1alpha1.WorkflowValidationFailed)
 		meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-			Type:    burninv1alpha1.WorkloadRunValidationFailed,
+			Type:    crev1alpha1.WorkloadRunValidationFailed,
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonThresholdViolation,
 			Message: msg,
@@ -166,11 +166,11 @@ func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *b
 }
 
 // setWorkloadRunCondition sets a condition with mutual exclusivity for execution conditions.
-func (r *WorkloadRunReconciler) setWorkloadRunCondition(run *burninv1alpha1.WorkloadRun, condType, reason, message string) {
+func (r *WorkloadRunReconciler) setWorkloadRunCondition(run *crev1alpha1.WorkloadRun, condType, reason, message string) {
 	executionTypes := []string{
-		burninv1alpha1.WorkloadRunInProgress,
-		burninv1alpha1.WorkloadRunSucceeded,
-		burninv1alpha1.WorkloadRunFailed,
+		crev1alpha1.WorkloadRunInProgress,
+		crev1alpha1.WorkloadRunSucceeded,
+		crev1alpha1.WorkloadRunFailed,
 	}
 	for _, t := range executionTypes {
 		status := metav1.ConditionFalse
@@ -190,7 +190,7 @@ func (r *WorkloadRunReconciler) setWorkloadRunCondition(run *burninv1alpha1.Work
 }
 
 // buildWorkflowSpec translates a WorkloadRunSpec into a WorkflowSpec.
-func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burninv1alpha1.WorkloadRun) *burninv1alpha1.WorkflowSpec {
+func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *crev1alpha1.WorkloadRun) *crev1alpha1.WorkflowSpec {
 	spec := &run.Spec
 
 	// Best-effort node discovery for GPU + platform defaults. The Workflow
@@ -276,7 +276,7 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 		rtCfg.GangSchedulerQueue = spec.GangScheduler.Queue
 	}
 
-	var runtimeDep burninv1alpha1.DependencySpec
+	var runtimeDep crev1alpha1.DependencySpec
 	switch frameworkType {
 	case FrameworkTorch:
 		runtimeDep = platform.BuildTorchRuntime(rtCfg)
@@ -287,7 +287,7 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 	}
 
 	// Build dependencies list.
-	deps := []burninv1alpha1.DependencySpec{runtimeDep}
+	deps := []crev1alpha1.DependencySpec{runtimeDep}
 
 	// ConfigMap dependency (if inline config provided).
 	if spec.Config != nil && len(spec.Config.Inline) > 0 {
@@ -331,13 +331,13 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 
 	// Extract the base OverrideSpec slice for the WorkflowSpec and append
 	// user's custom overrides.
-	overrides := make([]burninv1alpha1.OverrideSpec, 0, len(wrOverrides)+len(spec.Overrides))
+	overrides := make([]crev1alpha1.OverrideSpec, 0, len(wrOverrides)+len(spec.Overrides))
 	for _, o := range wrOverrides {
 		overrides = append(overrides, o.OverrideSpec)
 	}
 	overrides = append(overrides, spec.Overrides...)
 
-	workflowSpec := &burninv1alpha1.WorkflowSpec{
+	workflowSpec := &crev1alpha1.WorkflowSpec{
 		JobTemplate:   *jobTemplate,
 		Orchestration: *orch,
 		Dependencies:  deps,
@@ -346,10 +346,10 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 
 	// Build validation spec.
 	if len(spec.Thresholds) > 0 {
-		workflowSpec.Validation = &burninv1alpha1.ValidationSpec{
-			Performance: &burninv1alpha1.PerformanceValidationSpec{
+		workflowSpec.Validation = &crev1alpha1.ValidationSpec{
+			Performance: &crev1alpha1.PerformanceValidationSpec{
 				Enabled: true,
-				Thresholds: &burninv1alpha1.ThresholdSpec{
+				Thresholds: &crev1alpha1.ThresholdSpec{
 					Thresholds: spec.Thresholds,
 				},
 			},
@@ -360,7 +360,7 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *burn
 }
 
 // buildJobTemplate constructs the JobTemplateSpec for the workload.
-func (r *WorkloadRunReconciler) buildJobTemplate(run *burninv1alpha1.WorkloadRun, frameworkType string, gpusPerNode int32) *burninv1alpha1.JobTemplateSpec {
+func (r *WorkloadRunReconciler) buildJobTemplate(run *crev1alpha1.WorkloadRun, frameworkType string, gpusPerNode int32) *crev1alpha1.JobTemplateSpec {
 	spec := &run.Spec
 
 	// Build trainer spec based on framework.
@@ -421,12 +421,12 @@ func (r *WorkloadRunReconciler) buildJobTemplate(run *burninv1alpha1.WorkloadRun
 
 	workload.SetImagePullSecrets(trainJobSpec, spec.ImagePullSecrets)
 
-	jobSpec := burninv1alpha1.JobSpec{
-		Workload: burninv1alpha1.WorkloadSpec{
+	jobSpec := crev1alpha1.JobSpec{
+		Workload: crev1alpha1.WorkloadSpec{
 			TrainJob: trainJobSpec,
 		},
-		NodeHealthMonitor: &burninv1alpha1.NodeHealthMonitor{
-			CEL: &burninv1alpha1.CELNodeHealthCheck{
+		NodeHealthMonitor: &crev1alpha1.NodeHealthMonitor{
+			CEL: &crev1alpha1.CELNodeHealthCheck{
 				Expression: "node.spec.unschedulable == true",
 			},
 		},
@@ -445,19 +445,19 @@ func (r *WorkloadRunReconciler) buildJobTemplate(run *burninv1alpha1.WorkloadRun
 		if spec.Checkpoint.MaxRestarts != nil {
 			maxRestarts = *spec.Checkpoint.MaxRestarts
 		}
-		jobSpec.Checkpoint = &burninv1alpha1.CheckpointConfig{
+		jobSpec.Checkpoint = &crev1alpha1.CheckpointConfig{
 			PVCName:     pvcName,
 			MaxRestarts: &maxRestarts,
 		}
 	}
 
-	return &burninv1alpha1.JobTemplateSpec{
+	return &crev1alpha1.JobTemplateSpec{
 		Spec: jobSpec,
 	}
 }
 
 // buildWRConfigMapDep creates a ConfigMap dependency from inline config data.
-func buildWRConfigMapDep(name string, data map[string]string) burninv1alpha1.DependencySpec {
+func buildWRConfigMapDep(name string, data map[string]string) crev1alpha1.DependencySpec {
 	cm := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
@@ -468,11 +468,11 @@ func buildWRConfigMapDep(name string, data map[string]string) burninv1alpha1.Dep
 		"data": data,
 	}
 	raw, _ := json.Marshal(cm)
-	return burninv1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
+	return crev1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
 }
 
 // buildWRPVCDep creates a PVC dependency for checkpoint storage.
-func buildWRPVCDep(name string, checkpoint *burninv1alpha1.WorkloadRunCheckpoint) burninv1alpha1.DependencySpec {
+func buildWRPVCDep(name string, checkpoint *crev1alpha1.WorkloadRunCheckpoint) crev1alpha1.DependencySpec {
 	pvc := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "PersistentVolumeClaim",
@@ -489,7 +489,7 @@ func buildWRPVCDep(name string, checkpoint *burninv1alpha1.WorkloadRunCheckpoint
 		pvc["spec"].(map[string]any)["storageClassName"] = *checkpoint.StorageClassName
 	}
 	raw, _ := json.Marshal(pvc)
-	return burninv1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
+	return crev1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
 }
 
 // resolveWRTimeout turns a user-supplied timeoutPerJob into a duration, falling
@@ -509,8 +509,8 @@ func resolveWRTimeout(v string) *metav1.Duration {
 }
 
 // buildWROrchestration constructs the OrchestrationSpec from WorkloadRunSpec.
-func buildWROrchestration(spec *burninv1alpha1.WorkloadRunSpec) *burninv1alpha1.OrchestrationSpec {
-	orch := &burninv1alpha1.OrchestrationSpec{
+func buildWROrchestration(spec *crev1alpha1.WorkloadRunSpec) *crev1alpha1.OrchestrationSpec {
+	orch := &crev1alpha1.OrchestrationSpec{
 		Target:     spec.Target,
 		Iterations: 1,
 	}
@@ -519,18 +519,18 @@ func buildWROrchestration(spec *burninv1alpha1.WorkloadRunSpec) *burninv1alpha1.
 			orch.Iterations = int(*spec.Orchestration.RepeatCount)
 		}
 		switch spec.Orchestration.TestScale {
-		case burninv1alpha1.TestScaleIntraNode:
+		case crev1alpha1.TestScaleIntraNode:
 			// Handled by nodesPerJobForScale when the workload is built:
 			// one node per Job, so the Workflow makes one group per node.
 			// Nothing to set on the orchestration itself.
 		case "intra-rack":
 			// TopologyKey is set by platform override (workloadrun.yaml)
 			// to the platform's physical rack label.
-			orch.Topology = &burninv1alpha1.TopologySpec{
+			orch.Topology = &crev1alpha1.TopologySpec{
 				StrictDomain: true,
 			}
 		}
-		exec := burninv1alpha1.ExecutionSpec{}
+		exec := crev1alpha1.ExecutionSpec{}
 		if spec.Orchestration.MaxConcurrent != nil {
 			exec.MaxConcurrent = int(*spec.Orchestration.MaxConcurrent)
 		}
@@ -563,15 +563,15 @@ func condMsg(conditions []metav1.Condition, condType string) string {
 
 func (r *WorkloadRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&burninv1alpha1.WorkloadRun{}).
-		Owns(&burninv1alpha1.Workflow{}).
+		For(&crev1alpha1.WorkloadRun{}).
+		Owns(&crev1alpha1.Workflow{}).
 		Complete(r)
 }
 
 // applyWRPreTemplateOverrides applies overrides that must modify the WorkloadRun
 // spec before buildJobTemplate is called. Results are baked into the spec fields
 // consumed by buildJobTemplate (e.g. MPI.MpiArgs).
-func applyWRPreTemplateOverrides(spec *burninv1alpha1.WorkloadRunSpec, overrides []platform.WorkloadRunOverride, octx OverrideContext) {
+func applyWRPreTemplateOverrides(spec *crev1alpha1.WorkloadRunSpec, overrides []platform.WorkloadRunOverride, octx OverrideContext) {
 	for _, o := range overrides {
 		matches, err := matchesWhen(o.When, octx)
 		if err != nil || !matches {
@@ -586,7 +586,7 @@ func applyWRPreTemplateOverrides(spec *burninv1alpha1.WorkloadRunSpec, overrides
 // applyWRPostTemplateOverrides applies overrides that modify the already-built
 // JobTemplate. Results are stored in well-known trainer fields so they are
 // preserved in the Workflow CR without requiring new CRD schema fields.
-func applyWRPostTemplateOverrides(jt *burninv1alpha1.JobTemplateSpec, overrides []platform.WorkloadRunOverride, octx OverrideContext) {
+func applyWRPostTemplateOverrides(jt *crev1alpha1.JobTemplateSpec, overrides []platform.WorkloadRunOverride, octx OverrideContext) {
 	var preCommands []string
 	for _, o := range overrides {
 		matches, err := matchesWhen(o.When, octx)

--- a/pkg/controller/workloadrun_timeout_test.go
+++ b/pkg/controller/workloadrun_timeout_test.go
@@ -12,8 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // isJobTimedOut returns false when Execution.TimeoutPerJob is nil, so a
@@ -25,7 +25,7 @@ func TestWorkloadRunTimeout(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		var spec burninv1alpha1.WorkloadRunSpec
+		var spec crev1alpha1.WorkloadRunSpec
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &spec); err != nil {
 			return err
 		}
@@ -51,14 +51,14 @@ func TestWorkloadRunTimeout(t *testing.T) {
 // A single-value assertion: the bound only matters if isJobTimedOut reads it.
 func TestIsJobTimedOutUsesTheResolvedTimeout(t *testing.T) {
 	r := &WorkflowReconciler{}
-	orch := buildWROrchestration(&burninv1alpha1.WorkloadRunSpec{
-		Orchestration: &burninv1alpha1.WorkloadOrchestration{TimeoutPerJob: "1s"},
+	orch := buildWROrchestration(&crev1alpha1.WorkloadRunSpec{
+		Orchestration: &crev1alpha1.WorkloadOrchestration{TimeoutPerJob: "1s"},
 	})
-	wf := &burninv1alpha1.Workflow{Spec: burninv1alpha1.WorkflowSpec{Orchestration: *orch}}
+	wf := &crev1alpha1.Workflow{Spec: crev1alpha1.WorkflowSpec{Orchestration: *orch}}
 
 	started := metav1.NewTime(time.Now().Add(-2 * time.Second))
-	require.True(t, r.isJobTimedOut(wf, &burninv1alpha1.GroupStatus{StartTime: &started}))
+	require.True(t, r.isJobTimedOut(wf, &crev1alpha1.GroupStatus{StartTime: &started}))
 
 	fresh := metav1.NewTime(time.Now())
-	require.False(t, r.isJobTimedOut(wf, &burninv1alpha1.GroupStatus{StartTime: &fresh}))
+	require.False(t, r.isJobTimedOut(wf, &crev1alpha1.GroupStatus{StartTime: &fresh}))
 }

--- a/pkg/goodput/calculator_test.go
+++ b/pkg/goodput/calculator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/goodput/parser.go
+++ b/pkg/goodput/parser.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/numstr"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/numstr"
 )
 
 // k8sTimestampRe matches the RFC3339Nano prefix that kubelet injects when

--- a/pkg/goodput/parser_test.go
+++ b/pkg/goodput/parser_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/pkg/goodput/reader.go
+++ b/pkg/goodput/reader.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
 )
 
 // LogReader reads logs from Kubernetes pods and parses them using a ProfileParser.

--- a/pkg/goodput/reader_test.go
+++ b/pkg/goodput/reader_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/podlogs"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/podlogs"
 )
 
 // fakeLogFetcher returns pre-loaded log lines keyed by pod name.

--- a/pkg/gpu/product_test.go
+++ b/pkg/gpu/product_test.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 func TestParseProduct(t *testing.T) {

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -10,7 +10,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 func TestTruncate(t *testing.T) {

--- a/pkg/nccl/parser.go
+++ b/pkg/nccl/parser.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	v1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // Parser parses NCCL bandwidth test output using a compiled regex from a LogProfile.

--- a/pkg/nccl/parser_test.go
+++ b/pkg/nccl/parser_test.go
@@ -14,8 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	v1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	v1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // The lines below cover an NCCL INFO line, a two-line table header, data

--- a/pkg/nodemonitor/cel/detector.go
+++ b/pkg/nodemonitor/cel/detector.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/nodemonitor"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/nodemonitor"
 )
 
 const (

--- a/pkg/nodemonitor/cel/detector_test.go
+++ b/pkg/nodemonitor/cel/detector_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/nodemonitor/nodes.go
+++ b/pkg/nodemonitor/nodes.go
@@ -30,7 +30,7 @@ func NewNodeDiscoverer(c client.Client) *NodeDiscoverer {
 	return &NodeDiscoverer{client: c}
 }
 
-// DiscoverNodesForJob finds all nodes running pods associated with a burnin Job.
+// DiscoverNodesForJob finds all nodes running pods associated with a CRE Job.
 // It uses a field index on the cre.nvidia.com/job label for efficient cache-based lookups.
 // Only returns nodes where pods are Running or Pending (i.e., scheduled).
 func (d *NodeDiscoverer) DiscoverNodesForJob(ctx context.Context, namespace, jobName string) ([]string, error) {

--- a/pkg/noderesults/helper.go
+++ b/pkg/noderesults/helper.go
@@ -6,26 +6,26 @@ package noderesults
 import (
 	"sort"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // NodesWithFailureDetails wraps a list of node names into FailedNode entries with the
 // given reason and message. The result is sorted by node name.
-func NodesWithFailureDetails(names []string, reason burninv1alpha1.NodeFailureReason,
-	message string) []burninv1alpha1.FailedNode {
+func NodesWithFailureDetails(names []string, reason crev1alpha1.NodeFailureReason,
+	message string) []crev1alpha1.FailedNode {
 	if len(names) == 0 {
 		return nil
 	}
-	out := make([]burninv1alpha1.FailedNode, 0, len(names))
+	out := make([]crev1alpha1.FailedNode, 0, len(names))
 	for _, name := range names {
-		out = append(out, burninv1alpha1.FailedNode{Name: name, Reason: reason, Message: message})
+		out = append(out, crev1alpha1.FailedNode{Name: name, Reason: reason, Message: message})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
 // FailedNodeNames extracts the sorted, deduped node names from FailedNode entries.
-func FailedNodeNames(nodes []burninv1alpha1.FailedNode) []string {
+func FailedNodeNames(nodes []crev1alpha1.FailedNode) []string {
 	if len(nodes) == 0 {
 		return nil
 	}

--- a/pkg/noderesults/parser.go
+++ b/pkg/noderesults/parser.go
@@ -10,8 +10,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	gzip "github.com/NVIDIA/cluster-readiness-engine/pkg/controller/compress"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	gzip "github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller/compress"
 )
 
 const (
@@ -26,7 +26,7 @@ const (
 
 // DecodeFailedNodesFromConfigMap parses the failed-nodes entry (a JSON array of
 // {name, reason, message} objects) from a node-results ConfigMap's binaryData.
-func DecodeFailedNodesFromConfigMap(cm *corev1.ConfigMap) ([]burninv1alpha1.FailedNode, error) {
+func DecodeFailedNodesFromConfigMap(cm *corev1.ConfigMap) ([]crev1alpha1.FailedNode, error) {
 	if cm == nil {
 		return nil, nil
 	}
@@ -46,9 +46,9 @@ func DecodeFailedNodesFromConfigMap(cm *corev1.ConfigMap) ([]burninv1alpha1.Fail
 
 // FailedNodesToJSON encodes FailedNode entries as a JSON array of
 // {name, reason, message} objects.
-func FailedNodesToJSON(nodes []burninv1alpha1.FailedNode) ([]byte, error) {
+func FailedNodesToJSON(nodes []crev1alpha1.FailedNode) ([]byte, error) {
 	if nodes == nil {
-		nodes = []burninv1alpha1.FailedNode{}
+		nodes = []crev1alpha1.FailedNode{}
 	}
 	b, err := json.Marshal(nodes)
 	if err != nil {
@@ -59,11 +59,11 @@ func FailedNodesToJSON(nodes []burninv1alpha1.FailedNode) ([]byte, error) {
 
 // FailedNodesFromJSON parses the JSON array produced by FailedNodesToJSON back into
 // FailedNode entries.
-func FailedNodesFromJSON(b []byte) ([]burninv1alpha1.FailedNode, error) {
+func FailedNodesFromJSON(b []byte) ([]crev1alpha1.FailedNode, error) {
 	if len(b) == 0 {
 		return nil, nil
 	}
-	var out []burninv1alpha1.FailedNode
+	var out []crev1alpha1.FailedNode
 	if err := json.Unmarshal(b, &out); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal failed nodes from JSON: %w", err)
 	}

--- a/pkg/noderesults/parser_test.go
+++ b/pkg/noderesults/parser_test.go
@@ -6,12 +6,12 @@ package noderesults
 import (
 	"testing"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 func TestFailedNodesToJSON(t *testing.T) {
-	nodes := []burninv1alpha1.FailedNode{
-		{Name: "gpu-01", Reason: burninv1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
+	nodes := []crev1alpha1.FailedNode{
+		{Name: "gpu-01", Reason: crev1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
 	}
 	b, err := FailedNodesToJSON(nodes)
 	if err != nil {

--- a/pkg/numstr/numstr_test.go
+++ b/pkg/numstr/numstr_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // Each case parses tc.Inputs["input.yaml"]'s "in" string and formats the

--- a/pkg/orchestration/bisect_test.go
+++ b/pkg/orchestration/bisect_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/orchestration/diagnose_test.go
+++ b/pkg/orchestration/diagnose_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/orchestration/partition_test.go
+++ b/pkg/orchestration/partition_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/platform/overrides.go
+++ b/pkg/platform/overrides.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 	"text/template"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	sigyaml "sigs.k8s.io/yaml"
@@ -41,7 +41,7 @@ type OverrideConfig struct {
 // by the WorkloadRun controller at build time and never stored in the
 // Kubernetes API. Keeping them out of OverrideSpec avoids CRD schema changes.
 type WorkloadRunOverride struct {
-	burninv1alpha1.OverrideSpec
+	crev1alpha1.OverrideSpec
 
 	// PreCommand contains shell lines prepended to the trainer command.
 	// Applied by the WorkloadRun controller; baked into trainer.command/args.
@@ -138,7 +138,7 @@ func parseWorkloadRunFields(raw json.RawMessage, o *WorkloadRunOverride) error {
 // parseOneOverride populates an OverrideSpec from raw JSON. Fields that
 // the Workflow controller treats as opaque (jobTemplate, dependencies)
 // stay as raw bytes; typed fields (when, orchestration) are unmarshalled.
-func parseOneOverride(raw json.RawMessage, spec *burninv1alpha1.OverrideSpec) error {
+func parseOneOverride(raw json.RawMessage, spec *crev1alpha1.OverrideSpec) error {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		return err
@@ -170,14 +170,14 @@ func parseOneOverride(raw json.RawMessage, spec *burninv1alpha1.OverrideSpec) er
 		if err := json.Unmarshal(deps, &depList); err != nil {
 			return err
 		}
-		spec.Dependencies = make([]burninv1alpha1.DependencySpec, len(depList))
+		spec.Dependencies = make([]crev1alpha1.DependencySpec, len(depList))
 		for i, d := range depList {
 			spec.Dependencies[i].RawExtension = runtime.RawExtension{Raw: d}
 		}
 	}
 
 	if o, ok := fields["orchestration"]; ok {
-		spec.Orchestration = &burninv1alpha1.OrchestrationOverrideSpec{}
+		spec.Orchestration = &crev1alpha1.OrchestrationOverrideSpec{}
 		if err := json.Unmarshal(o, spec.Orchestration); err != nil {
 			return err
 		}

--- a/pkg/platform/overrides_test.go
+++ b/pkg/platform/overrides_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // TestEveryLibFragmentParsesThroughPlatform is the regression test for a

--- a/pkg/platform/resources_test.go
+++ b/pkg/platform/resources_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 type workerResourcesInput struct {

--- a/pkg/platform/runtime.go
+++ b/pkg/platform/runtime.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -123,7 +123,7 @@ func applyGangScheduler(cfg RuntimeConfig, podSpec, podLabels map[string]any) {
 
 // BuildTorchRuntime creates a TrainingRuntime dependency for PyTorch distributed
 // training. Generates a runtime with torch mlPolicy and a single "node" replicatedJob.
-func BuildTorchRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
+func BuildTorchRuntime(cfg RuntimeConfig) crev1alpha1.DependencySpec {
 	// Build container spec
 	container := map[string]any{
 		"name":  "node",
@@ -216,7 +216,7 @@ func BuildTorchRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
 	}
 
 	data, _ := json.Marshal(rt)
-	return burninv1alpha1.DependencySpec{
+	return crev1alpha1.DependencySpec{
 		RawExtension: runtime.RawExtension{Raw: data},
 	}
 }
@@ -226,7 +226,7 @@ func BuildTorchRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
 // - A runtime with MPI mlPolicy and launcher+node replicatedJobs
 // - Worker nodes with sshd, IPC_LOCK, readiness probe
 // - Launcher with mpirun and SSH key setup
-func BuildMPIRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
+func BuildMPIRuntime(cfg RuntimeConfig) crev1alpha1.DependencySpec {
 	// Worker (node) container: runs sshd
 	workerContainer := map[string]any{
 		"name":    "node",
@@ -402,14 +402,14 @@ func BuildMPIRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
 	}
 
 	data, _ := json.Marshal(rt)
-	return burninv1alpha1.DependencySpec{
+	return crev1alpha1.DependencySpec{
 		RawExtension: runtime.RawExtension{Raw: data},
 	}
 }
 
 // BuildExecRuntime creates a TrainingRuntime dependency for arbitrary command execution.
 // Uses a simple single-replicatedJob layout with torch mlPolicy.
-func BuildExecRuntime(cfg RuntimeConfig) burninv1alpha1.DependencySpec {
+func BuildExecRuntime(cfg RuntimeConfig) crev1alpha1.DependencySpec {
 	// Exec uses the same runtime shape as torch (simple single-replicatedJob)
 	// since the command is injected via the JobTemplate trainer field.
 	return BuildTorchRuntime(cfg)

--- a/pkg/podlogs/fetcher_test.go
+++ b/pkg/podlogs/fetcher_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 type openStreamInput struct {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,9 +25,9 @@ import (
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workload"
 )
 
 //go:embed nodes/*.yaml
@@ -111,19 +111,19 @@ type DryRunResult struct {
 
 // renderMetadata captures detection and override results from resolving a Workflow.
 type renderMetadata struct {
-	DetectedPlatform        string                           `json:"detectedPlatform"`
-	DetectedGPUArchitecture string                           `json:"detectedGPUArchitecture"`
-	AppliedOverrides        []burninv1alpha1.AppliedOverride `json:"appliedOverrides"`
+	DetectedPlatform        string                        `json:"detectedPlatform"`
+	DetectedGPUArchitecture string                        `json:"detectedGPUArchitecture"`
+	AppliedOverrides        []crev1alpha1.AppliedOverride `json:"appliedOverrides"`
 }
 
 // readWorkflow parses a Workflow YAML file from disk.
-func readWorkflow(path string) (*burninv1alpha1.Workflow, error) {
+func readWorkflow(path string) (*crev1alpha1.Workflow, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path is a user-provided CLI argument
 
 	if err != nil {
 		return nil, fmt.Errorf("read workflow: %w", err)
 	}
-	var workflow burninv1alpha1.Workflow
+	var workflow crev1alpha1.Workflow
 	if err := yaml.Unmarshal(data, &workflow); err != nil {
 		return nil, fmt.Errorf("parse workflow: %w", err)
 	}
@@ -132,8 +132,8 @@ func readWorkflow(path string) (*burninv1alpha1.Workflow, error) {
 
 // ResolveWorkflow applies overrides to a Workflow in-place and returns
 // detection metadata. The workflow's spec is mutated directly.
-func ResolveWorkflow(workflow *burninv1alpha1.Workflow, nodes []corev1.Node) (*renderMetadata, error) {
-	orch := &burninv1alpha1.OrchestrationStatus{
+func ResolveWorkflow(workflow *crev1alpha1.Workflow, nodes []corev1.Node) (*renderMetadata, error) {
+	orch := &crev1alpha1.OrchestrationStatus{
 		DetectedPlatform:        controller.DetectPlatform(nodes),
 		DetectedGPUArchitecture: controller.DetectGPUArchitecture(nodes),
 	}
@@ -156,7 +156,7 @@ func ResolveWorkflow(workflow *burninv1alpha1.Workflow, nodes []corev1.Node) (*r
 }
 
 // render resolves overrides and returns the full Workflow with metadata.
-func render(workflowFile, platform, gpuArch, nodesFile string) (*burninv1alpha1.Workflow, *renderMetadata, error) {
+func render(workflowFile, platform, gpuArch, nodesFile string) (*crev1alpha1.Workflow, *renderMetadata, error) {
 	workflow, err := readWorkflow(workflowFile)
 	if err != nil {
 		return nil, nil, err
@@ -197,7 +197,7 @@ func validateFlags(dryRun bool, nodesFile, platform, gpuArch string) error {
 func run(workflowFile, platform, gpuArch, nodesFile, outputFormat string,
 	configFlags *kubeconfig.ConfigFlags, dryRun bool) error {
 
-	var workflow *burninv1alpha1.Workflow
+	var workflow *crev1alpha1.Workflow
 	var meta *renderMetadata
 	var dryRunResults []DryRunResult
 	var err error
@@ -237,7 +237,7 @@ func run(workflowFile, platform, gpuArch, nodesFile, outputFormat string,
 }
 
 // SetRenderAnnotations stores detection metadata as annotations on the Workflow.
-func SetRenderAnnotations(workflow *burninv1alpha1.Workflow, meta *renderMetadata) {
+func SetRenderAnnotations(workflow *crev1alpha1.Workflow, meta *renderMetadata) {
 	if workflow.Annotations == nil {
 		workflow.Annotations = map[string]string{}
 	}
@@ -252,7 +252,7 @@ func SetRenderAnnotations(workflow *burninv1alpha1.Workflow, meta *renderMetadat
 // renderDryRun connects to a cluster, discovers real nodes, applies overrides,
 // and validates the resolved resources via server-side dry-run.
 func renderDryRun(workflowFile string, configFlags *kubeconfig.ConfigFlags) (
-	*burninv1alpha1.Workflow, *renderMetadata, []DryRunResult, error) {
+	*crev1alpha1.Workflow, *renderMetadata, []DryRunResult, error) {
 
 	workflow, err := readWorkflow(workflowFile)
 	if err != nil {
@@ -298,7 +298,7 @@ func NewK8sClient(cf *kubeconfig.ConfigFlags) (client.Client, error) {
 
 	s := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(s)
-	_ = burninv1alpha1.AddToScheme(s)
+	_ = crev1alpha1.AddToScheme(s)
 	_ = trainerv1alpha1.AddToScheme(s)
 
 	return client.New(restConfig, client.Options{Scheme: s})
@@ -314,7 +314,7 @@ func NewK8sWatchClient(cf *kubeconfig.ConfigFlags) (client.WithWatch, error) {
 
 	s := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(s)
-	_ = burninv1alpha1.AddToScheme(s)
+	_ = crev1alpha1.AddToScheme(s)
 	_ = trainerv1alpha1.AddToScheme(s)
 
 	return client.NewWithWatch(restConfig, client.Options{Scheme: s})
@@ -328,7 +328,7 @@ func NewK8sWatchClient(cf *kubeconfig.ConfigFlags) (client.WithWatch, error) {
 // dependency that would be created at runtime (e.g. a TrainingRuntime referenced
 // by a TrainJob). Such failures are reported as warnings rather than errors.
 func DryRunCreate(ctx context.Context, c client.Client, namespace string,
-	spec *burninv1alpha1.WorkflowSpec, nodes []corev1.Node) ([]DryRunResult, error) {
+	spec *crev1alpha1.WorkflowSpec, nodes []corev1.Node) ([]DryRunResult, error) {
 
 	var results []DryRunResult
 
@@ -373,8 +373,8 @@ func DryRunCreate(ctx context.Context, c client.Client, namespace string,
 
 	// Set default node health monitor if nil.
 	if specCopy.NodeHealthMonitor == nil {
-		specCopy.NodeHealthMonitor = &burninv1alpha1.NodeHealthMonitor{
-			CEL: &burninv1alpha1.CELNodeHealthCheck{
+		specCopy.NodeHealthMonitor = &crev1alpha1.NodeHealthMonitor{
+			CEL: &crev1alpha1.CELNodeHealthCheck{
 				Expression: `node.spec.unschedulable == true`,
 			},
 		}
@@ -409,7 +409,7 @@ func DryRunCreate(ctx context.Context, c client.Client, namespace string,
 	}
 
 	// --- 2. Validate Job ---
-	job := &burninv1alpha1.Job{
+	job := &crev1alpha1.Job{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cre.nvidia.com/v1alpha1",
 			Kind:       "Job",

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/report/build_excluded_test.go
+++ b/pkg/report/build_excluded_test.go
@@ -12,8 +12,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // A run that excluded nodes reports INCOMPLETE, not PASSED: it did not certify
@@ -31,7 +31,7 @@ func TestBuildExcludedReport(t *testing.T) {
 		if err := clientgoscheme.AddToScheme(scheme); err != nil {
 			return err
 		}
-		if err := burninv1alpha1.AddToScheme(scheme); err != nil {
+		if err := crev1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
 
@@ -41,10 +41,10 @@ func TestBuildExcludedReport(t *testing.T) {
 		}
 
 		builder := fake.NewClientBuilder().WithScheme(scheme)
-		var cert *burninv1alpha1.Certification
+		var cert *crev1alpha1.Certification
 		for _, o := range objs {
 			builder = builder.WithObjects(o)
-			if c, ok := o.(*burninv1alpha1.Certification); ok {
+			if c, ok := o.(*crev1alpha1.Certification); ok {
 				cert = c
 			}
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -21,10 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/numstr"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/numstr"
 )
 
 const (
@@ -100,20 +100,20 @@ type IterationReport struct {
 
 // DiagnoseReport holds results from the adaptive fault isolation algorithm.
 type DiagnoseReport struct {
-	Stage                string                                          `json:"stage"`
-	Rounds               int                                             `json:"rounds"`
-	HealthyCount         int                                             `json:"healthyCount"`
-	SuspectCount         int                                             `json:"suspectCount"`
-	ConfirmedFaulty      []string                                        `json:"confirmedFaulty,omitempty"`
-	InfrastructureFaults []burninv1alpha1.InfrastructureFault            `json:"infrastructureFaults,omitempty"`
-	ScreeningResults     map[string]burninv1alpha1.DomainScreeningResult `json:"-"` // not serialized, used for rendering
-	MaxBW                string                                          `json:"maxBW,omitempty"`
-	MaxBWDomain          string                                          `json:"maxBWDomain,omitempty"`
-	MaxBWNodeList        []string                                        `json:"maxBWNodes,omitempty"`
-	MinBW                string                                          `json:"minBW,omitempty"`
-	MinBWDomain          string                                          `json:"minBWDomain,omitempty"`
-	MinBWNodeList        []string                                        `json:"minBWNodes,omitempty"`
-	Tests                []DiagnoseTestRow                               `json:"tests,omitempty"`
+	Stage                string                                       `json:"stage"`
+	Rounds               int                                          `json:"rounds"`
+	HealthyCount         int                                          `json:"healthyCount"`
+	SuspectCount         int                                          `json:"suspectCount"`
+	ConfirmedFaulty      []string                                     `json:"confirmedFaulty,omitempty"`
+	InfrastructureFaults []crev1alpha1.InfrastructureFault            `json:"infrastructureFaults,omitempty"`
+	ScreeningResults     map[string]crev1alpha1.DomainScreeningResult `json:"-"` // not serialized, used for rendering
+	MaxBW                string                                       `json:"maxBW,omitempty"`
+	MaxBWDomain          string                                       `json:"maxBWDomain,omitempty"`
+	MaxBWNodeList        []string                                     `json:"maxBWNodes,omitempty"`
+	MinBW                string                                       `json:"minBW,omitempty"`
+	MinBWDomain          string                                       `json:"minBWDomain,omitempty"`
+	MinBWNodeList        []string                                     `json:"minBWNodes,omitempty"`
+	Tests                []DiagnoseTestRow                            `json:"tests,omitempty"`
 }
 
 // DiagnoseTestRow holds one test result from the diagnose algorithm.
@@ -176,7 +176,7 @@ type GroupBandwidthRow struct {
 // the referenced ConfigMap and decoding the failed-nodes entry.
 func FailedNodesFromRef(
 	ctx context.Context, c client.Client, namespace string, ref *corev1.TypedLocalObjectReference,
-) []burninv1alpha1.FailedNode {
+) []crev1alpha1.FailedNode {
 	if ref == nil || ref.Name == "" {
 		return nil
 	}
@@ -193,7 +193,7 @@ func FailedNodesFromRef(
 
 // CertFailedNodes returns the deduped union of failed node names across all
 // categories, resolved from each category's nodeResultsRef ConfigMap.
-func CertFailedNodes(ctx context.Context, c client.Client, cert *burninv1alpha1.Certification) []string {
+func CertFailedNodes(ctx context.Context, c client.Client, cert *crev1alpha1.Certification) []string {
 	seen := make(map[string]struct{})
 	var union []string
 	for _, cat := range cert.Status.CategoryStatuses {
@@ -213,11 +213,11 @@ func CertFailedNodes(ctx context.Context, c client.Client, cert *burninv1alpha1.
 }
 
 // Build fetches Workflow and measurement data for a Certification (completed or running).
-func Build(ctx context.Context, c client.Client, cert *burninv1alpha1.Certification) *CertReport {
+func Build(ctx context.Context, c client.Client, cert *crev1alpha1.Certification) *CertReport {
 	result := "RUNNING"
-	if controller.CondIsTrue(cert.Status.Conditions, burninv1alpha1.CertificationFailed) {
+	if controller.CondIsTrue(cert.Status.Conditions, crev1alpha1.CertificationFailed) {
 		result = "FAILED"
-	} else if controller.CondIsTrue(cert.Status.Conditions, burninv1alpha1.CertificationSucceeded) {
+	} else if controller.CondIsTrue(cert.Status.Conditions, crev1alpha1.CertificationSucceeded) {
 		result = "PASSED"
 	}
 	report := &CertReport{
@@ -256,7 +256,7 @@ func Build(ctx context.Context, c client.Client, cert *burninv1alpha1.Certificat
 		}
 
 		if cs.WorkflowRef != nil {
-			wf := &burninv1alpha1.Workflow{}
+			wf := &crev1alpha1.Workflow{}
 			ns := cs.WorkflowRef.Namespace
 			if ns == "" {
 				ns = cert.Namespace
@@ -277,7 +277,7 @@ func Build(ctx context.Context, c client.Client, cert *burninv1alpha1.Certificat
 		if cs.WorkflowRef == nil {
 			continue
 		}
-		wf := &burninv1alpha1.Workflow{}
+		wf := &crev1alpha1.Workflow{}
 		ns := cs.WorkflowRef.Namespace
 		if ns == "" {
 			ns = cert.Namespace
@@ -345,7 +345,7 @@ func batchJobFailureReason(ctx context.Context, c client.Client, excalMsg, names
 
 func failureReasonFromConditions(conditions []metav1.Condition) string {
 	for _, cond := range conditions {
-		if cond.Type == burninv1alpha1.WorkflowFailed && cond.Status == metav1.ConditionTrue {
+		if cond.Type == crev1alpha1.WorkflowFailed && cond.Status == metav1.ConditionTrue {
 			return cond.Message
 		}
 	}
@@ -355,7 +355,7 @@ func failureReasonFromConditions(conditions []metav1.Condition) string {
 // buildFailedGroups collects failed orchestration groups with their root cause.
 // buildIterationReports creates per-iteration timing from iteration history
 // and the current iteration. Returns reports and total runtime string.
-func buildIterationReports(orch *burninv1alpha1.OrchestrationStatus) ([]IterationReport, string) {
+func buildIterationReports(orch *crev1alpha1.OrchestrationStatus) ([]IterationReport, string) {
 	if orch == nil {
 		return nil, ""
 	}
@@ -394,11 +394,11 @@ func buildIterationReports(orch *burninv1alpha1.OrchestrationStatus) ([]Iteratio
 }
 
 // iterGroupDuration computes duration and status from completed iteration groups.
-func iterGroupDuration(groups []burninv1alpha1.GroupIterationResult, now int64) (string, int64) {
+func iterGroupDuration(groups []crev1alpha1.GroupIterationResult, now int64) (string, int64) {
 	status := statusSucceeded
 	var earliest, latest int64
 	for _, g := range groups {
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			status = statusFailed
 		}
 		if g.StartTime != nil {
@@ -424,15 +424,15 @@ func iterGroupDuration(groups []burninv1alpha1.GroupIterationResult, now int64) 
 }
 
 // currentGroupDuration computes duration and status from the current iteration's groups.
-func currentGroupDuration(groups []burninv1alpha1.GroupStatus, now int64) (string, int64) {
+func currentGroupDuration(groups []crev1alpha1.GroupStatus, now int64) (string, int64) {
 	status := statusSucceeded
 	allTerminal := true
 	var earliest, latest int64
 	for _, g := range groups {
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			status = statusFailed
 		}
-		if g.Phase != burninv1alpha1.GroupSucceeded && g.Phase != burninv1alpha1.GroupFailed {
+		if g.Phase != crev1alpha1.GroupSucceeded && g.Phase != crev1alpha1.GroupFailed {
 			allTerminal = false
 		}
 		if g.StartTime != nil {
@@ -474,14 +474,14 @@ func fmtSecs(secs int64) string {
 	return fmt.Sprintf("%dh %dm", secs/3600, (secs%3600)/60)
 }
 
-func buildFailedGroups(ctx context.Context, c client.Client, wf *burninv1alpha1.Workflow) []FailedGroupReport {
+func buildFailedGroups(ctx context.Context, c client.Client, wf *crev1alpha1.Workflow) []FailedGroupReport {
 	orch := wf.Status.Orchestration
 	if orch == nil || c == nil {
 		return nil
 	}
 	var result []FailedGroupReport
 	for _, g := range orch.Groups {
-		if g.Phase != burninv1alpha1.GroupFailed || g.JobRef == nil {
+		if g.Phase != crev1alpha1.GroupFailed || g.JobRef == nil {
 			continue
 		}
 		fg := FailedGroupReport{
@@ -489,10 +489,10 @@ func buildFailedGroups(ctx context.Context, c client.Client, wf *burninv1alpha1.
 			NodeCount: len(g.Nodes),
 			Nodes:     g.Nodes,
 		}
-		excalJob := &burninv1alpha1.Job{}
+		excalJob := &crev1alpha1.Job{}
 		if err := c.Get(ctx, client.ObjectKey{Name: g.JobRef.Name, Namespace: wf.Namespace}, excalJob); err == nil {
 			for _, cond := range excalJob.Status.Conditions {
-				if cond.Type == burninv1alpha1.JobFailed && cond.Status == metav1.ConditionTrue {
+				if cond.Type == crev1alpha1.JobFailed && cond.Status == metav1.ConditionTrue {
 					if reason := batchJobFailureReason(ctx, c, cond.Message, wf.Namespace); reason != "" {
 						fg.Reason = reason
 					} else {
@@ -509,7 +509,7 @@ func buildFailedGroups(ctx context.Context, c client.Client, wf *burninv1alpha1.
 
 // PopulateCategoryFromWorkflow fills in category metrics from a Workflow and its children.
 func PopulateCategoryFromWorkflow(
-	ctx context.Context, c client.Client, cat *CategoryReport, wf *burninv1alpha1.Workflow,
+	ctx context.Context, c client.Client, cat *CategoryReport, wf *crev1alpha1.Workflow,
 ) {
 	orch := wf.Status.Orchestration
 	if orch != nil {
@@ -529,9 +529,9 @@ func PopulateCategoryFromWorkflow(
 		stage := diag.Stage
 		// If the workflow is terminal, show "complete" regardless of the stored stage
 		// (older controller versions may not have set it on failure paths).
-		if controller.CondIsTrue(wf.Status.Conditions, burninv1alpha1.WorkflowSucceeded) ||
-			controller.CondIsTrue(wf.Status.Conditions, burninv1alpha1.WorkflowFailed) {
-			stage = burninv1alpha1.DiagnoseStageComplete
+		if controller.CondIsTrue(wf.Status.Conditions, crev1alpha1.WorkflowSucceeded) ||
+			controller.CondIsTrue(wf.Status.Conditions, crev1alpha1.WorkflowFailed) {
+			stage = crev1alpha1.DiagnoseStageComplete
 		}
 		cat.Diagnose = &DiagnoseReport{
 			Stage:        stage,
@@ -550,9 +550,9 @@ func PopulateCategoryFromWorkflow(
 	workflowJobs := collectWorkflowJobs(ctx, c, wf, orch)
 
 	// Find GoodputMeasurements owned by this Workflow's Jobs.
-	var goodputList burninv1alpha1.GoodputMeasurementList
+	var goodputList crev1alpha1.GoodputMeasurementList
 	if err := c.List(ctx, &goodputList, client.InNamespace(wf.Namespace)); err == nil {
-		var filtered []burninv1alpha1.GoodputMeasurement
+		var filtered []crev1alpha1.GoodputMeasurement
 		for _, gm := range goodputList.Items {
 			if workflowJobs[gm.Spec.JobRef.Name] {
 				filtered = append(filtered, gm)
@@ -564,10 +564,10 @@ func PopulateCategoryFromWorkflow(
 	}
 
 	// Find BandwidthMeasurements owned by this Workflow's Jobs.
-	var bwList burninv1alpha1.BandwidthMeasurementList
+	var bwList crev1alpha1.BandwidthMeasurementList
 	if err := c.List(ctx, &bwList, client.InNamespace(wf.Namespace)); err == nil {
 		// Collect filtered BandwidthMeasurements.
-		var filtered []burninv1alpha1.BandwidthMeasurement
+		var filtered []crev1alpha1.BandwidthMeasurement
 		for _, bm := range bwList.Items {
 			if workflowJobs[bm.Spec.JobRef.Name] {
 				filtered = append(filtered, bm)
@@ -591,7 +591,7 @@ func PopulateCategoryFromWorkflow(
 		// Show aggregate bandwidth for non-diagnose modes.
 		// Diagnose shows per-stage bandwidth in the diagnosis section.
 		if cat.Diagnose == nil {
-			var peak *burninv1alpha1.BandwidthResult
+			var peak *crev1alpha1.BandwidthResult
 			for i := range filtered {
 				r := peakBandwidthResult(filtered[i].Status.Results)
 				if r == nil {
@@ -616,8 +616,8 @@ func PopulateCategoryFromWorkflow(
 // buildGroupBandwidthRows maps BandwidthMeasurements to groups and returns
 // per-group peak bandwidth rows for multi-group Workflows.
 func buildGroupBandwidthRows(
-	orch *burninv1alpha1.OrchestrationStatus,
-	measurements []burninv1alpha1.BandwidthMeasurement,
+	orch *crev1alpha1.OrchestrationStatus,
+	measurements []crev1alpha1.BandwidthMeasurement,
 	minBusBandwidthGBps string,
 ) []GroupBandwidthRow {
 	// Map job name → group info.
@@ -636,7 +636,7 @@ func buildGroupBandwidthRows(
 				nodes:     g.Nodes,
 				domains:   g.Domains,
 				nodeCount: len(g.Nodes),
-				failed:    g.Phase == burninv1alpha1.GroupFailed,
+				failed:    g.Phase == crev1alpha1.GroupFailed,
 			}
 		}
 	}
@@ -689,7 +689,7 @@ func buildGroupBandwidthRows(
 		seen[r.GroupName] = true
 	}
 	for _, g := range orch.Groups {
-		if g.Phase != burninv1alpha1.GroupFailed {
+		if g.Phase != crev1alpha1.GroupFailed {
 			continue
 		}
 		var label string
@@ -714,7 +714,7 @@ func buildGroupBandwidthRows(
 // buildDomainReports groups GoodputMeasurements by topology domain.
 // If no domains exist, returns a single entry with averages across all measurements.
 func buildDomainReports(
-	orch *burninv1alpha1.OrchestrationStatus, measurements []burninv1alpha1.GoodputMeasurement,
+	orch *crev1alpha1.OrchestrationStatus, measurements []crev1alpha1.GoodputMeasurement,
 ) []DomainReport {
 	// Map job names to their group's domain info.
 	type groupInfo struct {
@@ -784,7 +784,7 @@ func buildDomainReports(
 // groups and failed nodes. For single-domain groups (intra-rack), node counts
 // are exact. For multi-domain groups, DomainNodeCounts provides per-domain
 // totals recorded at partition time.
-func buildCliqueReport(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1.FailedNode) []CliqueReport {
+func buildCliqueReport(wf *crev1alpha1.Workflow, failedNodes []crev1alpha1.FailedNode) []CliqueReport {
 	orch := wf.Status.Orchestration
 	if orch == nil {
 		return nil
@@ -798,7 +798,7 @@ func buildCliqueReport(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1
 	// Collect domains from groups with Failed phase.
 	failedDomains := make(map[string]bool)
 	for _, g := range orch.Groups {
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			for _, d := range g.Domains {
 				failedDomains[d] = true
 			}
@@ -886,7 +886,7 @@ func buildCliqueReport(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1
 // by the Certification controller when it creates the Workflow.
 const annotationRequestedTestScale = "cre.nvidia.com/requested-test-scale"
 
-func detectTestScale(wf *burninv1alpha1.Workflow) string {
+func detectTestScale(wf *crev1alpha1.Workflow) string {
 	// What the operator asked for, when the Certification recorded it. The
 	// fallback below infers the scale from what was applied, which is not the
 	// same thing: an entry whose template ignores testScale still partitions one
@@ -898,15 +898,15 @@ func detectTestScale(wf *burninv1alpha1.Workflow) string {
 	}
 	o := wf.Spec.Orchestration
 	if o.Topology != nil && o.Topology.StrictDomain {
-		return burninv1alpha1.TestScaleIntraRack
+		return crev1alpha1.TestScaleIntraRack
 	}
 	if o.Diagnose != nil {
-		return burninv1alpha1.TestScaleDiagnose
+		return crev1alpha1.TestScaleDiagnose
 	}
 	if wf.Status.Orchestration != nil && wf.Status.Orchestration.NodesPerJob == 1 {
-		return burninv1alpha1.TestScaleIntraNode
+		return crev1alpha1.TestScaleIntraNode
 	}
-	return burninv1alpha1.TestScaleFullScale
+	return crev1alpha1.TestScaleFullScale
 }
 
 // ---------------------------------------------------------------------------
@@ -1289,11 +1289,11 @@ func appendNodeLines(
 // For other modes, reads JobRefs from the current groups.
 func collectWorkflowJobs(
 	ctx context.Context, c client.Client,
-	wf *burninv1alpha1.Workflow, orch *burninv1alpha1.OrchestrationStatus,
+	wf *crev1alpha1.Workflow, orch *crev1alpha1.OrchestrationStatus,
 ) map[string]bool {
 	jobs := map[string]bool{}
 	if orch != nil && orch.Diagnose != nil {
-		var jobList burninv1alpha1.JobList
+		var jobList crev1alpha1.JobList
 		if err := c.List(ctx, &jobList, client.InNamespace(wf.Namespace),
 			client.MatchingLabels{"cre.nvidia.com/workflow": wf.Name}); err == nil {
 			for _, j := range jobList.Items {
@@ -1314,8 +1314,8 @@ func collectWorkflowJobs(
 // Workflow and correlating with BandwidthMeasurements.
 func buildDiagnoseTests(
 	ctx context.Context, c client.Client,
-	wf *burninv1alpha1.Workflow,
-	measurements []burninv1alpha1.BandwidthMeasurement,
+	wf *crev1alpha1.Workflow,
+	measurements []crev1alpha1.BandwidthMeasurement,
 ) []DiagnoseTestRow {
 	// Build bandwidth map: job name → peak BusBW (at the largest message size).
 	bwByJob := map[string]string{}
@@ -1326,7 +1326,7 @@ func buildDiagnoseTests(
 	}
 
 	// List all Jobs for this Workflow.
-	var jobList burninv1alpha1.JobList
+	var jobList crev1alpha1.JobList
 	if err := c.List(ctx, &jobList, client.InNamespace(wf.Namespace),
 		client.MatchingLabels{"cre.nvidia.com/workflow": wf.Name}); err != nil {
 		return nil
@@ -1336,7 +1336,7 @@ func buildDiagnoseTests(
 	for _, j := range jobList.Items {
 		groupName := j.GetLabels()["cre.nvidia.com/group"]
 		stage := inferDiagnoseStage(groupName)
-		passed := controller.CondIsTrue(j.Status.Conditions, burninv1alpha1.JobSucceeded)
+		passed := controller.CondIsTrue(j.Status.Conditions, crev1alpha1.JobSucceeded)
 		nodes := getJobNodes(&j)
 
 		// Only set domain for screening tests — other stages list individual nodes.
@@ -1381,7 +1381,7 @@ func inferDiagnoseStage(groupName string) string {
 }
 
 // lookupScreeningDomain finds the topology domain for a screening test's nodes.
-func lookupScreeningDomain(wf *burninv1alpha1.Workflow, nodes []string) string {
+func lookupScreeningDomain(wf *crev1alpha1.Workflow, nodes []string) string {
 	if len(nodes) == 0 || wf.Status.Orchestration == nil || wf.Status.Orchestration.Diagnose == nil {
 		return ""
 	}
@@ -1394,7 +1394,7 @@ func lookupScreeningDomain(wf *burninv1alpha1.Workflow, nodes []string) string {
 }
 
 // getJobNodes reads the group-nodes annotation set by the workflow controller.
-func getJobNodes(job *burninv1alpha1.Job) []string {
+func getJobNodes(job *crev1alpha1.Job) []string {
 	ann := job.GetAnnotations()["cre.nvidia.com/group-nodes"]
 	if ann == "" {
 		return nil
@@ -1404,7 +1404,7 @@ func getJobNodes(job *burninv1alpha1.Job) []string {
 
 // groupFaultyByDomain groups faulty nodes by their screening domain.
 // Returns sorted domain→nodes pairs. Nodes without a domain go under "unknown".
-func groupFaultyByDomain(faulty []string, screening map[string]burninv1alpha1.DomainScreeningResult) []struct {
+func groupFaultyByDomain(faulty []string, screening map[string]crev1alpha1.DomainScreeningResult) []struct {
 	domain string
 	nodes  []string
 } {
@@ -1707,8 +1707,8 @@ func fmtAvg(vals []float64, fn fmtFunc) string {
 // indexing the last entry: BandwidthMeasurement appends new sizes in the
 // order they are first observed in the data points, which is not guaranteed
 // to be ascending.
-func peakBandwidthResult(results []burninv1alpha1.BandwidthResult) *burninv1alpha1.BandwidthResult {
-	var peak *burninv1alpha1.BandwidthResult
+func peakBandwidthResult(results []crev1alpha1.BandwidthResult) *crev1alpha1.BandwidthResult {
+	var peak *crev1alpha1.BandwidthResult
 	for i := range results {
 		if peak == nil || results[i].SizeBytes > peak.SizeBytes {
 			peak = &results[i]

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -15,11 +15,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 const testAPIGroup = "cre.nvidia.com"
@@ -180,33 +180,33 @@ func TestBuildDomainReports(t *testing.T) {
 	apiGroup := testAPIGroup
 
 	t.Run("multi-domain grouping", func(t *testing.T) {
-		orch := &burninv1alpha1.OrchestrationStatus{
-			Groups: []burninv1alpha1.GroupStatus{
+		orch := &crev1alpha1.OrchestrationStatus{
+			Groups: []crev1alpha1.GroupStatus{
 				{
 					Name:    "group-0",
 					Nodes:   []string{"node-0", "node-1"},
 					Domains: []string{"clique-0"},
-					JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-0"},
+					JobRef:  &crev1alpha1.WorkloadReference{Name: "job-0"},
 				},
 				{
 					Name:    "group-1",
 					Nodes:   []string{"node-2", "node-3"},
 					Domains: []string{"clique-1"},
-					JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-1"},
+					JobRef:  &crev1alpha1.WorkloadReference{Name: "job-1"},
 				},
 			},
 		}
 
-		measurements := []burninv1alpha1.GoodputMeasurement{
+		measurements := []crev1alpha1.GoodputMeasurement{
 			{
-				Spec: burninv1alpha1.GoodputMeasurementSpec{
+				Spec: crev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
 						Kind:     "Job",
 						Name:     "job-0",
 					},
 				},
-				Status: burninv1alpha1.GoodputMeasurementStatus{
+				Status: crev1alpha1.GoodputMeasurementStatus{
 					Result:          "0.95",
 					AvgTFLOPSPerGPU: "800.5",
 					TrainingTimeSec: "120",
@@ -214,14 +214,14 @@ func TestBuildDomainReports(t *testing.T) {
 				},
 			},
 			{
-				Spec: burninv1alpha1.GoodputMeasurementSpec{
+				Spec: crev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
 						Kind:     "Job",
 						Name:     "job-1",
 					},
 				},
-				Status: burninv1alpha1.GoodputMeasurementStatus{
+				Status: crev1alpha1.GoodputMeasurementStatus{
 					Result:          "0.90",
 					AvgTFLOPSPerGPU: "750.0",
 					TrainingTimeSec: "130",
@@ -249,16 +249,16 @@ func TestBuildDomainReports(t *testing.T) {
 	})
 
 	t.Run("no-domain fallback", func(t *testing.T) {
-		measurements := []burninv1alpha1.GoodputMeasurement{
+		measurements := []crev1alpha1.GoodputMeasurement{
 			{
-				Spec: burninv1alpha1.GoodputMeasurementSpec{
+				Spec: crev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
 						Kind:     "Job",
 						Name:     "job-x",
 					},
 				},
-				Status: burninv1alpha1.GoodputMeasurementStatus{
+				Status: crev1alpha1.GoodputMeasurementStatus{
 					Result:          "0.88",
 					AvgTFLOPSPerGPU: "600",
 				},
@@ -272,12 +272,12 @@ func TestBuildDomainReports(t *testing.T) {
 	})
 
 	t.Run("empty measurements", func(t *testing.T) {
-		orch := &burninv1alpha1.OrchestrationStatus{
-			Groups: []burninv1alpha1.GroupStatus{
+		orch := &crev1alpha1.OrchestrationStatus{
+			Groups: []crev1alpha1.GroupStatus{
 				{
 					Name:    "group-0",
 					Domains: []string{"clique-0"},
-					JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-0"},
+					JobRef:  &crev1alpha1.WorkloadReference{Name: "job-0"},
 				},
 			},
 		}
@@ -788,16 +788,16 @@ func TestBuildDomainReportsPartialMetrics(t *testing.T) {
 	apiGroup := testAPIGroup
 
 	// Only goodput set, other metrics are empty.
-	measurements := []burninv1alpha1.GoodputMeasurement{
+	measurements := []crev1alpha1.GoodputMeasurement{
 		{
-			Spec: burninv1alpha1.GoodputMeasurementSpec{
+			Spec: crev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
 					APIGroup: &apiGroup,
 					Kind:     "Job",
 					Name:     "job-0",
 				},
 			},
-			Status: burninv1alpha1.GoodputMeasurementStatus{
+			Status: crev1alpha1.GoodputMeasurementStatus{
 				Result: "0.85",
 				// All other fields empty.
 			},
@@ -831,11 +831,11 @@ func TestBuildCliqueReport(t *testing.T) {
 			return err
 		}
 
-		wf := &burninv1alpha1.Workflow{}
+		wf := &crev1alpha1.Workflow{}
 		if !input.NilOrchestration {
-			orch := &burninv1alpha1.OrchestrationStatus{}
+			orch := &crev1alpha1.OrchestrationStatus{}
 			for _, g := range input.Groups {
-				orch.Groups = append(orch.Groups, burninv1alpha1.GroupStatus{
+				orch.Groups = append(orch.Groups, crev1alpha1.GroupStatus{
 					Name:             g.Name,
 					Nodes:            g.Nodes,
 					Domains:          g.Domains,
@@ -844,10 +844,10 @@ func TestBuildCliqueReport(t *testing.T) {
 			}
 			wf.Status.Orchestration = orch
 		}
-		var failedNodes []burninv1alpha1.FailedNode
+		var failedNodes []crev1alpha1.FailedNode
 		for _, n := range input.FailedNodes {
 			failedNodes = append(failedNodes,
-				burninv1alpha1.FailedNode{Name: n, Reason: "WorkloadFailed"})
+				crev1alpha1.FailedNode{Name: n, Reason: "WorkloadFailed"})
 		}
 
 		reports := buildCliqueReport(wf, failedNodes)
@@ -882,20 +882,20 @@ func TestDetectTestScale(t *testing.T) {
 			return err
 		}
 
-		wf := &burninv1alpha1.Workflow{}
+		wf := &crev1alpha1.Workflow{}
 		if input.RequestedTestScale != "" {
 			wf.Annotations = map[string]string{
 				annotationRequestedTestScale: input.RequestedTestScale,
 			}
 		}
 		if input.Topology != nil {
-			wf.Spec.Orchestration.Topology = &burninv1alpha1.TopologySpec{
+			wf.Spec.Orchestration.Topology = &crev1alpha1.TopologySpec{
 				TopologyKey:  input.Topology.TopologyKey,
 				StrictDomain: input.Topology.StrictDomain,
 			}
 		}
 		if input.NodesPerJob > 0 {
-			wf.Status.Orchestration = &burninv1alpha1.OrchestrationStatus{
+			wf.Status.Orchestration = &crev1alpha1.OrchestrationStatus{
 				NodesPerJob: input.NodesPerJob,
 			}
 		}
@@ -916,41 +916,41 @@ func TestDetectTestScale(t *testing.T) {
 func TestBuildDomainReportsMultipleMeasurementsSameDomain(t *testing.T) {
 	apiGroup := testAPIGroup
 
-	orch := &burninv1alpha1.OrchestrationStatus{
-		Groups: []burninv1alpha1.GroupStatus{
+	orch := &crev1alpha1.OrchestrationStatus{
+		Groups: []crev1alpha1.GroupStatus{
 			{
 				Name:    "group-0",
 				Nodes:   []string{"node-0", "node-1"},
 				Domains: []string{"rack-a"},
-				JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-0"},
+				JobRef:  &crev1alpha1.WorkloadReference{Name: "job-0"},
 			},
 			{
 				Name:    "group-1",
 				Nodes:   []string{"node-2", "node-3"},
 				Domains: []string{"rack-a"}, // Same domain.
-				JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-1"},
+				JobRef:  &crev1alpha1.WorkloadReference{Name: "job-1"},
 			},
 		},
 	}
 
-	measurements := []burninv1alpha1.GoodputMeasurement{
+	measurements := []crev1alpha1.GoodputMeasurement{
 		{
-			Spec: burninv1alpha1.GoodputMeasurementSpec{
+			Spec: crev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
 					APIGroup: &apiGroup, Kind: "Job", Name: "job-0",
 				},
 			},
-			Status: burninv1alpha1.GoodputMeasurementStatus{
+			Status: crev1alpha1.GoodputMeasurementStatus{
 				Result: "0.90", AvgTFLOPSPerGPU: "800",
 			},
 		},
 		{
-			Spec: burninv1alpha1.GoodputMeasurementSpec{
+			Spec: crev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
 					APIGroup: &apiGroup, Kind: "Job", Name: "job-1",
 				},
 			},
-			Status: burninv1alpha1.GoodputMeasurementStatus{
+			Status: crev1alpha1.GoodputMeasurementStatus{
 				Result: "0.80", AvgTFLOPSPerGPU: "700",
 			},
 		},
@@ -969,11 +969,11 @@ func TestBuildDomainReportsMultipleMeasurementsSameDomain(t *testing.T) {
 func TestPeakBandwidthResult(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		assert.Nil(t, peakBandwidthResult(nil))
-		assert.Nil(t, peakBandwidthResult([]burninv1alpha1.BandwidthResult{}))
+		assert.Nil(t, peakBandwidthResult([]crev1alpha1.BandwidthResult{}))
 	})
 
 	t.Run("ascending — last is peak", func(t *testing.T) {
-		results := []burninv1alpha1.BandwidthResult{
+		results := []crev1alpha1.BandwidthResult{
 			{SizeBytes: 1024, BusBW: "1.0"},
 			{SizeBytes: 1048576, BusBW: "100.0"},
 			{SizeBytes: 17179869184, BusBW: "350.0"},
@@ -985,7 +985,7 @@ func TestPeakBandwidthResult(t *testing.T) {
 	})
 
 	t.Run("unsorted — picks largest size, not last", func(t *testing.T) {
-		results := []burninv1alpha1.BandwidthResult{
+		results := []crev1alpha1.BandwidthResult{
 			{SizeBytes: 17179869184, BusBW: "350.0"},
 			{SizeBytes: 1024, BusBW: "1.0"},
 			{SizeBytes: 1048576, BusBW: "100.0"},
@@ -997,7 +997,7 @@ func TestPeakBandwidthResult(t *testing.T) {
 	})
 
 	t.Run("single entry", func(t *testing.T) {
-		results := []burninv1alpha1.BandwidthResult{{SizeBytes: 8, BusBW: "0.1"}}
+		results := []crev1alpha1.BandwidthResult{{SizeBytes: 8, BusBW: "0.1"}}
 		peak := peakBandwidthResult(results)
 		require.NotNil(t, peak)
 		assert.Equal(t, int64(8), peak.SizeBytes)
@@ -1006,25 +1006,25 @@ func TestPeakBandwidthResult(t *testing.T) {
 
 func TestBuildGroupBandwidthRowsUnsorted(t *testing.T) {
 	apiGroup := testAPIGroup
-	orch := &burninv1alpha1.OrchestrationStatus{
-		Groups: []burninv1alpha1.GroupStatus{
+	orch := &crev1alpha1.OrchestrationStatus{
+		Groups: []crev1alpha1.GroupStatus{
 			{
 				Name:    "group-0",
 				Nodes:   []string{"node-0", "node-1"},
 				Domains: []string{"clique-0"},
-				JobRef:  &burninv1alpha1.WorkloadReference{Name: "job-0"},
+				JobRef:  &crev1alpha1.WorkloadReference{Name: "job-0"},
 			},
 		},
 	}
-	measurements := []burninv1alpha1.BandwidthMeasurement{
+	measurements := []crev1alpha1.BandwidthMeasurement{
 		{
-			Spec: burninv1alpha1.BandwidthMeasurementSpec{
+			Spec: crev1alpha1.BandwidthMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
 					APIGroup: &apiGroup, Kind: "Job", Name: "job-0",
 				},
 			},
-			Status: burninv1alpha1.BandwidthMeasurementStatus{
-				Results: []burninv1alpha1.BandwidthResult{
+			Status: crev1alpha1.BandwidthMeasurementStatus{
+				Results: []crev1alpha1.BandwidthResult{
 					// Largest size first — last entry is NOT the peak.
 					{SizeBytes: 17179869184, BusBW: "350.0"},
 					{SizeBytes: 1024, BusBW: "1.0"},

--- a/pkg/setup/helm.go
+++ b/pkg/setup/helm.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	helmReleaseName    = "cluster-readiness-engine"
-	helmChartOCI       = "oci://ghcr.io/nvidia/cluster-readiness-engine"
+	helmChartOCI       = "oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine"
 	ghcrRegistryUser   = "token"
 	helmInstallTimeout = 5 * time.Minute
 

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,7 +34,7 @@ const (
 	kubeflowTrainerVersion = "v2.2.1"
 
 	defaultImageRegistry   = "ghcr.io"
-	defaultImageRepository = "nvidia/cluster-readiness-engine/manager"
+	defaultImageRepository = "dsx-ai-factory/cluster-readiness-engine/manager"
 
 	creNamespace = "cluster-readiness-engine"
 
@@ -89,7 +89,7 @@ func newInitCommand(version string) *cobra.Command {
 
 Phases:
   [deps]  Kubeflow Trainer ` + kubeflowTrainerVersion + `
-  [helm]  CRE Helm chart (oci://ghcr.io/nvidia/cluster-readiness-engine)
+  [helm]  CRE Helm chart (oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine)
 
 The Helm chart is pulled from GHCR at the CLI version. Dev builds require --version.
 Pass --image-pull-secret to authenticate against a private GHCR registry.

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	sigsyaml "sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,7 +175,7 @@ func TestParseImage(t *testing.T) {
 func TestDefaultImage(t *testing.T) {
 	img := defaultImage("dev")
 	assert.Equal(t, defaultImageRegistry+"/"+defaultImageRepository+":"+"dev", img)
-	assert.Contains(t, img, "ghcr.io/nvidia/cluster-readiness-engine/manager:")
+	assert.Contains(t, img, "ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/setup/status.go
+++ b/pkg/setup/status.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/threshold/evaluator_test.go
+++ b/pkg/threshold/evaluator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // Covers the >=, >, <=, < operators, ranges, ratio-typed thresholds, and the

--- a/pkg/workload/adapter.go
+++ b/pkg/workload/adapter.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // WorkloadPhase represents the normalized phase of a workload.
@@ -39,39 +39,39 @@ type Adapter interface {
 
 	// Build creates a fully typed workload object from the WorkloadSpec.
 	// The name and namespace are set on the returned object.
-	Build(name, namespace string, spec *burninv1alpha1.WorkloadSpec) (client.Object, error)
+	Build(name, namespace string, spec *crev1alpha1.WorkloadSpec) (client.Object, error)
 
 	// InjectPodLabel ensures the given label reaches pod templates.
 	// Mutates spec in-place — call on a DeepCopy before Build.
-	InjectPodLabel(spec *burninv1alpha1.WorkloadSpec, key, value string)
+	InjectPodLabel(spec *crev1alpha1.WorkloadSpec, key, value string)
 
 	// SetNodeSelector sets nodeSelector on the workload's pod templates.
 	// Mutates spec in-place — call on a DeepCopy before Build.
-	SetNodeSelector(spec *burninv1alpha1.WorkloadSpec, selector map[string]string)
+	SetNodeSelector(spec *crev1alpha1.WorkloadSpec, selector map[string]string)
 
 	// SetNodeAffinity sets node affinity on the workload's pod templates.
 	// Mutates spec in-place — call on a DeepCopy before Build.
-	SetNodeAffinity(spec *burninv1alpha1.WorkloadSpec, affinity *corev1.NodeAffinity)
+	SetNodeAffinity(spec *crev1alpha1.WorkloadSpec, affinity *corev1.NodeAffinity)
 
 	// SetTolerations appends tolerations to the workload's pod templates.
 	// Mutates spec in-place — call on a DeepCopy before Build.
-	SetTolerations(spec *burninv1alpha1.WorkloadSpec, tolerations []corev1.Toleration)
+	SetTolerations(spec *crev1alpha1.WorkloadSpec, tolerations []corev1.Toleration)
 
 	// NodesRequired returns the number of nodes required by the workload spec.
 	// This is auto-detected from the replica count in the workload definition.
-	NodesRequired(spec *burninv1alpha1.WorkloadSpec) (int, error)
+	NodesRequired(spec *crev1alpha1.WorkloadSpec) (int, error)
 
 	// SetNumNodes overrides the number of nodes/replicas in the workload spec.
 	// Used by bisection to match the workload's node count to the group size,
 	// which changes each round. Mutates spec in-place.
-	SetNumNodes(spec *burninv1alpha1.WorkloadSpec, numNodes int)
+	SetNumNodes(spec *crev1alpha1.WorkloadSpec, numNodes int)
 
 	// GetStatus reads typed status conditions and returns a normalized WorkloadStatus.
 	GetStatus(obj client.Object) (*WorkloadStatus, error)
 }
 
 // ForSpec returns the appropriate Adapter for the given WorkloadSpec.
-func ForSpec(spec *burninv1alpha1.WorkloadSpec) (Adapter, error) {
+func ForSpec(spec *crev1alpha1.WorkloadSpec) (Adapter, error) {
 	switch {
 	case spec.TrainJob != nil:
 		return &TrainJobAdapter{}, nil

--- a/pkg/workload/adapter_test.go
+++ b/pkg/workload/adapter_test.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // --- ForSpec (all adapters) ---
@@ -27,7 +27,7 @@ func TestForSpec(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		var spec burninv1alpha1.WorkloadSpec
+		var spec crev1alpha1.WorkloadSpec
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &spec); err != nil {
 			return err
 		}
@@ -56,9 +56,9 @@ func TestTrainJobBuild(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Name      string                      `yaml:"name"`
-			Namespace string                      `yaml:"namespace"`
-			Spec      burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			Name      string                   `yaml:"name"`
+			Namespace string                   `yaml:"namespace"`
+			Spec      crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -93,9 +93,9 @@ func TestTrainJobInjectPodLabel(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			LabelKey   string                      `yaml:"labelKey"`
-			LabelValue string                      `yaml:"labelValue"`
-			Spec       burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			LabelKey   string                   `yaml:"labelKey"`
+			LabelValue string                   `yaml:"labelValue"`
+			Spec       crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -119,8 +119,8 @@ func TestTrainJobSetNodeSelector(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			NodeSelector map[string]string           `yaml:"nodeSelector"`
-			Spec         burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			NodeSelector map[string]string        `yaml:"nodeSelector"`
+			Spec         crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -144,8 +144,8 @@ func TestTrainJobSetNodeAffinity(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Affinity *corev1.NodeAffinity        `yaml:"affinity"`
-			Spec     burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			Affinity *corev1.NodeAffinity     `yaml:"affinity"`
+			Spec     crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -202,7 +202,7 @@ func TestTrainJobNodesRequired(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Spec burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			Spec crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -230,8 +230,8 @@ func TestTrainJobSetTolerations(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Tolerations []corev1.Toleration         `yaml:"tolerations"`
-			Spec        burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			Tolerations []corev1.Toleration      `yaml:"tolerations"`
+			Spec        crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -255,7 +255,7 @@ func TestHasLauncherTarget(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Spec burninv1alpha1.WorkloadSpec `yaml:"spec"`
+			Spec crev1alpha1.WorkloadSpec `yaml:"spec"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err

--- a/pkg/workload/trainjob.go
+++ b/pkg/workload/trainjob.go
@@ -14,7 +14,7 @@ import (
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 const (
@@ -42,7 +42,7 @@ func (a *TrainJobAdapter) NewObject() client.Object {
 	return &trainerv1alpha1.TrainJob{}
 }
 
-func (a *TrainJobAdapter) Build(name, namespace string, spec *burninv1alpha1.WorkloadSpec) (client.Object, error) {
+func (a *TrainJobAdapter) Build(name, namespace string, spec *crev1alpha1.WorkloadSpec) (client.Object, error) {
 	if spec.TrainJob == nil {
 		return nil, fmt.Errorf("WorkloadSpec.TrainJob is nil")
 	}
@@ -61,7 +61,7 @@ func (a *TrainJobAdapter) Build(name, namespace string, spec *burninv1alpha1.Wor
 	return trainJob, nil
 }
 
-func (a *TrainJobAdapter) InjectPodLabel(spec *burninv1alpha1.WorkloadSpec, key, value string) {
+func (a *TrainJobAdapter) InjectPodLabel(spec *crev1alpha1.WorkloadSpec, key, value string) {
 	if spec.TrainJob == nil {
 		return
 	}
@@ -80,7 +80,7 @@ func (a *TrainJobAdapter) InjectPodLabel(spec *burninv1alpha1.WorkloadSpec, key,
 	podTemplate.Metadata.Labels[key] = value
 }
 
-func (a *TrainJobAdapter) SetNodeSelector(spec *burninv1alpha1.WorkloadSpec, selector map[string]string) {
+func (a *TrainJobAdapter) SetNodeSelector(spec *crev1alpha1.WorkloadSpec, selector map[string]string) {
 	if spec.TrainJob == nil {
 		return
 	}
@@ -95,7 +95,7 @@ func (a *TrainJobAdapter) SetNodeSelector(spec *burninv1alpha1.WorkloadSpec, sel
 	maps.Copy(podSpec.NodeSelector, selector)
 }
 
-func (a *TrainJobAdapter) SetNodeAffinity(spec *burninv1alpha1.WorkloadSpec, affinity *corev1.NodeAffinity) {
+func (a *TrainJobAdapter) SetNodeAffinity(spec *crev1alpha1.WorkloadSpec, affinity *corev1.NodeAffinity) {
 	if spec.TrainJob == nil {
 		return
 	}
@@ -111,7 +111,7 @@ func (a *TrainJobAdapter) SetNodeAffinity(spec *burninv1alpha1.WorkloadSpec, aff
 	}
 }
 
-func (a *TrainJobAdapter) SetTolerations(spec *burninv1alpha1.WorkloadSpec, tolerations []corev1.Toleration) {
+func (a *TrainJobAdapter) SetTolerations(spec *crev1alpha1.WorkloadSpec, tolerations []corev1.Toleration) {
 	if spec.TrainJob == nil {
 		return
 	}
@@ -125,7 +125,7 @@ func (a *TrainJobAdapter) SetTolerations(spec *burninv1alpha1.WorkloadSpec, tole
 	}
 }
 
-func (a *TrainJobAdapter) NodesRequired(spec *burninv1alpha1.WorkloadSpec) (int, error) {
+func (a *TrainJobAdapter) NodesRequired(spec *crev1alpha1.WorkloadSpec) (int, error) {
 	if spec.TrainJob == nil {
 		return 0, fmt.Errorf("WorkloadSpec.TrainJob is nil")
 	}
@@ -135,7 +135,7 @@ func (a *TrainJobAdapter) NodesRequired(spec *burninv1alpha1.WorkloadSpec) (int,
 	return int(*spec.TrainJob.Trainer.NumNodes), nil
 }
 
-func (a *TrainJobAdapter) SetNumNodes(spec *burninv1alpha1.WorkloadSpec, numNodes int) {
+func (a *TrainJobAdapter) SetNumNodes(spec *crev1alpha1.WorkloadSpec, numNodes int) {
 	if spec.TrainJob == nil || spec.TrainJob.Trainer == nil {
 		return
 	}
@@ -194,7 +194,7 @@ func workerTargetJob(patches []trainerv1alpha1.RuntimePatch) string {
 // HasLauncherTarget reports whether the workload spec contains an MPI launcher
 // target in its runtimePatches. Used by the workflow controller to decide
 // whether to apply global tolerations (only MPI workloads need them).
-func HasLauncherTarget(spec *burninv1alpha1.WorkloadSpec) bool {
+func HasLauncherTarget(spec *crev1alpha1.WorkloadSpec) bool {
 	if spec.TrainJob == nil {
 		return false
 	}

--- a/pkg/workloadrun/build_workflow_spec_test.go
+++ b/pkg/workloadrun/build_workflow_spec_test.go
@@ -10,8 +10,8 @@ import (
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // BuildWorkflowSpec renders the Workflow that "ncrectl workloadrun render" and
@@ -38,11 +38,11 @@ func TestBuildWorkflowSpec(t *testing.T) {
 		// error. With yaml tags, a typo in a key would go unnoticed and would
 		// write gpusPerNode: 0 into the expected file.
 		var input struct {
-			Run           burninv1alpha1.WorkloadRun `json:"run"`
-			GpusPerNode   int32                      `json:"gpusPerNode"`
-			MlnxPerNode   int32                      `json:"mlnxPerNode"`
-			EnableMNNVL   bool                       `json:"enableMNNVL"`
-			FrameworkType string                     `json:"frameworkType"`
+			Run           crev1alpha1.WorkloadRun `json:"run"`
+			GpusPerNode   int32                   `json:"gpusPerNode"`
+			MlnxPerNode   int32                   `json:"mlnxPerNode"`
+			EnableMNNVL   bool                    `json:"enableMNNVL"`
+			FrameworkType string                  `json:"frameworkType"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -69,7 +69,7 @@ type projection struct {
 	// Validation records the contents and not only whether the block is
 	// present. The exact threshold key is part of it, because issue #52 is open
 	// about one unknown key turning off every threshold check without saying so.
-	Validation *burninv1alpha1.ValidationSpec `json:"validation"`
+	Validation *crev1alpha1.ValidationSpec `json:"validation"`
 	// WorkerEnv holds "NAME=value" for the worker container of the runtime
 	// dependency, which is the container the workload runs in. It records values
 	// and not only names, so a case can tell a variable the user asked for apart
@@ -92,7 +92,7 @@ type projection struct {
 	GangSchedulerQueue string `json:"gangSchedulerQueue,omitempty"`
 }
 
-func project(s *burninv1alpha1.WorkflowSpec) projection {
+func project(s *crev1alpha1.WorkflowSpec) projection {
 	out := projection{
 		Iterations:    s.Orchestration.Iterations,
 		Validation:    s.Validation,
@@ -112,7 +112,7 @@ func project(s *burninv1alpha1.WorkflowSpec) projection {
 }
 
 // dependencyKind reads the Kind out of a dependency's embedded raw resource.
-func dependencyKind(d *burninv1alpha1.DependencySpec) string {
+func dependencyKind(d *crev1alpha1.DependencySpec) string {
 	var obj struct {
 		Kind string `json:"kind"`
 	}
@@ -127,7 +127,7 @@ func dependencyKind(d *burninv1alpha1.DependencySpec) string {
 // gang-scheduler queue label. It follows one named path rather than searching
 // the document, because a search would also find containers the workload does
 // not run in (e.g. an MPI launcher).
-func runtimeWorker(s *burninv1alpha1.WorkflowSpec) (env, mounts, volumes []string, schedulerName, queueLabel string) {
+func runtimeWorker(s *crev1alpha1.WorkflowSpec) (env, mounts, volumes []string, schedulerName, queueLabel string) {
 	if len(s.Dependencies) == 0 || len(s.Dependencies[0].Raw) == 0 {
 		return nil, nil, nil, "", ""
 	}
@@ -172,7 +172,7 @@ func TestValidateExecFramework(t *testing.T) {
 		ExpectedSuffix: ".json",
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
-		var spec burninv1alpha1.WorkloadRunSpec
+		var spec crev1alpha1.WorkloadRunSpec
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &spec); err != nil {
 			return err
 		}

--- a/pkg/workloadrun/run_overrides_test.go
+++ b/pkg/workloadrun/run_overrides_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/testutil"
 )
 
 // applyRunOverrides merges the command line flags into the spec that was read
@@ -24,12 +24,12 @@ func TestApplyRunOverrides(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Run            burninv1alpha1.WorkloadRun `yaml:"run"`
-			NameOverride   string                     `yaml:"nameOverride"`
-			NodeList       string                     `yaml:"nodeList"`
-			TopologyDomain string                     `yaml:"topologyDomain"`
-			TopologyKey    string                     `yaml:"topologyKey"`
-			TestScale      string                     `yaml:"testScale"`
+			Run            crev1alpha1.WorkloadRun `yaml:"run"`
+			NameOverride   string                  `yaml:"nameOverride"`
+			NodeList       string                  `yaml:"nodeList"`
+			TopologyDomain string                  `yaml:"topologyDomain"`
+			TopologyKey    string                  `yaml:"topologyKey"`
+			TestScale      string                  `yaml:"testScale"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
@@ -40,10 +40,10 @@ func TestApplyRunOverrides(t *testing.T) {
 			input.TopologyDomain, input.TopologyKey, input.TestScale)
 
 		out := struct {
-			Name     string                                `json:"name"`
-			NumNodes int32                                 `json:"numNodes"`
-			Target   *burninv1alpha1.TargetSpec            `json:"target"`
-			Orch     *burninv1alpha1.WorkloadOrchestration `json:"orchestration"`
+			Name     string                             `json:"name"`
+			NumNodes int32                              `json:"numNodes"`
+			Target   *crev1alpha1.TargetSpec            `json:"target"`
+			Orch     *crev1alpha1.WorkloadOrchestration `json:"orchestration"`
 		}{run.Name, run.Spec.NumNodes, run.Spec.Target, run.Spec.Orchestration}
 
 		b, err := json.MarshalIndent(out, "", "  ")

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/kubeconfig"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,17 +27,17 @@ import (
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/cluster"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/controller"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/gpu"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/platform"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/report"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/setup"
-	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/catalog"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/cluster"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/controller"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/gpu"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/noderesults"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/platform"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/render"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/report"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/setup"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/pkg/workload"
 )
 
 const (
@@ -50,8 +50,8 @@ const (
 // intra-node means each node is tested on its own, so one node per Job however
 // many the run targets; the Workflow then makes one group per node. Anything
 // else keeps the requested count.
-func nodesPerJobForScale(orch *burninv1alpha1.WorkloadOrchestration, numNodes int32) int32 {
-	if orch != nil && orch.TestScale == burninv1alpha1.TestScaleIntraNode {
+func nodesPerJobForScale(orch *crev1alpha1.WorkloadOrchestration, numNodes int32) int32 {
+	if orch != nil && orch.TestScale == crev1alpha1.TestScaleIntraNode {
 		return 1
 	}
 	return numNodes
@@ -188,7 +188,7 @@ func runWorkloadRunRender(file, outputFormat, platformFlag string) error {
 	// If platform specified, apply overrides using synthetic nodes.
 	if platformFlag != "" {
 		nodes := loadSyntheticNodes(platformFlag, gpuArch)
-		orch := &burninv1alpha1.OrchestrationStatus{
+		orch := &crev1alpha1.OrchestrationStatus{
 			DetectedPlatform:        platformFlag,
 			DetectedGPUArchitecture: gpuArch,
 		}
@@ -200,7 +200,7 @@ func runWorkloadRunRender(file, outputFormat, platformFlag string) error {
 	}
 
 	// Build output Workflow.
-	workflow := &burninv1alpha1.Workflow{
+	workflow := &crev1alpha1.Workflow{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cre.nvidia.com/v1alpha1",
 			Kind:       "Workflow",
@@ -237,9 +237,9 @@ func runWorkloadRunRender(file, outputFormat, platformFlag string) error {
 // BuildWorkflowSpec constructs a WorkflowSpec from a WorkloadRun
 // (shared logic between controller and CLI).
 func BuildWorkflowSpec(
-	run *burninv1alpha1.WorkloadRun,
+	run *crev1alpha1.WorkloadRun,
 	gpusPerNode, mlnxPerNode int32, enableMNNVL bool, frameworkType string,
-) *burninv1alpha1.WorkflowSpec {
+) *crev1alpha1.WorkflowSpec {
 	spec := &run.Spec
 
 	// Build merged env vars.
@@ -288,7 +288,7 @@ func BuildWorkflowSpec(
 		rtCfg.GangSchedulerQueue = spec.GangScheduler.Queue
 	}
 
-	var runtimeDep burninv1alpha1.DependencySpec
+	var runtimeDep crev1alpha1.DependencySpec
 	switch frameworkType {
 	case controller.FrameworkTorch:
 		runtimeDep = platform.BuildTorchRuntime(rtCfg)
@@ -298,7 +298,7 @@ func BuildWorkflowSpec(
 		runtimeDep = platform.BuildExecRuntime(rtCfg)
 	}
 
-	deps := []burninv1alpha1.DependencySpec{runtimeDep}
+	deps := []crev1alpha1.DependencySpec{runtimeDep}
 
 	if spec.Config != nil && len(spec.Config.Inline) > 0 {
 		deps = append(deps, buildWRCLIConfigMapDep(run.Name, spec.Config.Inline))
@@ -308,7 +308,7 @@ func BuildWorkflowSpec(
 	jobTemplate := buildCLIJobTemplate(run, frameworkType, gpusPerNode, enableMNNVL)
 
 	// Build OrchestrationSpec.
-	orch := &burninv1alpha1.OrchestrationSpec{
+	orch := &crev1alpha1.OrchestrationSpec{
 		Target:     spec.Target,
 		Iterations: 1,
 	}
@@ -320,11 +320,11 @@ func BuildWorkflowSpec(
 		case "intra-rack":
 			// TopologyKey is set by platform override (workloadrun.yaml)
 			// to the platform's physical rack label.
-			orch.Topology = &burninv1alpha1.TopologySpec{
+			orch.Topology = &crev1alpha1.TopologySpec{
 				StrictDomain: true,
 			}
 		}
-		exec := burninv1alpha1.ExecutionSpec{}
+		exec := crev1alpha1.ExecutionSpec{}
 		if spec.Orchestration.MaxConcurrent != nil {
 			exec.MaxConcurrent = int(*spec.Orchestration.MaxConcurrent)
 		}
@@ -346,13 +346,13 @@ func BuildWorkflowSpec(
 		FrameworkType: frameworkType,
 	}
 	wrOverrides := platform.BuildOverrides(overrideCfg)
-	overrides := make([]burninv1alpha1.OverrideSpec, 0, len(wrOverrides)+len(spec.Overrides))
+	overrides := make([]crev1alpha1.OverrideSpec, 0, len(wrOverrides)+len(spec.Overrides))
 	for _, o := range wrOverrides {
 		overrides = append(overrides, o.OverrideSpec)
 	}
 	overrides = append(overrides, spec.Overrides...)
 
-	workflowSpec := &burninv1alpha1.WorkflowSpec{
+	workflowSpec := &crev1alpha1.WorkflowSpec{
 		JobTemplate:   *jobTemplate,
 		Orchestration: *orch,
 		Dependencies:  deps,
@@ -360,10 +360,10 @@ func BuildWorkflowSpec(
 	}
 
 	if len(spec.Thresholds) > 0 {
-		workflowSpec.Validation = &burninv1alpha1.ValidationSpec{
-			Performance: &burninv1alpha1.PerformanceValidationSpec{
+		workflowSpec.Validation = &crev1alpha1.ValidationSpec{
+			Performance: &crev1alpha1.PerformanceValidationSpec{
 				Enabled: true,
-				Thresholds: &burninv1alpha1.ThresholdSpec{
+				Thresholds: &crev1alpha1.ThresholdSpec{
 					Thresholds: spec.Thresholds,
 				},
 			},
@@ -376,7 +376,7 @@ func BuildWorkflowSpec(
 // validateExecFramework returns an error when the exec framework is implied
 // (neither Torch nor MPI is set) but spec.Framework.Exec is nil, which would
 // cause a nil-pointer dereference inside buildCLIJobTemplate.
-func validateExecFramework(spec *burninv1alpha1.WorkloadRunSpec, name string) error {
+func validateExecFramework(spec *crev1alpha1.WorkloadRunSpec, name string) error {
 	if spec.Framework.Torch == nil && spec.Framework.MPI == nil && spec.Framework.Exec == nil {
 		return fmt.Errorf("workloadrun %s: exec framework selected but spec.framework.exec is nil", name)
 	}
@@ -384,8 +384,8 @@ func validateExecFramework(spec *burninv1alpha1.WorkloadRunSpec, name string) er
 }
 
 func buildCLIJobTemplate(
-	run *burninv1alpha1.WorkloadRun, frameworkType string, gpusPerNode int32, enableMNNVL bool,
-) *burninv1alpha1.JobTemplateSpec {
+	run *crev1alpha1.WorkloadRun, frameworkType string, gpusPerNode int32, enableMNNVL bool,
+) *crev1alpha1.JobTemplateSpec {
 	spec := &run.Spec
 
 	var command []string
@@ -443,12 +443,12 @@ func buildCLIJobTemplate(
 
 	workload.SetImagePullSecrets(trainJobSpec, spec.ImagePullSecrets)
 
-	jobSpec := burninv1alpha1.JobSpec{
-		Workload: burninv1alpha1.WorkloadSpec{
+	jobSpec := crev1alpha1.JobSpec{
+		Workload: crev1alpha1.WorkloadSpec{
 			TrainJob: trainJobSpec,
 		},
-		NodeHealthMonitor: &burninv1alpha1.NodeHealthMonitor{
-			CEL: &burninv1alpha1.CELNodeHealthCheck{
+		NodeHealthMonitor: &crev1alpha1.NodeHealthMonitor{
+			CEL: &crev1alpha1.CELNodeHealthCheck{
 				Expression: "node.spec.unschedulable == true",
 			},
 		},
@@ -461,10 +461,10 @@ func buildCLIJobTemplate(
 		jobSpec.BandwidthMeasurement = spec.BandwidthMeasurement
 	}
 
-	return &burninv1alpha1.JobTemplateSpec{Spec: jobSpec}
+	return &crev1alpha1.JobTemplateSpec{Spec: jobSpec}
 }
 
-func buildWRCLIConfigMapDep(name string, data map[string]string) burninv1alpha1.DependencySpec {
+func buildWRCLIConfigMapDep(name string, data map[string]string) crev1alpha1.DependencySpec {
 	cm := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
@@ -475,7 +475,7 @@ func buildWRCLIConfigMapDep(name string, data map[string]string) burninv1alpha1.
 		"data": data,
 	}
 	raw, _ := json.Marshal(cm)
-	return burninv1alpha1.DependencySpec{
+	return crev1alpha1.DependencySpec{
 		RawExtension: kruntime.RawExtension{Raw: raw},
 	}
 }
@@ -534,7 +534,7 @@ func runWorkloadRunRenderDryRun(
 	workflowSpec := BuildWorkflowSpec(
 		run, gpusPerNode, mlnxPerNode, enableMNNVL, frameworkType)
 
-	orch := &burninv1alpha1.OrchestrationStatus{
+	orch := &crev1alpha1.OrchestrationStatus{
 		DetectedPlatform:        detectedPlatform,
 		DetectedGPUArchitecture: gpuArch,
 	}
@@ -545,7 +545,7 @@ func runWorkloadRunRenderDryRun(
 	}
 	workflowSpec.Overrides = nil
 
-	workflow := &burninv1alpha1.Workflow{
+	workflow := &crev1alpha1.Workflow{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cre.nvidia.com/v1alpha1",
 			Kind:       "Workflow",
@@ -824,7 +824,7 @@ func runWorkloadRunExecute(
 func watchWorkloadRun(
 	ctx context.Context, c client.WithWatch,
 	name, namespace string, timeout time.Duration, _ io.Writer,
-) (*burninv1alpha1.WorkloadRun, error) {
+) (*crev1alpha1.WorkloadRun, error) {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -836,16 +836,16 @@ func watchWorkloadRun(
 		case <-deadline:
 			return nil, fmt.Errorf("timeout waiting for WorkloadRun %s", name)
 		case <-ticker.C:
-			var current burninv1alpha1.WorkloadRun
+			var current crev1alpha1.WorkloadRun
 			key := client.ObjectKey{Name: name, Namespace: namespace}
 			if err := c.Get(ctx, key, &current); err != nil {
 				continue
 			}
-			if controller.CondIsTrue(current.Status.Conditions, burninv1alpha1.WorkloadRunSucceeded) {
+			if controller.CondIsTrue(current.Status.Conditions, crev1alpha1.WorkloadRunSucceeded) {
 				return &current, nil
 			}
-			if controller.CondIsTrue(current.Status.Conditions, burninv1alpha1.WorkloadRunFailed) {
-				msg := controller.CondMessage(current.Status.Conditions, burninv1alpha1.WorkloadRunFailed)
+			if controller.CondIsTrue(current.Status.Conditions, crev1alpha1.WorkloadRunFailed) {
+				msg := controller.CondMessage(current.Status.Conditions, crev1alpha1.WorkloadRunFailed)
 				return &current, fmt.Errorf("WorkloadRun failed: %s", msg)
 			}
 		}
@@ -854,14 +854,14 @@ func watchWorkloadRun(
 
 // --- helpers ---
 
-func readWorkloadRun(file string) (*burninv1alpha1.WorkloadRun, error) {
+func readWorkloadRun(file string) (*crev1alpha1.WorkloadRun, error) {
 	data, err := os.ReadFile(file) // #nosec G304 -- file is a user-provided CLI argument
 
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", file, err)
 	}
 
-	var run burninv1alpha1.WorkloadRun
+	var run crev1alpha1.WorkloadRun
 	if err := yaml.NewYAMLOrJSONDecoder(
 		bytes.NewReader(data), 4096).Decode(&run); err != nil {
 		return nil, fmt.Errorf("parsing WorkloadRun: %w", err)
@@ -945,7 +945,7 @@ func runWorkloadRunReport(
 		return fmt.Errorf("build kubernetes client: %w", err)
 	}
 
-	var run burninv1alpha1.WorkloadRun
+	var run crev1alpha1.WorkloadRun
 	if err := c.Get(ctx, client.ObjectKey{
 		Name: name, Namespace: namespace,
 	}, &run); err != nil {
@@ -976,9 +976,9 @@ func runWorkloadRunReport(
 	}
 
 	succeeded := controller.CondIsTrue(
-		run.Status.Conditions, burninv1alpha1.WorkloadRunSucceeded)
+		run.Status.Conditions, crev1alpha1.WorkloadRunSucceeded)
 	failed := controller.CondIsTrue(
-		run.Status.Conditions, burninv1alpha1.WorkloadRunFailed)
+		run.Status.Conditions, crev1alpha1.WorkloadRunFailed)
 	if !succeeded && !failed {
 		return fmt.Errorf("workloadrun %q is still running", name)
 	}
@@ -992,14 +992,14 @@ func runWorkloadRunReport(
 // its child Workflow. Reuses the same report model and PopulateCategoryFromWorkflow
 // function as certification reports.
 func buildWorkloadRunReport(
-	ctx context.Context, c client.Client, run *burninv1alpha1.WorkloadRun,
+	ctx context.Context, c client.Client, run *crev1alpha1.WorkloadRun,
 ) *report.CertReport {
 	result := "RUNNING"
 	if controller.CondIsTrue(
-		run.Status.Conditions, burninv1alpha1.WorkloadRunFailed) {
+		run.Status.Conditions, crev1alpha1.WorkloadRunFailed) {
 		result = "FAILED"
 	} else if controller.CondIsTrue(
-		run.Status.Conditions, burninv1alpha1.WorkloadRunSucceeded) {
+		run.Status.Conditions, crev1alpha1.WorkloadRunSucceeded) {
 		result = "PASSED"
 	}
 
@@ -1019,7 +1019,7 @@ func buildWorkloadRunReport(
 	}
 
 	if run.Status.WorkflowRef != nil {
-		wf := &burninv1alpha1.Workflow{}
+		wf := &crev1alpha1.Workflow{}
 		ns := run.Status.WorkflowRef.Namespace
 		if ns == "" {
 			ns = run.Namespace
@@ -1033,11 +1033,11 @@ func buildWorkloadRunReport(
 
 			// Set category status from Workflow conditions.
 			switch {
-			case controller.CondIsTrue(wf.Status.Conditions, burninv1alpha1.WorkflowSucceeded):
+			case controller.CondIsTrue(wf.Status.Conditions, crev1alpha1.WorkflowSucceeded):
 				cat.Status = "Succeeded"
-			case controller.CondIsTrue(wf.Status.Conditions, burninv1alpha1.WorkflowFailed):
+			case controller.CondIsTrue(wf.Status.Conditions, crev1alpha1.WorkflowFailed):
 				cat.Status = statusFailed
-			case controller.CondIsTrue(wf.Status.Conditions, burninv1alpha1.WorkflowInProgress):
+			case controller.CondIsTrue(wf.Status.Conditions, crev1alpha1.WorkflowInProgress):
 				cat.Status = "Running"
 			}
 
@@ -1053,7 +1053,7 @@ func buildWorkloadRunReport(
 
 // applyRunOverrides modifies a WorkloadRun based on CLI override flags.
 func applyRunOverrides(
-	run *burninv1alpha1.WorkloadRun,
+	run *crev1alpha1.WorkloadRun,
 	nameOverride, nodeList, topologyDomain, topologyKey, testScale string,
 ) {
 	if nameOverride != "" {
@@ -1062,7 +1062,7 @@ func applyRunOverrides(
 	if nodeList != "" {
 		names := strings.Split(nodeList, ",")
 		if run.Spec.Target == nil {
-			run.Spec.Target = &burninv1alpha1.TargetSpec{}
+			run.Spec.Target = &crev1alpha1.TargetSpec{}
 		}
 		run.Spec.Target.NodeNames = names
 		if int32(len(names)) < run.Spec.NumNodes {
@@ -1071,7 +1071,7 @@ func applyRunOverrides(
 	}
 	if topologyDomain != "" {
 		if run.Spec.Target == nil {
-			run.Spec.Target = &burninv1alpha1.TargetSpec{}
+			run.Spec.Target = &crev1alpha1.TargetSpec{}
 		}
 		key := topologyKey
 		if key == "" {
@@ -1087,14 +1087,14 @@ func applyRunOverrides(
 	}
 	if testScale != "" {
 		if run.Spec.Orchestration == nil {
-			run.Spec.Orchestration = &burninv1alpha1.WorkloadOrchestration{}
+			run.Spec.Orchestration = &crev1alpha1.WorkloadOrchestration{}
 		}
 		run.Spec.Orchestration.TestScale = testScale
 	}
 }
 
 // buildNodeResults flattens orchestration groups into per-node pass/fail results.
-func buildNodeResults(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1.FailedNode) []report.NodeResultReport {
+func buildNodeResults(wf *crev1alpha1.Workflow, failedNodes []crev1alpha1.FailedNode) []report.NodeResultReport {
 	orch := wf.Status.Orchestration
 	if orch == nil {
 		return nil
@@ -1107,7 +1107,7 @@ func buildNodeResults(wf *burninv1alpha1.Workflow, failedNodes []burninv1alpha1.
 	var results []report.NodeResultReport
 	for _, g := range orch.Groups {
 		groupStatus := "Passed"
-		if g.Phase == burninv1alpha1.GroupFailed {
+		if g.Phase == crev1alpha1.GroupFailed {
 			groupStatus = statusFailed
 		}
 		rack := ""
@@ -1159,7 +1159,7 @@ func newWorkloadRunStatusCommand() *cobra.Command {
 				return err
 			}
 
-			var run burninv1alpha1.WorkloadRun
+			var run crev1alpha1.WorkloadRun
 			if err := c.Get(ctx, client.ObjectKey{
 				Name: args[0], Namespace: namespace,
 			}, &run); err != nil {
@@ -1171,11 +1171,11 @@ func newWorkloadRunStatusCommand() *cobra.Command {
 
 			status := "Pending"
 			switch {
-			case controller.CondIsTrue(run.Status.Conditions, burninv1alpha1.WorkloadRunSucceeded):
+			case controller.CondIsTrue(run.Status.Conditions, crev1alpha1.WorkloadRunSucceeded):
 				status = "Succeeded"
-			case controller.CondIsTrue(run.Status.Conditions, burninv1alpha1.WorkloadRunFailed):
+			case controller.CondIsTrue(run.Status.Conditions, crev1alpha1.WorkloadRunFailed):
 				status = "Failed"
-			case controller.CondIsTrue(run.Status.Conditions, burninv1alpha1.WorkloadRunInProgress):
+			case controller.CondIsTrue(run.Status.Conditions, crev1alpha1.WorkloadRunInProgress):
 				status = "InProgress"
 			}
 
@@ -1223,7 +1223,7 @@ func newWorkloadRunCancelCommand() *cobra.Command {
 
 			var lastErr error
 			for _, name := range args {
-				run := &burninv1alpha1.WorkloadRun{
+				run := &crev1alpha1.WorkloadRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: namespace,

--- a/test/uat/Tiltfile
+++ b/test/uat/Tiltfile
@@ -10,7 +10,7 @@
 #   make tilt-uat-ci     # CI mode (headless, exits after deploy)
 
 KWOK_VERSION = os.getenv('KWOK_VERSION', 'v0.7.0')
-IMG = os.getenv('IMG', 'ghcr.io/nvidia/cluster-readiness-engine/manager:uat-test')
+IMG = os.getenv('IMG', 'ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:uat-test')
 NCRECTL = os.getenv('NCRECTL', '../../bin/ncrectl')
 KIND_CLUSTER = os.getenv('KIND_CLUSTER_UAT', 'cre-test-uat')
 

--- a/test/uat/aws_gb200_nccl_test.go
+++ b/test/uat/aws_gb200_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestAWSGB200NCCL tests the full certification lifecycle for AWS GB200 NCCL all-reduce.

--- a/test/uat/aws_gb200_workloadrun_test.go
+++ b/test/uat/aws_gb200_workloadrun_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestAWSGB200WorkloadRunNemotron5 runs a Nemotron 5 (56B) training WorkloadRun

--- a/test/uat/aws_gb300_nccl_test.go
+++ b/test/uat/aws_gb300_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestAWSGB300NCCL tests the full certification lifecycle for AWS GB300 NCCL all-reduce.

--- a/test/uat/aws_h100_nccl_test.go
+++ b/test/uat/aws_h100_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 func TestAWSH100NCCL(t *testing.T) {

--- a/test/uat/aws_h100_workloadrun_test.go
+++ b/test/uat/aws_h100_workloadrun_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestAWSH100WorkloadRunNemotron5 runs a Nemotron 5 (56B) training WorkloadRun

--- a/test/uat/gcp_gb200_nccl_test.go
+++ b/test/uat/gcp_gb200_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestGCPGB200NCCL tests the full certification lifecycle for GCP GB200 NCCL all-reduce.

--- a/test/uat/gcp_h100_nccl_test.go
+++ b/test/uat/gcp_h100_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 // TestGCPH100NCCL tests the full certification lifecycle for GCP H100 NCCL all-reduce.

--- a/test/uat/togetherai_h100_nccl_test.go
+++ b/test/uat/togetherai_h100_nccl_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/NVIDIA/cluster-readiness-engine/test/uat/util"
+	"github.com/dsx-ai-factory/cluster-readiness-engine/test/uat/util"
 )
 
 func TestTogetherAIH100NCCL(t *testing.T) {

--- a/test/uat/util/helpers.go
+++ b/test/uat/util/helpers.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/yaml"
 
-	burninv1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	crev1alpha1 "github.com/dsx-ai-factory/cluster-readiness-engine/api/v1alpha1"
 )
 
 // Polling configuration.
@@ -47,7 +47,7 @@ var (
 func Scheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(s)
-	_ = burninv1alpha1.AddToScheme(s)
+	_ = crev1alpha1.AddToScheme(s)
 	_ = trainerv1alpha1.AddToScheme(s)
 	_ = batchv1.AddToScheme(s)
 	return s
@@ -140,9 +140,9 @@ func WaitForCertification(
 	key types.NamespacedName,
 	conditionType string,
 	timeout time.Duration,
-) *burninv1alpha1.Certification {
+) *crev1alpha1.Certification {
 	t.Helper()
-	cert := &burninv1alpha1.Certification{}
+	cert := &crev1alpha1.Certification{}
 	require.Eventually(t, func() bool {
 		if err := c.Get(ctx, key, cert); err != nil {
 			return false
@@ -280,7 +280,7 @@ func CompareCertification(
 ) {
 	t.Helper()
 
-	cert := &burninv1alpha1.Certification{}
+	cert := &crev1alpha1.Certification{}
 	require.NoError(t, c.Get(ctx, key, cert))
 	StripCertVolatile(cert)
 
@@ -420,7 +420,7 @@ func stripLabel(pod *corev1.Pod, key string) {
 }
 
 // StripCertVolatile removes timestamps and UIDs from a Certification.
-func StripCertVolatile(cert *burninv1alpha1.Certification) {
+func StripCertVolatile(cert *crev1alpha1.Certification) {
 	cert.ResourceVersion = ""
 	cert.UID = ""
 	cert.Generation = 0
@@ -449,7 +449,7 @@ func StripCertVolatile(cert *burninv1alpha1.Certification) {
 
 // DeleteCertification deletes a Certification and ignores not-found errors.
 func DeleteCertification(ctx context.Context, c client.Client, name, namespace string) {
-	cert := &burninv1alpha1.Certification{}
+	cert := &crev1alpha1.Certification{}
 	cert.Name = name
 	cert.Namespace = namespace
 	_ = client.IgnoreNotFound(c.Delete(ctx, cert))
@@ -542,9 +542,9 @@ func WaitForWorkloadRun(
 	key types.NamespacedName,
 	conditionType string,
 	timeout time.Duration,
-) *burninv1alpha1.WorkloadRun {
+) *crev1alpha1.WorkloadRun {
 	t.Helper()
-	run := &burninv1alpha1.WorkloadRun{}
+	run := &crev1alpha1.WorkloadRun{}
 	require.Eventually(t, func() bool {
 		if err := c.Get(ctx, key, run); err != nil {
 			return false
@@ -558,7 +558,7 @@ func WaitForWorkloadRun(
 
 // DeleteWorkloadRun deletes a WorkloadRun and ignores not-found errors.
 func DeleteWorkloadRun(ctx context.Context, c client.Client, name, namespace string) {
-	run := &burninv1alpha1.WorkloadRun{}
+	run := &crev1alpha1.WorkloadRun{}
 	run.Name = name
 	run.Namespace = namespace
 	_ = client.IgnoreNotFound(c.Delete(ctx, run))


### PR DESCRIPTION
## Summary

The repo transferred from the NVIDIA org to dsx-ai-factory; this migrates everything in-repo to the new home in one pass — 131 files, +293/−289.

- Go module path: `github.com/NVIDIA/cluster-readiness-engine` → `github.com/dsx-ai-factory/cluster-readiness-engine`, with every import rewritten (~112 Go files). `make manifests generate` ran clean — generated files don't embed the module path and are byte-identical
- `PROJECT`: the `repo:` field and four `resources[].path` entries updated — kubebuilder requires these to match the module path; this is the one sanctioned edit to a never-edit file, called out here deliberately
- **The 12 workflow guards** (`if: github.repository == 'NVIDIA/...'`) across ci/verify/codeql/release/publish/container-build/uat/govulncheck have been evaluating false since the transfer, silently skipping every job — **CI has not actually been running on any PR**. This fixes them, and publish/container-build/release now derive image refs and release-note URLs from `${{ github.repository }}` so a future transfer can't drift them again
- Runtime registry defaults moved: `pkg/setup` (`defaultImageRepository`, `helmChartOCI`), `--image` help text, Makefile `IMAGE_REPOSITORY`/`HELM_OCI_REGISTRY`, Tiltfile — clean sweep to `ghcr.io/dsx-ai-factory/...` (the official transfer moved the packages with the repo)
- Installer script (`GH_REPO`, usage URL), README badges/URLs, SECURITY.md cosign `--certificate-identity-regexp`, CONTRIBUTING/RELEASE/MAINTAINERS, issue templates, fern navbar link
- Deliberately unchanged (verified by exact match counts against main): `cre.nvidia.com` API group (1180 refs), `ncrectl.nvidia.com` annotations, `nvidia.com/*` labels, `nvcr.io` workload images, NVIDIA copyright headers

Justified remnants (14 lines, all inert): historical prose in five ADRs (docs/designs/038/039/045/064/065) describing decisions as they were made, and four `parse-image` test fixtures where the registry string is an arbitrary parser input, not a default.

Open question flagged, not changed: `fern/fern.config.json` `organization: nvidia` and the `docs.nvidia.com` custom domain identify the Fern publishing account, not the GitHub org — renaming them blindly would break docs publishing. Needs a decision on where docs hosting lives now.

Notes for merge sequencing:
- **Merge this before rebasing the open PR queue** — every open branch imports the old module path and gets updated by a rebase pass right after this lands
- Pre-rename tags (v0.1.0-rc.*) permanently embed the old module path in their go.mod; they stay fetchable via the old path (redirect + proxy cache). The first tag cut after this merge is clean under the new path

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [x] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [x] Catalog / Workloads
- [x] CLI (ncrectl)
- [x] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally (full unit suite + envtest integration suite green under the new module path; zero golden-file changes)
- [x] Manual testing completed (full-tree grep for both old paths returns only the 14 justified inert lines; must-not-change domains verified identical by match count)
- [x] No breaking changes (or documented — see merge-sequencing notes)

## Checklist
- [x] Self-review completed
- [x] `make manifests generate` run — clean, zero drift
- [ ] Golden files updated — n/a (none changed)
- [x] Documentation updated
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, contribution, security, release, and project links to the current repository location.
  * Refreshed examples and terminology to use Cluster Readiness Engine resources consistently.

* **Configuration**
  * Updated default controller images, container publishing paths, and Helm registry references.
  * CI, release, verification, security scanning, and UAT workflows now target the current repository and artifact locations.

* **Compatibility**
  * Updated API and command-line integrations to use the current repository identity while preserving existing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->