### PR TITLE
feat(ci): add Fern docs CI workflows and fix scaffold

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates Fern docs configuration on pull requests that touch docs or fern/.
+
+name: Fern Docs CI
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  changed-files:
+    runs-on: linux-amd64-cpu8
+    outputs:
+      docs: ${{ steps.changes.outputs.docs }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only "${{ github.event.before }}" HEAD 2>/dev/null | grep -qE '^(docs/|fern/)'; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+          else
+            echo "docs=false" >> $GITHUB_OUTPUT
+          fi
+
+  fern-check:
+    name: Fern Check
+    needs: changed-files
+    if: needs.changed-files.outputs.docs == 'true'
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install Fern CLI
+        run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
+
+      - name: Check MDX safety
+        run: |
+          BAD=$(grep -rn '<img\b[^>]*[^/]>\|<img>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
+            echo "$BAD"
+            exit 1
+          fi
+
+      - name: Fern check
+        run: fern check
+
+      - name: Check MDX validity
+        run: fern docs md check
+
+      - name: Check broken links
+        run: fern docs broken-links

--- a/.github/workflows/fern-docs-preflight.yml
+++ b/.github/workflows/fern-docs-preflight.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Docs pre-flight check — runs on a schedule and before releases.
+#
+# Complements the PR-time fern-docs-ci.yml with checks that are too slow or
+# network-dependent to run on every pull request:
+#
+#   1. External link check — lychee without --offline; catches link rot in
+#      external URLs that fern docs broken-links does not follow.
+#
+# Trigger manually before cutting a release to confirm the docs are clean.
+#
+# No secrets required.
+
+name: Fern Docs Preflight
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly, Monday 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  external-links:
+    name: External Link Check
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check external links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --no-progress
+            --exclude-loopback
+            --exclude 'localhost'
+            --exclude 'docs\.nvidia\.com'
+            --retry-wait-time 5
+            'docs/**/*.md'
+          fail: true

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workflow 1 of 2 for Fern doc previews.
+#
+# Collects the fern/ and docs/ sources plus PR metadata from the PR branch and
+# uploads them as an artifact. Both directories are needed because
+# fern/docs.yml references ../docs/index.yml; omitting docs/ causes
+# `fern generate --docs` to fail in the companion workflow. No secrets are
+# used here, so this is safe to run on fork PRs via the regular pull_request
+# trigger.
+#
+# The companion workflow (fern-docs-preview-comment.yml) picks up the artifact,
+# builds the preview with DOCS_FERN_TOKEN, and posts the PR comment.
+
+name: "Preview Fern Docs: Build"
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changed-files:
+    runs-on: linux-amd64-cpu8
+    outputs:
+      docs: ${{ steps.changes.outputs.docs }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs changes
+        id: changes
+        run: |
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only "${{ github.event.before }}" HEAD 2>/dev/null | grep -qE '^(docs/|fern/)'; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+          else
+            echo "docs=false" >> $GITHUB_OUTPUT
+          fi
+
+  collect:
+    needs: changed-files
+    if: needs.changed-files.outputs.docs == 'true'
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Save PR metadata
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          mkdir -p preview-metadata
+          echo "${BRANCH_NAME#pull-request/}" > preview-metadata/pr_number
+          echo "$BRANCH_NAME" > preview-metadata/head_ref
+          git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
+
+      - name: Checkout frozen version content
+        run: |
+          set -eo pipefail
+          for version_file in fern/versions/v*.yml; do
+            [ -f "$version_file" ] || continue
+            version=$(basename "$version_file" .yml)
+            if git show-ref --verify --quiet "refs/tags/${version}"; then
+              mkdir -p "fern/versions/${version}-content"
+              git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
+              echo "Extracted docs from $version"
+            else
+              echo "::error::Tag $version not found — cannot load frozen docs content"
+              exit 1
+            fi
+          done
+
+      - name: Upload fern sources and metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fern-preview
+          path: |
+            fern/
+            docs/
+            preview-metadata/
+          retention-days: 1

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workflow 2 of 2 for Fern doc previews.
+#
+# Triggered by workflow_run after "Preview Fern Docs: Build" completes.
+# Downloads the fern/ artifact, builds a preview with DOCS_FERN_TOKEN, and
+# posts a stable :herb: comment on the PR. This workflow never checks out the
+# PR branch directly, keeping secrets isolated from untrusted code.
+#
+# Required configuration:
+# - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
+
+name: "Preview Fern Docs: Comment"
+
+on:
+  workflow_run:
+    workflows: ["Preview Fern Docs: Build"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 15
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download fern sources and metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fern-preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: metadata
+        run: |
+          echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install Fern CLI
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r .version fern/fern.config.json)
+          if ! [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?|latest)$ ]]; then
+            echo "::error::fern.config.json .version '$VERSION' is not a valid semver or 'latest'"
+            exit 1
+          fi
+          npm install -g "fern-api@${VERSION}"
+
+      - name: Generate preview URL
+        id: generate-docs
+        env:
+          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+          HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
+        working-directory: ./fern
+        run: |
+          set -o pipefail
+          fern generate --docs --preview --id "$HEAD_REF" 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
+          if [ -z "$URL" ]; then
+            echo "::error::Failed to generate preview URL. See fern output above."
+            exit 1
+          fi
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Build page links for changed files
+        id: page-links
+        env:
+          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+        run: |
+          CHANGED_FILES=""
+          if [ -f preview-metadata/changed_md_files ]; then
+            CHANGED_FILES=$(cat preview-metadata/changed_md_files)
+          fi
+
+          if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          BASE_URL="${PREVIEW_URL%/}"
+          FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//' \
+            | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=',/'))")
+          RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          }
+
+          PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
+            '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
+
+          if [ -n "$PAGE_LINKS" ]; then
+            { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          else
+            echo "page_links=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post or update PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+          PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
+        run: |
+          BODY=":herb: **Preview your docs:** <${PREVIEW_URL}>"
+          if [ -n "${PAGE_LINKS}" ]; then
+            BODY="${BODY}
+
+          Here are the markdown pages you've updated:
+          ${PAGE_LINKS}"
+          fi
+
+          MARKER="<!-- preview-docs -->"
+          BODY="${BODY}
+
+          ${MARKER}"
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | tr -d '\r' | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="$BODY"
+          fi

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -39,10 +39,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-artifact:
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 5
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      has_artifact: ${{ steps.check.outputs.has_artifact }}
+    steps:
+      - name: Check for fern-preview artifact
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name == "fern-preview" and .expired == false)] | length')
+          echo "has_artifact=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
   preview:
+    needs: check-artifact
+    if: needs.check-artifact.outputs.has_artifact == 'true'
     runs-on: linux-amd64-cpu8
     timeout-minutes: 15
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Publishes the Fern documentation site on GitHub Release or manual dispatch.
+#
+# All versions serve frozen content extracted from their git tag — there is no
+# "live docs" entry. The newest version is stamped "Latest · vX.Y.Z" at publish
+# time so readers know which is current; the stamp is transient and not persisted.
+#
+# Manual dispatch accepts an optional `tag` input:
+#   - empty: resolves to the latest GitHub release tag
+#   - explicit (e.g. v1.2.0): publishes that tag
+#
+# On a vX.Y.Z release (publish or dispatch), the workflow also:
+#   1. Generates fern/versions/vX.Y.Z.yml from the tag's docs/index.yml
+#   2. Adds a version entry to fern/docs.yml, sorted by semver descending
+#   3. Prunes older versions to keep only the MAX_VERSIONS most recent
+#   4. Opens a PR to persist registry changes back to main (after publish)
+#
+# Pre-releases trigger publish but skip version registration.
+#
+# Required configuration:
+# - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
+
+name: Publish Fern Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v1.2.0). Leave empty to use the latest GitHub release tag."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: fern-publish
+  cancel-in-progress: true
+
+env:
+  YQ_VERSION: v4.53.2
+  MAX_VERSIONS: 3
+
+jobs:
+  publish:
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install yq
+        run: |
+          if command -v yq &>/dev/null; then
+            echo "yq already installed: $(yq --version)"
+          else
+            OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64)  ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+            esac
+            mkdir -p "$HOME/.local/bin"
+            curl -sSfL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${OS}_${ARCH}" -o "$HOME/.local/bin/yq"
+            chmod +x "$HOME/.local/bin/yq"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Resolve target tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -eo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            TAG="${RELEASE_TAG}"
+            IS_PRERELEASE="${RELEASE_PRERELEASE}"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          elif [ -n "${INPUT_TAG}" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName)
+            if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+              echo "::error::Could not determine latest release tag"
+              exit 1
+            fi
+          fi
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag '${TAG}' is not a valid semver tag (expected vMAJOR.MINOR.PATCH[-PRERELEASE])"
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
+            echo "::error::Tag '${TAG}' does not exist in this repository"
+            exit 1
+          fi
+          # Pre-release detection: use the Release event flag when available,
+          # fall back to hyphen check for tag-push and dispatch triggers.
+          if [ "${IS_PRERELEASE}" = "true" ] || [[ "$TAG" == *-* ]]; then
+            IS_RELEASE=false
+          else
+            IS_RELEASE=true
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
+
+      - name: Register new version from tag
+        if: steps.resolve.outputs.is_release == 'true'
+        env:
+          TAG_VERSION: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -eo pipefail
+
+          if [ -f "fern/versions/${TAG_VERSION}.yml" ]; then
+            echo "Version ${TAG_VERSION} already registered — skipping"
+            exit 0
+          fi
+
+          mkdir -p fern/versions
+          echo "Generating fern/versions/${TAG_VERSION}.yml from tag $TAG_VERSION"
+          git archive "refs/tags/${TAG_VERSION}" -- docs/index.yml | tar -xO docs/index.yml | \
+            sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
+
+          export TAG_VERSION
+          EXPR='.products[0].versions += [{"display-name": env(TAG_VERSION),'
+          EXPR+=' "path": "versions/" + env(TAG_VERSION) + ".yml",'
+          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}]'
+          yq -i "$EXPR" fern/docs.yml
+
+          # Sort all version entries by semver descending
+          SORTED_SLUGS=$(yq '.products[0].versions[].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = []' fern/docs.yml
+          for slug in $SORTED_SLUGS; do
+            export slug
+            yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
+          done
+
+          echo "--- docs.yml versions after insert + sort ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
+
+      - name: Prune old versions
+        if: steps.resolve.outputs.is_release == 'true'
+        run: |
+          set -eo pipefail
+          TOTAL=$(yq '.products[0].versions | length' fern/docs.yml)
+
+          if [ "$TOTAL" -le "$MAX_VERSIONS" ]; then
+            echo "Only $TOTAL versions — nothing to prune (keeping $MAX_VERSIONS)"
+            exit 0
+          fi
+
+          PRUNED=$(yq ".products[0].versions[$MAX_VERSIONS:][].slug" fern/docs.yml)
+          yq -i ".products[0].versions |= .[:$MAX_VERSIONS]" fern/docs.yml
+
+          for slug in $PRUNED; do
+            rm -f "fern/versions/${slug}.yml"
+            echo "Pruned $slug"
+          done
+
+          echo "--- docs.yml versions after prune ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
+
+      - name: Checkout frozen version content
+        run: |
+          set -eo pipefail
+          for version_file in fern/versions/v*.yml; do
+            [ -f "$version_file" ] || continue
+            version=$(basename "$version_file" .yml)
+            if git show-ref --verify --quiet "refs/tags/${version}"; then
+              mkdir -p "fern/versions/${version}-content"
+              git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
+              echo "Extracted docs from $version"
+            else
+              echo "::error::Tag $version not found — cannot pin frozen docs content"
+              exit 1
+            fi
+          done
+
+      - name: Stamp newest version as Latest
+        run: |
+          cp fern/docs.yml /tmp/docs.yml.preStamp
+          NEWEST=$(yq '.products[0].versions[0].display-name' fern/docs.yml)
+          if [ -n "$NEWEST" ] && [ "$NEWEST" != "null" ]; then
+            export NEWEST
+            yq -i '.products[0].versions[0].display-name = "Latest · " + env(NEWEST)' fern/docs.yml
+          fi
+          echo "--- docs.yml versions after stamp ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install Fern CLI
+        run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
+
+      - name: Publish docs
+        env:
+          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+        working-directory: ./fern
+        run: |
+          set -eo pipefail
+          fern generate --docs 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
+          if [ -n "$URL" ]; then
+            echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Restore unstamped docs.yml for persistence
+        if: steps.resolve.outputs.is_release == 'true'
+        run: cp /tmp/docs.yml.preStamp fern/docs.yml
+
+      - name: Open PR for version registry changes
+        if: steps.resolve.outputs.is_release == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: main
+          branch: chore/fern-register-${{ steps.resolve.outputs.tag }}
+          delete-branch: true
+          sign-commits: true
+          commit-message: "chore(fern): register ${{ steps.resolve.outputs.tag }}, keep latest ${{ env.MAX_VERSIONS }} versions [automated]"
+          title: "chore(fern): register ${{ steps.resolve.outputs.tag }}"
+          body: |
+            Automated registration of `${{ steps.resolve.outputs.tag }}` in the Fern docs versions registry.
+
+            Generated by the `Publish Fern Docs` workflow.
+          add-paths: |
+            fern/versions/v*.yml
+            fern/docs.yml

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -52,7 +52,7 @@ permissions:
 
 concurrency:
   group: fern-publish
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   YQ_VERSION: v4.53.2

--- a/docs/cli-reference/certification.md
+++ b/docs/cli-reference/certification.md
@@ -23,7 +23,7 @@ nvcrectl certification run --category communication/nccl-all-reduce [flags]
 | `--category` | — | Category in `domain/variant` format; repeatable (mutually exclusive with `--cert-file`) |
 | `--name` | auto | Certification name (default: `nvcrectl-<timestamp>`) |
 | `--setup` | `false` | Install CRDs, controller, and LogProfiles before creating the certification |
-| `--image` | — | Controller image for `--setup` (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Controller image for `--setup` (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
 | `--wait` | `false` | Block until the certification completes and print a report |
 | `--timeout` | derived | Timeout for `--wait`. When not set, derived from the selected categories' `timeoutPerJob` budgets (max across categories × iterations × 1.5), floored at `30m`; the CLI prints the derived value when the watch starts. An explicit value always wins. On timeout, the CLI prints a partial report and leaves the Certification running unless `--cleanup` is set. |
 | `--cleanup` | `false` | Delete the certification, namespace, and installed components after completion |

--- a/docs/cli-reference/certification.md
+++ b/docs/cli-reference/certification.md
@@ -23,7 +23,7 @@ nvcrectl certification run --category communication/nccl-all-reduce [flags]
 | `--category` | — | Category in `domain/variant` format; repeatable (mutually exclusive with `--cert-file`) |
 | `--name` | auto | Certification name (default: `nvcrectl-<timestamp>`) |
 | `--setup` | `false` | Install CRDs, controller, and LogProfiles before creating the certification |
-| `--image` | — | Controller image for `--setup` (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Controller image for `--setup` (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
 | `--wait` | `false` | Block until the certification completes and print a report |
 | `--timeout` | derived | Timeout for `--wait`. When not set, derived from the selected categories' `timeoutPerJob` budgets (max across categories × iterations × 1.5), floored at `30m`; the CLI prints the derived value when the watch starts. An explicit value always wins. On timeout, the CLI prints a partial report and leaves the Certification running unless `--cleanup` is set. |
 | `--cleanup` | `false` | Delete the certification, namespace, and installed components after completion |

--- a/docs/cli-reference/setup.md
+++ b/docs/cli-reference/setup.md
@@ -52,7 +52,7 @@ Automatic recovery deletes the `kubeflow-system` namespace, including anything y
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--image-pull-secret` | — | GitHub token — the CLI creates a `ghcr.io` pull secret and uses it to authenticate the Helm chart pull |
-| `--image` | — | Override the controller image (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Override the controller image (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
 | `--skip-phases` | — | Comma-separated phases to skip (e.g., `deps`) |
 | `--version` | — | Helm chart version to install (required for dev builds) |
 | `--auto-approve` | `false` | Skip the interactive confirmation prompt (for CI/automation) |
@@ -114,6 +114,8 @@ Runs three phases in order:
 | `deps` | Kubeflow Trainer |
 
 Use `--skip-phases=deps` to keep Kubeflow Trainer.
+
+After all phases complete, `setup reset` prints a **Retained resources** block listing any namespaces or secrets that were not deleted (Helm never removes the release namespace, and the `nvcrectl-pull-secret` created by `setup init` is outside the Helm release). Each entry includes the `kubectl delete` command to remove it manually if you want a pristine cluster.
 
 ### Flags
 

--- a/docs/cli-reference/setup.md
+++ b/docs/cli-reference/setup.md
@@ -52,7 +52,7 @@ Automatic recovery deletes the `kubeflow-system` namespace, including anything y
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--image-pull-secret` | — | GitHub token — the CLI creates a `ghcr.io` pull secret and uses it to authenticate the Helm chart pull |
-| `--image` | — | Override the controller image (default: `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager:<version>`) |
+| `--image` | — | Override the controller image (default: `ghcr.io/nvidia/cluster-readiness-engine/manager:<version>`) |
 | `--skip-phases` | — | Comma-separated phases to skip (e.g., `deps`) |
 | `--version` | — | Helm chart version to install (required for dev builds) |
 | `--auto-approve` | `false` | Skip the interactive confirmation prompt (for CI/automation) |

--- a/docs/concepts/platform-detection.md
+++ b/docs/concepts/platform-detection.md
@@ -59,12 +59,15 @@ A `jobTemplatePatch` that appends to an array must come **after** any `jobTempla
 
 ## Architecture-specific resources
 
-Different GPU architectures require different Kubernetes resources:
+Different GPU architectures and cloud platforms require different Kubernetes resources:
 
-| Architecture | Interconnect | Key resources |
-|-------------|-------------|--------------|
-| GB200 | EFA (AWS) | `hugepages-2Mi`, `vpc.amazonaws.com/efa`, EFA hostPath volume |
-| GB300 | RoCE (AWS) | `roce-channel` resource claim, no hugepages, no EFA |
-| H100 | EFA (AWS) | `vpc.amazonaws.com/efa: 32`, no hugepages |
+| Architecture | Platform | Interconnect | Key resources |
+|-------------|---------|-------------|--------------|
+| GB200 | AWS | EFA | `hugepages-2Mi`, `vpc.amazonaws.com/efa`, EFA hostPath volume, ComputeDomain |
+| GB200 | Azure | InfiniBand | mlnxnics dep, topo ConfigMap, ComputeDomain |
+| GB300 | AWS | RoCE | `roce-channel` resource claim (DRA), no hugepages, no EFA |
+| GB300 | Azure | InfiniBand | mlnxnics dep, topo ConfigMap, ComputeDomain |
+| H100 | AWS | EFA | `vpc.amazonaws.com/efa: 32`, no hugepages |
+| H100 | Azure | InfiniBand | mlnxnics dep, topo ConfigMap |
 
 The live controller tracks which overrides matched in `status.orchestration.appliedOverrides`. When using `nvcrectl workflow render`, the same information is also written to the `nvcrectl.nvidia.com/applied-overrides` annotation on the rendered manifest.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -15,7 +15,7 @@ CRE supports two install paths. Both pull the same artifacts from the GitHub Con
 | Method | Audience | Installs Kubeflow Trainer |
 |--------|----------|---------------------------|
 | `nvcrectl setup init` | Operators, quick setup | Yes (skip with `--skip-phases=deps`) |
-| Helm chart (`oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine`) | GitOps / platform teams | No (install separately) |
+| Helm chart (`oci://ghcr.io/nvidia/cluster-readiness-engine`) | GitOps / platform teams | No (install separately) |
 
 ### nvcrectl setup init
 
@@ -23,7 +23,7 @@ Install the CLI first with the installer script (see [Install](../getting-starte
 
 ```bash
 export NVCRECTL_VERSION=v0.1.0-rc.9
-curl -sSL "https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
+curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
 ```
 
 Then set up the cluster:
@@ -64,23 +64,23 @@ Then inspect and install, pinning an explicit version:
 ```bash
 CRE_VERSION=v0.1.0-rc.9
 
-helm show chart oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine --version "$CRE_VERSION"
+helm show chart oci://ghcr.io/nvidia/cluster-readiness-engine --version "$CRE_VERSION"
 
 helm install cluster-readiness-engine \
-  oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
+  oci://ghcr.io/nvidia/cluster-readiness-engine \
   --version "$CRE_VERSION" \
   --namespace cluster-readiness-engine \
   --create-namespace
 ```
 
-The controller image is `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
+The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
 
 Key chart values:
 
 | Value | Default | Purpose |
 |-------|---------|---------|
 | `manager.replicas` | `1` | Controller Deployment replicas |
-| `manager.image.repository` | `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager` | Controller image |
+| `manager.image.repository` | `ghcr.io/nvidia/cluster-readiness-engine/manager` | Controller image |
 | `manager.image.tag` | `""` (uses chart `appVersion`) | Controller image tag |
 | `manager.imagePullSecrets` | `[]` | Pull secrets for the controller image |
 | `manager.resources` | `10m/500m` CPU, `1Gi/1Gi` memory | Controller resource requests/limits |
@@ -200,7 +200,7 @@ CEL evaluation is lightweight per node, pod-to-node lookups use field indexes, a
 
 The controller runs without external network access at runtime. All catalog entries are embedded in the binary at compile time, and the controller makes no outbound API calls — it communicates only with the Kubernetes API server. For air-gapped deployment:
 
-1. Mirror the controller image (`ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`) and the Kubeflow Trainer images to your internal registry
+1. Mirror the controller image (`ghcr.io/nvidia/cluster-readiness-engine/manager`) and the Kubeflow Trainer images to your internal registry
 2. Install the Helm chart with `manager.image.repository` pointing at your internal registry
 3. Pre-load any workload images referenced by catalog entries (NeMo, NCCL tests)
 
@@ -239,7 +239,7 @@ readinessProbe:
 2. Upgrade the Helm release (log in to `ghcr.io` first, as above):
    ```bash
    helm upgrade cluster-readiness-engine \
-     oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
+     oci://ghcr.io/nvidia/cluster-readiness-engine \
      --version <new-version> \
      --namespace cluster-readiness-engine
    ```

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -15,15 +15,15 @@ CRE supports two install paths. Both pull the same artifacts from the GitHub Con
 | Method | Audience | Installs Kubeflow Trainer |
 |--------|----------|---------------------------|
 | `nvcrectl setup init` | Operators, quick setup | Yes (skip with `--skip-phases=deps`) |
-| Helm chart (`oci://ghcr.io/nvidia/cluster-readiness-engine`) | GitOps / platform teams | No (install separately) |
+| Helm chart (`oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine`) | GitOps / platform teams | No (install separately) |
 
 ### nvcrectl setup init
 
 Install the CLI first with the installer script (see [Install](../getting-started/install.md) for the full walkthrough):
 
 ```bash
-export NVCRECTL_VERSION=v0.1.0-rc.8
-curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
+export NVCRECTL_VERSION=v0.1.0-rc.9
+curl -sSL "https://github.com/dsx-ai-factory/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
 ```
 
 Then set up the cluster:
@@ -62,25 +62,25 @@ echo $GITHUB_TOKEN | helm registry login ghcr.io --username <github-username> --
 Then inspect and install, pinning an explicit version:
 
 ```bash
-CRE_VERSION=v0.1.0-rc.8
+CRE_VERSION=v0.1.0-rc.9
 
-helm show chart oci://ghcr.io/nvidia/cluster-readiness-engine --version "$CRE_VERSION"
+helm show chart oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine --version "$CRE_VERSION"
 
 helm install cluster-readiness-engine \
-  oci://ghcr.io/nvidia/cluster-readiness-engine \
+  oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
   --version "$CRE_VERSION" \
   --namespace cluster-readiness-engine \
   --create-namespace
 ```
 
-The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
+The controller image is `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
 
 Key chart values:
 
 | Value | Default | Purpose |
 |-------|---------|---------|
 | `manager.replicas` | `1` | Controller Deployment replicas |
-| `manager.image.repository` | `ghcr.io/nvidia/cluster-readiness-engine/manager` | Controller image |
+| `manager.image.repository` | `ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager` | Controller image |
 | `manager.image.tag` | `""` (uses chart `appVersion`) | Controller image tag |
 | `manager.imagePullSecrets` | `[]` | Pull secrets for the controller image |
 | `manager.resources` | `10m/500m` CPU, `1Gi/1Gi` memory | Controller resource requests/limits |
@@ -200,7 +200,7 @@ CEL evaluation is lightweight per node, pod-to-node lookups use field indexes, a
 
 The controller runs without external network access at runtime. All catalog entries are embedded in the binary at compile time, and the controller makes no outbound API calls — it communicates only with the Kubernetes API server. For air-gapped deployment:
 
-1. Mirror the controller image (`ghcr.io/nvidia/cluster-readiness-engine/manager`) and the Kubeflow Trainer images to your internal registry
+1. Mirror the controller image (`ghcr.io/dsx-ai-factory/cluster-readiness-engine/manager`) and the Kubeflow Trainer images to your internal registry
 2. Install the Helm chart with `manager.image.repository` pointing at your internal registry
 3. Pre-load any workload images referenced by catalog entries (NeMo, NCCL tests)
 
@@ -239,7 +239,7 @@ readinessProbe:
 2. Upgrade the Helm release (log in to `ghcr.io` first, as above):
    ```bash
    helm upgrade cluster-readiness-engine \
-     oci://ghcr.io/nvidia/cluster-readiness-engine \
+     oci://ghcr.io/dsx-ai-factory/cluster-readiness-engine \
      --version <new-version> \
      --namespace cluster-readiness-engine
    ```

--- a/fern/.gitignore
+++ b/fern/.gitignore
@@ -1,0 +1,2 @@
+.fern/
+node_modules/

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,16 +1,24 @@
 # yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 instances:
-  - url: cluster-readiness-engine.docs.buildwithfern.com/cluster-readiness-engine
+  - url: nvidia-cluster-readiness-engine.docs.buildwithfern.com/cluster-readiness-engine
     custom-domain: docs.nvidia.com/cluster-readiness-engine
     multi-source: true
+
+redirects:
+  - source: /cluster-readiness-engine/index.html
+    destination: /cluster-readiness-engine
 
 title: NVIDIA Cluster Readiness Engine
 
 global-theme: nvidia
+
+logo:
+  href: /cluster-readiness-engine
+  right-text: Cluster Readiness Engine
 
 navbar-links:
   - type: github

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.89.4"
+  "version": "latest"
 }


### PR DESCRIPTION
## Summary

- Add five GitHub Actions workflows for Fern docs: CI validation, preview build/comment, publish with version registry, and weekly external link preflight
- All workflows use copy-PR-bot triggers (`push: branches: pull-request/[0-9]+`) with changed-files gating and `linux-amd64-cpu8` self-hosted runners
- Fix scaffold: canonical instance URL (`nvidia-cluster-readiness-engine`), add redirects, logo block, `fern/.gitignore`, unpin Fern CLI to `latest`
- Doc fixes bundled in (opportunistic, caught during Fern CI bringup): bump rc.8 → rc.9; correct `ghcr.io`/GitHub URLs after org migration churn; expand platform-detection table with Azure InfiniBand rows for GB200/GB300/H100 (source: #192); add retained-resources note to `setup reset` CLI reference (source: #189)

Fixes #220

## Test plan

- [ ] Verify `fern check` passes locally against current docs
- [ ] Confirm CI workflow triggers on a docs PR via copy-PR-bot
- [ ] Confirm preview comment appears on a docs PR (requires `DOCS_FERN_TOKEN` org secret)
- [ ] Confirm publish fires on a GitHub Release (or manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)