### PR TITLE
fix: publish manager image to the documented GHCR path; fix installer on older gh

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Build container image (no push)
         run: make docker-buildx BUILDX_PUSH=
         env:
-          IMG: ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }}
+          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,11 +74,14 @@ jobs:
           make docker-buildx
           # Capture the image digest for signing
           DIGEST=$(docker buildx imagetools inspect \
-            ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }} \
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }} \
             --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         env:
-          IMG: ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }}
+          # GHCR paths must be lowercase and github.repository expands to
+          # uppercase 'NVIDIA/...', so the path is hardcoded. Keep in sync with
+          # the Makefile, helm values.yaml, and pkg/setup/setup.go.
+          IMG: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -86,12 +89,12 @@ jobs:
       - name: Sign container image
         run: |
           cosign sign --yes \
-            ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0.24.0
         with:
-          image: ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+          image: ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
 
@@ -100,4 +103,4 @@ jobs:
           cosign attest --yes \
             --predicate sbom.cyclonedx.json \
             --type cyclonedx \
-            ghcr.io/nvidia/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}
+            ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}@${{ steps.push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,9 @@ jobs:
       - name: Package and push Helm chart
         run: make helm-push VERSION="${{ steps.tag.outputs.value }}"
         env:
-          # Derive the OCI registry from the repository so a future org
-          # transfer cannot leave this workflow pushing to a stale path.
+          # GHCR requires lowercase paths but the repo slug is uppercase
+          # 'NVIDIA', so the value is hardcoded. Keep in sync with
+          # RELEASE.md and pkg/setup/helm.go.
           HELM_OCI_REGISTRY: oci://ghcr.io/nvidia
 
   build-cli:

--- a/installer
+++ b/installer
@@ -164,7 +164,7 @@ elif [[ "${GH_AVAILABLE}" == "true" ]]; then
   if [[ "${PRERELEASE}" == "true" ]]; then
     VERSION=$(gh release list --repo "${GH_REPO}" --limit 1 --json tagName -q '.[0].tagName')
   else
-    VERSION=$(gh release view --repo "${GH_REPO}" --json tagName -q '.tagName')
+    VERSION=$(gh release view --repo "${GH_REPO}" --json tagName -q '.tagName' || true)
   fi
 else
   msg "Fetching latest version..."
@@ -172,17 +172,17 @@ else
   if [[ "${PRERELEASE}" == "true" ]]; then
     ENDPOINT="${GH_API_URL}/releases?per_page=1"
     RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
-      -H "Accept: application/vnd.github.v3+json" "${ENDPOINT}")
-    VERSION=$(echo "${RELEASE_JSON}" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+      -H "Accept: application/vnd.github.v3+json" "${ENDPOINT}" || true)
+    VERSION=$(echo "${RELEASE_JSON}" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
   else
     RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
-      -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/latest")
-    VERSION=$(echo "${RELEASE_JSON}" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+      -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/latest" || true)
+    VERSION=$(echo "${RELEASE_JSON}" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
   fi
 fi
 
 if [[ -z "${VERSION}" ]]; then
-  err "Failed to determine latest version from GitHub releases"
+  err "Failed to determine latest version from GitHub releases. If every release is a pre-release, re-run with -p, or pin a version with -v <tag>."
 fi
 
 # Decide whether this is a fresh install or an upgrade and print intent.
@@ -212,9 +212,14 @@ if [[ "${GH_AVAILABLE}" == "true" ]]; then
   gh release download "${VERSION}" \
     --repo "${GH_REPO}" \
     --pattern "${BINARY_NAME}" \
-    --output "${TEMP_DIR}/${BINARY_NAME}" \
-    --clobber
+    --dir "${TEMP_DIR}"
 elif [[ -n "${GH_TOKEN}" ]]; then
+  # RELEASE_JSON is only set by the latest-version curl fallback above; fetch
+  # the release for the exact tag when the version came from -v or gh.
+  if [[ -z "${RELEASE_JSON:-}" ]]; then
+    RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
+      -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/tags/${VERSION}")
+  fi
   # Use the GitHub API asset endpoint with Accept: application/octet-stream.
   # GitHub redirects to a pre-signed S3 URL; the auth header is not forwarded.
   # Put each asset object on its own line, then pick the line whose name
@@ -225,7 +230,7 @@ elif [[ -n "${GH_TOKEN}" ]]; then
     | grep "\"name\" *: *\"${BINARY_NAME}\"" \
     | grep -o '"url" *: *"https://api\.github\.com[^"]*releases/assets/[0-9]*"' \
     | head -1 \
-    | sed 's/.*"\(https[^"]*\)".*/\1/')
+    | sed 's/.*"\(https[^"]*\)".*/\1/' || true)
 
   if [[ -z "${ASSET_URL}" ]]; then
     err "Binary ${BINARY_NAME} not found in release ${VERSION}"
@@ -256,14 +261,13 @@ if [[ "${GH_AVAILABLE}" == "true" ]]; then
   gh release download "${VERSION}" \
     --repo "${GH_REPO}" \
     --pattern "checksums.txt" \
-    --output "${CHECKSUMS_FILE}" \
-    --clobber 2>/dev/null || true
+    --dir "${TEMP_DIR}" 2>/dev/null || true
 elif [[ -n "${GH_TOKEN}" ]]; then
-  CHECKSUM_ASSET_URL=$(echo "${RELEASE_JSON}" | tr -d '\n' | tr '{' '\n' \
+  CHECKSUM_ASSET_URL=$(echo "${RELEASE_JSON:-}" | tr -d '\n' | tr '{' '\n' \
     | grep '"name" *: *"checksums\.txt"' \
     | grep -o '"url" *: *"https://api\.github\.com[^"]*releases/assets/[0-9]*"' \
     | head -1 \
-    | sed 's/.*"\(https[^"]*\)".*/\1/')
+    | sed 's/.*"\(https[^"]*\)".*/\1/' || true)
   if [[ -n "${CHECKSUM_ASSET_URL}" ]]; then
     curl -fsSL \
       -H "Authorization: token ${GH_TOKEN}" \


### PR DESCRIPTION
## Summary

v0.1.0-rc.12 shipped a controller image nobody can pull and an installer that breaks on stock Ubuntu. Verified against the CI run logs for the tag. Rebased on #222 (CRE → NVCRE rename); the release-notes and ADR-049 fixes originally in this PR landed there, so this PR is now just the image path and the installer.

**Image path** — Commit 6ae23d5 fixed the uppercase-owner OCI reference (`ghcr.io/NVIDIA/...` after the org move-back) by hardcoding `ghcr.io/nvidia/manager`, dropping the `cluster-readiness-engine/` segment. The rc.12 publish run pushed/signed/attested that truncated path, while the Helm chart, `nvcrectl setup` defaults, Makefile, and docs all expect `ghcr.io/nvidia/cluster-readiness-engine/manager` — so default installs go straight to ImagePullBackOff.
- Restore the full path in `publish.yml` (IMG, digest inspect, cosign sign, SBOM, attest) and `container-build.yml`, with a comment explaining why the value is hardcoded.
- Refresh the stale comment above `HELM_OCI_REGISTRY` in `release.yml`, which still claimed the value was derived from the repository.

**Installer** — `gh release download --output` needs gh >= 2.19.0 and `--clobber` >= 2.15.0; Ubuntu 22.04 ships gh 2.4.0, which rejects both.
- Use `--dir "${TEMP_DIR}"` instead (supported since gh 1.0) — assets land under their asset names, which is what the script already expects.
- Token-only path with `-v <tag>` referenced `RELEASE_JSON` before it was ever set (aborts under `set -u`); backfill it from `releases/tags/<tag>`.
- The version/asset-URL `grep` pipelines aborted under `pipefail` on no match, making the friendly errors after them unreachable — including when every release is a prerelease and `/releases/latest` 404s (true today). Guard them with `|| true` and point the user at `-p` / `-v <tag>`.

**Follow-up after merge**: re-run Publish via workflow_dispatch with the `v0.1.0-rc.12` tag (or cut rc.13) so the documented image path actually resolves.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [x] Other: installer script

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review