### PR TITLE
docs: resolve the newest release dynamically instead of pinning tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,10 @@ authenticated API downloads — plain `curl` against `releases/download/...` ret
 with the gh CLI (authenticate with `gh auth login` first):
 
 ```bash
-NVCRE_VERSION=v0.1.0-rc.9
+NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 gh release download "${NVCRE_VERSION}" --repo NVIDIA/cluster-readiness-engine \
   --pattern installer --output - | bash -s -- -v "${NVCRE_VERSION}"
 ```
-
-> **Note**: Releases up to and including `v0.1.0-rc.10` serve the old
-> `cre.nvidia.com` API group and publish the Helm chart as
-> `oci://ghcr.io/nvidia/cluster-readiness-engine`. The examples in this README
-> use the renamed `nvcre.nvidia.com` group and the `oci://ghcr.io/nvidia/nvcre`
-> chart, which require the first release cut after the rename (or a build from
-> `main`).
 
 Once the repository is public and a stable release exists, this shorter form works
 and picks up the newest stable release:
@@ -160,7 +153,7 @@ gh auth token | helm registry login ghcr.io \
 ```
 
 ```bash
-NVCRE_VERSION=v0.1.0-rc.8
+NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 
 # Inspect the chart before installing it
 helm show chart oci://ghcr.io/nvidia/nvcre --version "$NVCRE_VERSION"
@@ -192,9 +185,9 @@ The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagge
 with the same release version. Builds from `main` are also published, tagged
 `main-<commit-sha>`; use a release tag rather than one of those.
 
-Pin an explicit version rather than installing whatever is newest. Chart and
-image versions move together, so the two commands above and your own manifests
-should all name the same tag.
+The snippets above resolve the newest release. For reproducible installs, set
+`NVCRE_VERSION` to an explicit tag instead. Chart and image versions move
+together, so both commands and your own manifests should all name the same tag.
 
 ## Run a workload
 

--- a/docs/cli-reference/overview.md
+++ b/docs/cli-reference/overview.md
@@ -14,7 +14,7 @@ While this repository is internal, release assets require authenticated API
 downloads, so fetch the installer with the gh CLI (`gh auth login` first):
 
 ```bash
-export NVCRECTL_VERSION=v0.1.0-rc.9
+export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 gh release download "${NVCRECTL_VERSION}" --repo NVIDIA/cluster-readiness-engine \
   --pattern installer --output - | bash -s -- -v "${NVCRECTL_VERSION}"
 nvcrectl --version

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -26,23 +26,17 @@ Cordoned nodes are skipped. If a node is cordoned, NVCRE does not select it, and
 
 ## Step 1: install the CLI
 
-While this repository is internal, GitHub serves release assets only through authenticated API downloads — plain `curl` against `releases/download/...` returns a 404 "Not Found" page instead of the script, even with a token. Fetch the installer with the gh CLI (authenticate with `gh auth login` first) and name the version explicitly:
+While this repository is internal, GitHub serves release assets only through authenticated API downloads — plain `curl` against `releases/download/...` returns a 404 "Not Found" page instead of the script, even with a token. Fetch the installer with the gh CLI (authenticate with `gh auth login` first); the snippet resolves the newest release:
 
 ```bash
-NVCRE_VERSION=v0.1.0-rc.9
+NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 gh release download "${NVCRE_VERSION}" --repo NVIDIA/cluster-readiness-engine \
   --pattern installer --output - | bash -s -- -v "${NVCRE_VERSION}"
 ```
 
-> **Note**: Releases up to and including `v0.1.0-rc.10` serve the old
-> `cre.nvidia.com` API group and publish the Helm chart as
-> `oci://ghcr.io/nvidia/cluster-readiness-engine`. The renamed
-> `nvcre.nvidia.com` group and `oci://ghcr.io/nvidia/nvcre` chart require the
-> first release cut after the rename (or a build from `main`).
-
 Once the repository is public and `v0.1.0` is tagged, the shorter `curl -sSL .../releases/latest/download/installer | bash` form works and installs the newest stable release. (`releases/latest` resolves only to the newest **stable** release, and every release so far is a pre-release.)
 
-The installer takes `-p` to accept pre-releases when it resolves a version itself. That flag is an argument to the script, so it cannot help you download the script — which is why the version is named explicitly above.
+The installer takes `-p` to accept pre-releases when it resolves a version itself. That flag is an argument to the script, so it cannot help you download the script — which is why the version is resolved with `gh release list` above.
 
 The installer detects your OS and architecture, downloads the matching `nvcrectl` binary, installs it to `/usr/local/bin` (with sudo if needed), and adds a `kubectl-nvcre` symlink. After it finishes, both forms work and are the same binary:
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -18,20 +18,14 @@ description: Install the nvcrectl CLI and set up the NVIDIA Cluster Readiness En
 While this repository is internal, GitHub serves release assets only through
 authenticated API downloads — plain `curl` against `releases/download/...` returns a
 404 "Not Found" page instead of the script, even with a token. Fetch the installer
-with the gh CLI (authenticate with `gh auth login` first). Set the version you want
-to install, then run the installer:
+with the gh CLI (authenticate with `gh auth login` first). Resolve the newest
+release, then run the installer:
 
 ```bash
-export NVCRECTL_VERSION=v0.1.0-rc.9
+export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 gh release download "${NVCRECTL_VERSION}" --repo NVIDIA/cluster-readiness-engine \
   --pattern installer --output - | bash -s -- -v "${NVCRECTL_VERSION}"
 ```
-
-> **Note**: Releases up to and including `v0.1.0-rc.10` serve the old
-> `cre.nvidia.com` API group and publish the Helm chart as
-> `oci://ghcr.io/nvidia/cluster-readiness-engine`. The renamed
-> `nvcre.nvidia.com` group and `oci://ghcr.io/nvidia/nvcre` chart require the
-> first release cut after the rename (or a build from `main`).
 
 The installer automatically downloads and verifies a SHA-256 checksum before installing. On air-gapped systems, ensure `checksums.txt` from the same release is reachable alongside the binary.
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -22,7 +22,7 @@ NVCRE supports two install paths. Both pull the same artifacts from the GitHub C
 Install the CLI first with the installer script (see [Install](../getting-started/install.md) for the full walkthrough):
 
 ```bash
-export NVCRECTL_VERSION=v0.1.0-rc.9
+export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
 ```
 
@@ -59,10 +59,10 @@ For GitOps workflows, install the chart directly. **Log in to the GHCR Helm regi
 echo $GITHUB_TOKEN | helm registry login ghcr.io --username <github-username> --password-stdin
 ```
 
-Then inspect and install, pinning an explicit version:
+Then inspect and install (the snippet resolves the newest release; set `NVCRE_VERSION` to an explicit tag for reproducible installs):
 
 ```bash
-NVCRE_VERSION=v0.1.0-rc.9
+NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
 
 helm show chart oci://ghcr.io/nvidia/nvcre --version "$NVCRE_VERSION"
 
@@ -72,12 +72,6 @@ helm install nvcre \
   --namespace nvcre \
   --create-namespace
 ```
-
-> **Note**: Releases up to and including `v0.1.0-rc.10` serve the old
-> `cre.nvidia.com` API group and publish the Helm chart as
-> `oci://ghcr.io/nvidia/cluster-readiness-engine`. The renamed
-> `nvcre.nvidia.com` group and `oci://ghcr.io/nvidia/nvcre` chart require the
-> first release cut after the rename (or a build from `main`).
 
 The controller image is `ghcr.io/nvidia/cluster-readiness-engine/manager`, tagged with the same release version. Chart and image versions move together — name the same tag everywhere. The Helm path does not install Kubeflow Trainer; install it separately before running `TrainJob` workloads.
 


### PR DESCRIPTION
## Summary

The install and Helm snippets in the README and docs pinned stale release tags (`v0.1.0-rc.9` from before rc.13, `v0.1.0-rc.8` in the Helm section) that needed a manual bump on every release — which nobody did, so users copy-pasted old versions.

- Replace every pinned `NVCRE_VERSION=`/`NVCRECTL_VERSION=` literal with dynamic resolution of the newest release: `$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')`. No doc carries a literal tag anymore, so nothing needs updating when a release is cut. (`releases/latest` can't be used while every release is a prerelease — it 404s.)
- Reword the pin guidance so it stays coherent: the snippets resolve the newest release; set the variable to an explicit tag for reproducible installs.
- Remove the note about releases up to rc.10 serving the old `cre.nvidia.com` API group and the old chart path — `v0.1.0-rc.13` is the first release cut after the rename, so the examples now work against the newest release. The same note existed in `docs/getting-started/install.md`, `docs/getting-started/first-certification.md`, and `docs/operations/deployment.md`; removed there too, along with their pinned versions (`docs/cli-reference/overview.md` as well).

Verified: `grep -rn 'v0\.1\.0-rc' README.md docs/getting-started docs/operations docs/cli-reference` returns nothing, and the dynamic command resolves to `v0.1.0-rc.13` today.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review