### PR TITLE
fix(threshold): fail loudly on unknown threshold keys instead of skipping validation

### DIFF
--- a/api/v1alpha1/workloadrun_types.go
+++ b/api/v1alpha1/workloadrun_types.go
@@ -257,7 +257,7 @@ type WorkloadRunSpec struct {
 	Orchestration *WorkloadOrchestration `json:"orchestration,omitempty"`
 
 	// thresholds defines performance pass/fail criteria as CEL expressions.
-	// Keys are metric names (e.g., "busBandwidthGBps", "avgTFLOPSPerGPU").
+	// Keys are metric names (e.g., "busBandwidthGBps", "avgTFLOPsPerGPU").
 	// Values are CEL expressions using a `value` variable (e.g., "value >= 900").
 	// +optional
 	Thresholds map[string]string `json:"thresholds,omitempty"`

--- a/cmd/integration/testdata/reconcile/job-unknown-threshold-key/expected.json
+++ b/cmd/integration/testdata/reconcile/job-unknown-threshold-key/expected.json
@@ -1,0 +1,79 @@
+{
+  "Job/test-unknown-key": {
+    "kind": "Job",
+    "apiVersion": "nvcre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-unknown-key",
+      "namespace": "default",
+      "finalizers": [
+        "nvcre.nvidia.com/finalizer"
+      ]
+    },
+    "spec": {
+      "workload": {
+        "trainJob": {
+          "runtimeRef": {
+            "name": "test-runtime",
+            "apiGroup": "trainer.kubeflow.org",
+            "kind": "TrainingRuntime"
+          },
+          "trainer": {
+            "image": "test-image:latest",
+            "command": [
+              "mpirun"
+            ],
+            "numNodes": 1
+          },
+          "suspend": false,
+          "managedBy": "trainer.kubeflow.org/trainjob-controller"
+        }
+      },
+      "thresholds": {
+        "avgTFLOPSPerGPU": "value \u003e= 1000",
+        "busBandwidthGBps": "value \u003e= 400"
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Succeeded",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "WorkloadCompleted",
+          "message": "Workload TrainJob/test-unknown-key-workload completed: All workers completed"
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "ValidationFailed",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "UnknownThresholdKey",
+          "message": "unknown threshold key(s) [avgTFLOPSPerGPU]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]"
+        }
+      ],
+      "workloadRef": {
+        "apiVersion": "trainer.kubeflow.org/v1alpha1",
+        "kind": "TrainJob",
+        "name": "test-unknown-key-workload",
+        "namespace": "default"
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/job-unknown-threshold-key/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/job-unknown-threshold-key/input_client_objects.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: test-unknown-key-workload
+  namespace: default
+spec:
+  runtimeRef:
+    kind: TrainingRuntime
+    name: test-runtime
+  trainer:
+    image: test-image:latest
+    command:
+      - mpirun
+    numNodes: 1
+status:
+  conditions:
+    - type: Complete
+      status: "True"
+      reason: JobCompleted
+      message: "All workers completed"
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+---
+# The threshold key avgTFLOPSPerGPU (capital S) is the GoodputMeasurement
+# status field, not the registry key avgTFLOPsPerGPU — the typo from issue #52.
+# Before the fix the unknown key could never be measured, so the Job sat in the
+# missing-key path until it failed with a misleading MeasurementTimeout. Now
+# the Job controller rejects it immediately with reason UnknownThresholdKey,
+# even though the valid busBandwidthGBps threshold has no measurement yet.
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-unknown-key
+  namespace: default
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - mpirun
+        numNodes: 1
+  thresholds:
+    avgTFLOPSPerGPU: "value >= 1000"
+    busBandwidthGBps: "value >= 400"
+status:
+  workloadRef:
+    apiVersion: trainer.kubeflow.org/v1alpha1
+    kind: TrainJob
+    name: test-unknown-key-workload
+    namespace: default

--- a/cmd/integration/testdata/reconcile/job-unknown-threshold-key/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/job-unknown-threshold-key/input_config.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The Job succeeded but its thresholds name a key that is not in the threshold
+# registry. The controller must fail validation immediately with reason
+# UnknownThresholdKey — naming the key and listing the valid ones — instead of
+# waiting for a measurement that can never arrive and reporting
+# MeasurementTimeout (issue #52).
+waitFor:
+  kind: Job
+  name: test-unknown-key
+  namespace: default
+  condition: ValidationFailed
+  reason: UnknownThresholdKey
+collect:
+  - kind: Job
+    name: test-unknown-key
+    namespace: default

--- a/docs/concepts/goodput-bandwidth.md
+++ b/docs/concepts/goodput-bandwidth.md
@@ -22,7 +22,7 @@ While the measured `Job` is running, the measurement's `Measuring` condition is 
 
 When the `Job` reaches a terminal state, the controller performs one final log read and folds it into a single terminal status write, anchored to the timestamp of the Job's terminal condition rather than the controller's wall clock: `completionTime` is the Job's terminal transition time, and `trainingTimeSec` (and therefore `result`) is measured up to that instant. That write sets `Complete=True` and `Measuring=False`.
 
-Once `Complete` is `True` the measurement is **frozen**: its status never changes again, so `nvcrectl certification report` returns the same goodput on every read, and controller restarts or repeated reconciles cannot move the value (see [ADR-072](../designs/072-goodput-terminal-freeze.md)). Goodput-based threshold evaluation (`goodputRatio`, `avgTFLOPSPerGPU`, `avgStepTimeSec`) waits for `Complete=True` and only ever consumes the frozen values.
+Once `Complete` is `True` the measurement is **frozen**: its status never changes again, so `nvcrectl certification report` returns the same goodput on every read, and controller restarts or repeated reconciles cannot move the value (see [ADR-072](../designs/072-goodput-terminal-freeze.md)). Goodput-based threshold evaluation (`goodputRatio`, `avgTFLOPsPerGPU`, `avgStepTimeSec`) waits for `Complete=True` and only ever consumes the frozen values.
 
 ### Interpreting goodput
 

--- a/docs/designs/072-goodput-terminal-freeze.md
+++ b/docs/designs/072-goodput-terminal-freeze.md
@@ -28,7 +28,7 @@ The existing `Complete=True` gate at [goodputmeasurement_controller.go:122](../.
 
 4. **Deterministic handling of in-flight parsing at the boundary.** The final log read remains best-effort: on failure, the terminal write proceeds from the last persisted values (today's behavior, minus the second write). `ApplicationStopTime` and the log read window are capped at `anchor` so late-arriving log timestamps cannot push terminal metrics past the Job's terminal time. Because re-entry recomputes from the same anchored inputs, a duplicate terminal write (stale cache, conflict retry, controller restart) is byte-identical rather than a new value.
 
-5. **Threshold evaluation consumes only frozen values.** `collectJobMeasuredValues` skips goodput-derived keys (`goodputRatio`, `avgTFLOPSPerGPU`, `avgStepTimeSec`) while the GoodputMeasurement's `Complete` condition is not `True`. The existing missing-key requeue and `measurementTimeout` machinery in `checkPerformanceThresholds` already handles the wait.
+5. **Threshold evaluation consumes only frozen values.** `collectJobMeasuredValues` skips goodput-derived keys (`goodputRatio`, `avgTFLOPsPerGPU`, `avgStepTimeSec`) while the GoodputMeasurement's `Complete` condition is not `True`. The existing missing-key requeue and `measurementTimeout` machinery in `checkPerformanceThresholds` already handles the wait.
 
 6. **Do not copy final values into Job/Workflow/Certification status.** The report aggregates GoodputMeasurements directly, and they already outlive their Jobs by design.
 

--- a/helm/nvcre/crds/nvcre.nvidia.com_workloadruns.yaml
+++ b/helm/nvcre/crds/nvcre.nvidia.com_workloadruns.yaml
@@ -2512,7 +2512,7 @@ spec:
                   type: string
                 description: |-
                   thresholds defines performance pass/fail criteria as CEL expressions.
-                  Keys are metric names (e.g., "busBandwidthGBps", "avgTFLOPSPerGPU").
+                  Keys are metric names (e.g., "busBandwidthGBps", "avgTFLOPsPerGPU").
                   Values are CEL expressions using a `value` variable (e.g., "value >= 900").
                 type: object
               volumeMounts:

--- a/pkg/certification/certification.go
+++ b/pkg/certification/certification.go
@@ -35,6 +35,7 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/report"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/setup"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
 )
 
 // NewCommand returns the "certification" cobra command.
@@ -390,6 +391,23 @@ func readCertification(path string) (*nvcrev1alpha1.Certification, error) {
 	var cert nvcrev1alpha1.Certification
 	if err := yaml.Unmarshal(data, &cert); err != nil {
 		return nil, fmt.Errorf("parse certification: %w", err)
+	}
+
+	// Reject unknown threshold keys at read time — render and run --cert-file
+	// both pass through here — so a typo'd key is reported immediately instead
+	// of failing validation after the workload has already run (issue #52).
+	// Thresholds appear at the spec level and per category.
+	if err := threshold.ValidateKeysError(cert.Spec.Thresholds); err != nil {
+		return nil, fmt.Errorf("certification %s: %w", cert.Name, err)
+	}
+	for _, cat := range cert.Spec.Categories {
+		if cat.Options == nil {
+			continue
+		}
+		if err := threshold.ValidateKeysError(cat.Options.Thresholds); err != nil {
+			return nil, fmt.Errorf("certification %s: category %s/%s: %w",
+				cert.Name, cat.Domain, cat.Variant, err)
+		}
 	}
 	return &cert, nil
 }

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/expected.json
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "certification test-cert: category communication/nccl-all-reduce: unknown threshold key(s) [avgTFLOPSPerGPU]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]"
+}

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/input_certification.yaml
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/input_certification.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Per-category options thresholds carry the same typo from issue #52. The
+# error names the category so the user knows which entry to fix.
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Certification
+metadata:
+  name: test-cert
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.product: NVIDIA-GB200
+  categories:
+    - domain: communication
+      variant: nccl-all-reduce
+      options:
+        thresholds:
+          avgTFLOPSPerGPU: "value >= 1000"

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/input_config.yaml
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-category/input_config.yaml
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{}

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/expected.json
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "certification test-cert: unknown threshold key(s) [avgTFLOPSPerGPU]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]"
+}

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/input_certification.yaml
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/input_certification.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The typo from issue #52 at the spec level: avgTFLOPSPerGPU is the
+# GoodputMeasurement status field, one character away from the threshold key
+# avgTFLOPsPerGPU. readCertification rejects it before anything is rendered
+# or created, mirroring the WorkloadRun CLI behavior.
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Certification
+metadata:
+  name: test-cert
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.product: NVIDIA-GB200
+  thresholds:
+    avgTFLOPSPerGPU: "value >= 1000"
+    busBandwidthGBps: "value >= 400"
+  categories:
+    - domain: communication
+      variant: nccl-all-reduce

--- a/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/input_config.yaml
+++ b/pkg/certification/testdata/certification-render-errors/unknown-threshold-key-spec/input_config.yaml
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{}

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -71,6 +71,10 @@ const (
 
 	// reasonThresholdsMet indicates threshold validation passed explicitly.
 	reasonThresholdsMet = "ThresholdsMet"
+
+	// reasonUnknownThresholdKey indicates threshold validation failed because
+	// the Job spec names a threshold key that is not in the threshold registry.
+	reasonUnknownThresholdKey = "UnknownThresholdKey"
 )
 
 // JobReconciler reconciles a Job object
@@ -627,6 +631,20 @@ func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *nvc
 		return false
 	}
 	log := logf.FromContext(ctx)
+
+	// Reject unknown threshold keys before waiting for measurements. An
+	// unknown key can never be measured — collectJobMeasuredValues only emits
+	// registry keys — so letting it reach the missing-key path below would
+	// stall until it surfaced as a misleading MeasurementTimeout. Fail
+	// validation immediately, naming the offending key.
+	if keyErr := threshold.ValidateKeysError(job.Spec.Thresholds); keyErr != nil {
+		log.Info("Threshold check failed: unknown threshold key", "message", keyErr.Error())
+		if err := r.setJobValidationStatus(ctx, job, metav1.ConditionTrue, reasonUnknownThresholdKey, keyErr.Error()); err != nil {
+			log.Error(err, "Failed to set ValidationFailed for unknown threshold key")
+		}
+		return false
+	}
+
 	measured := collectJobMeasuredValues(ctx, r.Client, job)
 
 	if missing := missingJobThresholdKeys(job.Spec.Thresholds, measured); len(missing) > 0 {
@@ -645,7 +663,17 @@ func (r *JobReconciler) checkPerformanceThresholds(ctx context.Context, job *nvc
 		return true
 	}
 
-	if violations := threshold.EvaluateAll(job.Spec.Thresholds, measured); len(violations) > 0 {
+	violations, evalErr := threshold.EvaluateAll(job.Spec.Thresholds, measured)
+	if evalErr != nil {
+		// Unreachable when the upfront key check above passed, but fail loudly
+		// rather than treating an evaluation error as a pass.
+		log.Error(evalErr, "Threshold evaluation failed")
+		if err := r.setJobValidationStatus(ctx, job, metav1.ConditionTrue, reasonUnknownThresholdKey, evalErr.Error()); err != nil {
+			log.Error(err, "Failed to set ValidationFailed for threshold evaluation error")
+		}
+		return false
+	}
+	if len(violations) > 0 {
 		v := violations[0]
 		log.Info("Threshold check failed", "key", v.Key, "reason", v.Reason, "message", v.Message)
 		if err := r.setJobValidationStatus(ctx, job, metav1.ConditionTrue, v.Reason, v.Message); err != nil {

--- a/pkg/threshold/evaluator.go
+++ b/pkg/threshold/evaluator.go
@@ -8,6 +8,8 @@ package threshold
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/google/cel-go/cel"
@@ -46,7 +48,17 @@ func knownKeys() map[string]bool {
 	return registryKeys
 }
 
-// ValidateKeys returns any keys in thresholds that are not in the Registry.
+// Keys returns all known threshold keys in Registry order.
+func Keys() []string {
+	keys := make([]string, 0, len(Registry))
+	for _, d := range Registry {
+		keys = append(keys, d.Key)
+	}
+	return keys
+}
+
+// ValidateKeys returns any keys in thresholds that are not in the Registry,
+// sorted for deterministic messages.
 func ValidateKeys(thresholds map[string]string) []string {
 	known := knownKeys()
 	var unknown []string
@@ -55,7 +67,21 @@ func ValidateKeys(thresholds map[string]string) []string {
 			unknown = append(unknown, k)
 		}
 	}
+	sort.Strings(unknown)
 	return unknown
+}
+
+// ValidateKeysError returns an error when thresholds contains keys that are
+// not in the Registry. The error names each offending key and lists the valid
+// keys, so a typo is diagnosed instead of silently disabling validation.
+// Returns nil when every key is known.
+func ValidateKeysError(thresholds map[string]string) error {
+	unknown := ValidateKeys(thresholds)
+	if len(unknown) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unknown threshold key(s) [%s]; valid keys: [%s]",
+		strings.Join(unknown, ", "), strings.Join(Keys(), ", "))
 }
 
 // ValidateExpressions compiles all CEL expressions and returns errors
@@ -66,36 +92,41 @@ type Violation struct {
 	Key        string
 	Expression string
 	Measured   float64
-	Reason     string // "ThresholdViolated", "UnknownThresholdKey", "InvalidThresholdExpression"
+	Reason     string // "ThresholdViolated", "InvalidThresholdExpression"
 	Message    string
 }
 
 // EvaluateAll checks all thresholds against measured values.
-// Returns a list of violations (empty if all thresholds pass).
-func EvaluateAll(thresholds map[string]string, measured map[string]float64) []Violation {
+// Returns a list of violations (empty if all thresholds pass), sorted by key.
+// Returns an error when thresholds contains a key that is not in the Registry:
+// an unknown key can never be measured, so evaluating around it would silently
+// skip validation. The error names the offending keys and lists the valid ones.
+func EvaluateAll(thresholds map[string]string, measured map[string]float64) ([]Violation, error) {
 	if len(thresholds) == 0 {
-		return nil
+		return nil, nil
 	}
 
+	// Reject unknown keys first: a typo in one key must fail loudly rather
+	// than disable threshold validation.
+	if err := ValidateKeysError(thresholds); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(thresholds))
+	for key := range thresholds {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Evaluate each threshold in sorted key order for deterministic output.
 	var violations []Violation
-
-	// Validate keys first.
-	for _, key := range ValidateKeys(thresholds) {
-		violations = append(violations, Violation{
-			Key:     key,
-			Reason:  "UnknownThresholdKey",
-			Message: fmt.Sprintf("Unknown threshold key %q", key),
-		})
-	}
-	if len(violations) > 0 {
-		return violations
-	}
-
-	// Evaluate each threshold.
-	for key, expr := range thresholds {
+	for _, key := range keys {
+		expr := thresholds[key]
 		value, ok := measured[key]
 		if !ok {
-			continue // no measurement available — skip silently
+			// No measurement available — the caller's missing-key handling
+			// (requeue then MeasurementTimeout) is responsible for this case.
+			continue
 		}
 		pass, err := Evaluate(value, expr)
 		if err != nil {
@@ -118,7 +149,7 @@ func EvaluateAll(thresholds map[string]string, measured map[string]float64) []Vi
 			})
 		}
 	}
-	return violations
+	return violations, nil
 }
 
 // Evaluate compiles and evaluates a CEL expression with the measured value.

--- a/pkg/threshold/evaluator_test.go
+++ b/pkg/threshold/evaluator_test.go
@@ -52,6 +52,43 @@ func TestEvaluate(t *testing.T) {
 	})
 }
 
+// TestEvaluateAll covers the pass, violation, invalid-expression, and
+// missing-measurement paths, plus the unknown-key error (issue #52): a key
+// that is not in the Registry makes EvaluateAll return an error naming the
+// key and listing the valid keys, instead of silently skipping validation.
+func TestEvaluateAll(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "evaluate-all",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			Thresholds map[string]string  `json:"thresholds"`
+			Measured   map[string]float64 `json:"measured"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &in); err != nil {
+			return err
+		}
+
+		violations, err := EvaluateAll(in.Thresholds, in.Measured)
+		if err != nil {
+			return err
+		}
+
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(struct {
+			Violations []Violation `json:"violations"`
+		}{violations}); err != nil {
+			return err
+		}
+		tc.Actual = buf.String()
+		return nil
+	})
+}
+
 func TestValidateKeys(t *testing.T) {
 	t.Run("all known", func(t *testing.T) {
 		unknown := ValidateKeys(map[string]string{

--- a/pkg/threshold/testdata/evaluate-all/all-pass/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/all-pass/expected.json
@@ -1,0 +1,3 @@
+{
+  "violations": null
+}

--- a/pkg/threshold/testdata/evaluate-all/all-pass/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/all-pass/input.yaml
@@ -1,0 +1,6 @@
+thresholds:
+  busBandwidthGBps: "value >= 400"
+  goodputRatio: "value >= 0.9"
+measured:
+  busBandwidthGBps: 480.5
+  goodputRatio: 0.95

--- a/pkg/threshold/testdata/evaluate-all/empty-thresholds/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/empty-thresholds/expected.json
@@ -1,0 +1,3 @@
+{
+  "violations": null
+}

--- a/pkg/threshold/testdata/evaluate-all/empty-thresholds/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/empty-thresholds/input.yaml
@@ -1,0 +1,2 @@
+thresholds: {}
+measured: {}

--- a/pkg/threshold/testdata/evaluate-all/invalid-expression/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/invalid-expression/expected.json
@@ -1,0 +1,11 @@
+{
+  "violations": [
+    {
+      "Key": "busBandwidthGBps",
+      "Expression": "value + 1.0",
+      "Measured": 100,
+      "Reason": "InvalidThresholdExpression",
+      "Message": "Threshold \"busBandwidthGBps\": compile threshold expression \"value + 1.0\": expression must return bool, got double"
+    }
+  ]
+}

--- a/pkg/threshold/testdata/evaluate-all/invalid-expression/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/invalid-expression/input.yaml
@@ -1,0 +1,7 @@
+# The key is valid but the expression does not return a bool. This is a
+# violation with reason InvalidThresholdExpression, not an EvaluateAll error:
+# only unknown keys abort evaluation.
+thresholds:
+  busBandwidthGBps: "value + 1.0"
+measured:
+  busBandwidthGBps: 100

--- a/pkg/threshold/testdata/evaluate-all/missing-measurement-skipped/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/missing-measurement-skipped/expected.json
@@ -1,0 +1,3 @@
+{
+  "violations": null
+}

--- a/pkg/threshold/testdata/evaluate-all/missing-measurement-skipped/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/missing-measurement-skipped/input.yaml
@@ -1,0 +1,8 @@
+# A registry key with no measured value is not evaluated here. The Job
+# controller's missing-key path owns that case: it requeues until the
+# measurement arrives and fails with MeasurementTimeout if it never does.
+thresholds:
+  busBandwidthGBps: "value >= 400"
+  goodputRatio: "value >= 0.9"
+measured:
+  goodputRatio: 0.95

--- a/pkg/threshold/testdata/evaluate-all/single-violation/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/single-violation/expected.json
@@ -1,0 +1,11 @@
+{
+  "violations": [
+    {
+      "Key": "busBandwidthGBps",
+      "Expression": "value >= 400",
+      "Measured": 350,
+      "Reason": "ThresholdViolated",
+      "Message": "Threshold \"busBandwidthGBps\" violated: measured 350.0000, expression: value >= 400"
+    }
+  ]
+}

--- a/pkg/threshold/testdata/evaluate-all/single-violation/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/single-violation/input.yaml
@@ -1,0 +1,4 @@
+thresholds:
+  busBandwidthGBps: "value >= 400"
+measured:
+  busBandwidthGBps: 350

--- a/pkg/threshold/testdata/evaluate-all/unknown-key-fails/error
+++ b/pkg/threshold/testdata/evaluate-all/unknown-key-fails/error
@@ -1,0 +1,1 @@
+unknown threshold key(s) [avgTFLOPSPerGPU]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]

--- a/pkg/threshold/testdata/evaluate-all/unknown-key-fails/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/unknown-key-fails/input.yaml
@@ -1,0 +1,9 @@
+# The scenario from issue #52: avgTFLOPSPerGPU (capital S) is the
+# GoodputMeasurement status field, one character away from the threshold key
+# avgTFLOPsPerGPU. It used to make EvaluateAll skip every threshold silently;
+# now it is an error, even when the other keys are valid and measured.
+thresholds:
+  avgTFLOPSPerGPU: "value >= 1000"
+  busBandwidthGBps: "value >= 400"
+measured:
+  busBandwidthGBps: 100

--- a/pkg/threshold/testdata/evaluate-all/unknown-keys-sorted/error
+++ b/pkg/threshold/testdata/evaluate-all/unknown-keys-sorted/error
@@ -1,0 +1,1 @@
+unknown threshold key(s) [aaaNotAKey, zzzNotAKey]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]

--- a/pkg/threshold/testdata/evaluate-all/unknown-keys-sorted/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/unknown-keys-sorted/input.yaml
@@ -1,0 +1,6 @@
+# Multiple unknown keys are reported sorted, so the error message (and the
+# ValidationFailed condition message built from it) is deterministic.
+thresholds:
+  zzzNotAKey: "value >= 1"
+  aaaNotAKey: "value >= 1"
+measured: {}

--- a/pkg/threshold/testdata/evaluate-all/violations-sorted-by-key/expected.json
+++ b/pkg/threshold/testdata/evaluate-all/violations-sorted-by-key/expected.json
@@ -1,0 +1,18 @@
+{
+  "violations": [
+    {
+      "Key": "avgStepTimeSec",
+      "Expression": "value <= 3.0",
+      "Measured": 5,
+      "Reason": "ThresholdViolated",
+      "Message": "Threshold \"avgStepTimeSec\" violated: measured 5.0000, expression: value <= 3.0"
+    },
+    {
+      "Key": "goodputRatio",
+      "Expression": "value >= 0.9",
+      "Measured": 0.5,
+      "Reason": "ThresholdViolated",
+      "Message": "Threshold \"goodputRatio\" violated: measured 0.5000, expression: value >= 0.9"
+    }
+  ]
+}

--- a/pkg/threshold/testdata/evaluate-all/violations-sorted-by-key/input.yaml
+++ b/pkg/threshold/testdata/evaluate-all/violations-sorted-by-key/input.yaml
@@ -1,0 +1,8 @@
+# Two violated thresholds must come back in sorted key order, so the caller's
+# use of violations[0] and any golden file built on the output are deterministic.
+thresholds:
+  goodputRatio: "value >= 0.9"
+  avgStepTimeSec: "value <= 3.0"
+measured:
+  goodputRatio: 0.5
+  avgStepTimeSec: 5

--- a/pkg/workloadrun/build_workflow_spec_test.go
+++ b/pkg/workloadrun/build_workflow_spec_test.go
@@ -67,8 +67,10 @@ type projection struct {
 	Iterations      int                      `json:"iterations"`
 	DependencyKinds []string                 `json:"dependencyKinds"`
 	// Validation records the contents and not only whether the block is
-	// present. The exact threshold key is part of it, because issue #52 is open
-	// about one unknown key turning off every threshold check without saying so.
+	// present. The exact threshold key is part of it: since issue #52 was
+	// fixed, a key must be a threshold-registry key — readWorkloadRun rejects
+	// unknown keys and the Job controller fails validation on them — so the
+	// exact string decides whether a run is accepted at all.
 	Validation *nvcrev1alpha1.ValidationSpec `json:"validation"`
 	// WorkerEnv holds "NAME=value" for the worker container of the runtime
 	// dependency, which is the container the workload runs in. It records values

--- a/pkg/workloadrun/read_workloadrun_test.go
+++ b/pkg/workloadrun/read_workloadrun_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadrun
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// readWorkloadRun is the single choke point through which render, dry-run,
+// and run load the user's YAML, so validation applied here covers every CLI
+// entry point. The unknown-threshold-key case is issue #52: avgTFLOPSPerGPU
+// (capital S) is the GoodputMeasurement status field, one character away from
+// the threshold key avgTFLOPsPerGPU, and it used to slip through and surface
+// only after the run as a misleading MeasurementTimeout.
+func TestReadWorkloadRun(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "read-workloadrun",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		file := filepath.Join(tc.T.TempDir(), "workloadrun.yaml")
+		if err := os.WriteFile(file, []byte(tc.Inputs["input.yaml"]), 0o600); err != nil {
+			return err
+		}
+
+		run, err := readWorkloadRun(file)
+		if err != nil {
+			return err
+		}
+
+		// Record identity and the thresholds map — the fields this validation
+		// is about — rather than the whole spec.
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(struct {
+			Name       string            `json:"name"`
+			Thresholds map[string]string `json:"thresholds"`
+		}{run.Name, run.Spec.Thresholds}); err != nil {
+			return err
+		}
+		tc.Actual = buf.String()
+		return nil
+	})
+}

--- a/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/input.yaml
+++ b/pkg/workloadrun/testdata/build-workflow-spec/thresholds-enable-validation/input.yaml
@@ -4,9 +4,10 @@
 # collected. The presence of the block decides whether a run is measured or only
 # watched.
 #
-# Note the spelling of the key. Issue #52 is open because one unknown threshold
-# key turns off all threshold checks without saying so, which makes the exact
-# string here important.
+# Note the spelling of the key. Since issue #52 was fixed, an unknown threshold
+# key is rejected outright — by readWorkloadRun at the CLI and by the Job
+# controller with ValidationFailed reason UnknownThresholdKey — so the exact
+# string here decides whether the run is accepted at all.
 run:
   metadata:
     name: wr-thresholds

--- a/pkg/workloadrun/testdata/read-workloadrun/no-thresholds-pass/expected.json
+++ b/pkg/workloadrun/testdata/read-workloadrun/no-thresholds-pass/expected.json
@@ -1,0 +1,4 @@
+{
+  "name": "wr-no-thresholds",
+  "thresholds": null
+}

--- a/pkg/workloadrun/testdata/read-workloadrun/no-thresholds-pass/input.yaml
+++ b/pkg/workloadrun/testdata/read-workloadrun/no-thresholds-pass/input.yaml
@@ -1,0 +1,11 @@
+# No thresholds at all is fine — the run is watched but not measured.
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: wr-no-thresholds
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 2
+  framework:
+    torch:
+      script: /workspace/train.py

--- a/pkg/workloadrun/testdata/read-workloadrun/unknown-threshold-key-rejected/error
+++ b/pkg/workloadrun/testdata/read-workloadrun/unknown-threshold-key-rejected/error
@@ -1,0 +1,1 @@
+workloadrun wr-typo: unknown threshold key(s) [avgTFLOPSPerGPU]; valid keys: [busBandwidthGBps, algBandwidthGBps, goodputRatio, avgTFLOPsPerGPU, avgStepTimeSec]

--- a/pkg/workloadrun/testdata/read-workloadrun/unknown-threshold-key-rejected/input.yaml
+++ b/pkg/workloadrun/testdata/read-workloadrun/unknown-threshold-key-rejected/input.yaml
@@ -1,0 +1,17 @@
+# The typo from issue #52: avgTFLOPSPerGPU is one character away from the
+# threshold key avgTFLOPsPerGPU. Before the fix this file was accepted, the
+# run completed, and the failure showed up as a MeasurementTimeout. Now the
+# CLI rejects the file before anything is created.
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: wr-typo
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 2
+  framework:
+    torch:
+      script: /workspace/train.py
+  thresholds:
+    avgTFLOPSPerGPU: "value >= 1000"
+    busBandwidthGBps: "value >= 400"

--- a/pkg/workloadrun/testdata/read-workloadrun/valid-threshold-keys-pass/expected.json
+++ b/pkg/workloadrun/testdata/read-workloadrun/valid-threshold-keys-pass/expected.json
@@ -1,0 +1,10 @@
+{
+  "name": "wr-valid-thresholds",
+  "thresholds": {
+    "algBandwidthGBps": "value >= 300",
+    "avgStepTimeSec": "value <= 3.0",
+    "avgTFLOPsPerGPU": "value >= 1000",
+    "busBandwidthGBps": "value >= 400",
+    "goodputRatio": "value >= 0.85"
+  }
+}

--- a/pkg/workloadrun/testdata/read-workloadrun/valid-threshold-keys-pass/input.yaml
+++ b/pkg/workloadrun/testdata/read-workloadrun/valid-threshold-keys-pass/input.yaml
@@ -1,0 +1,18 @@
+# Every registry key is accepted. Note avgTFLOPsPerGPU with a lower-case s:
+# that is the threshold key; avgTFLOPSPerGPU is the status field (issue #52).
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: wr-valid-thresholds
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 2
+  framework:
+    torch:
+      script: /workspace/train.py
+  thresholds:
+    busBandwidthGBps: "value >= 400"
+    algBandwidthGBps: "value >= 300"
+    goodputRatio: "value >= 0.85"
+    avgTFLOPsPerGPU: "value >= 1000"
+    avgStepTimeSec: "value <= 3.0"

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -38,6 +38,7 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/render"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/report"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/setup"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/threshold"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/workload"
 )
 
@@ -957,6 +958,13 @@ func readWorkloadRun(file string) (*nvcrev1alpha1.WorkloadRun, error) {
 
 	if run.Kind != "" && run.Kind != "WorkloadRun" {
 		return nil, fmt.Errorf("expected kind WorkloadRun, got %q", run.Kind)
+	}
+
+	// Reject unknown threshold keys at read time — render, dry-run, and run
+	// all pass through here — so a typo'd key is reported immediately instead
+	// of failing validation after the workload has already run (issue #52).
+	if err := threshold.ValidateKeysError(run.Spec.Thresholds); err != nil {
+		return nil, fmt.Errorf("workloadrun %s: %w", run.Name, err)
 	}
 
 	return &run, nil


### PR DESCRIPTION
## Summary

Fixes #52

- One unknown threshold key used to disable all threshold validation silently: `EvaluateAll` short-circuited on it, and in the controller the key never even reached the evaluator — it tripped the missing-measurement path and the Job failed with a misleading `MeasurementTimeout` five minutes after success.
- `EvaluateAll` now returns `([]Violation, error)` and rejects unknown keys with an error naming the offending keys and listing all valid registry keys. Violations come back in sorted key order so output is deterministic.
- The Job controller validates threshold keys at the top of `checkPerformanceThresholds` and sets `ValidationFailed` with reason `UnknownThresholdKey` immediately — the behavior ADR-054 already documented.
- Both CLI entry points reject a typo'd key before anything is created: `nvcrectl workloadrun` (render, `--dry-run`, and run all load the file through `readWorkloadRun`) and `nvcrectl certification` (render and `run --cert-file` load through `readCertification`, which checks spec-level thresholds and per-category `options.thresholds` and names the category in the error).
- Fixed the doc comment on `WorkloadRunSpec.Thresholds` that documented the key as `avgTFLOPSPerGPU` (the status-field spelling) instead of the registry key `avgTFLOPsPerGPU`, plus the two docs that repeated it in threshold-key context. The status field itself is unchanged; the two spellings stay distinct on purpose.
- Tests: golden cases for `EvaluateAll` in `pkg/threshold` (pass, violation, sorted multi-violation, invalid expression, missing measurement, and both unknown-key error shapes), golden cases for `readWorkloadRun` in `pkg/workloadrun` including the exact typo from the issue, two golden cases for `readCertification` in `pkg/certification` (spec-level and per-category typo), and a new integration case `job-unknown-threshold-key` that pins `ValidationFailed`/`UnknownThresholdKey` on the Job.
- Goldens: no existing golden changed — valid-key behavior is untouched. New goldens only: the integration `expected.json` was generated for the new case and reviewed (it records the immediate `UnknownThresholdKey` condition with the full key list in the message); the `pkg/threshold`, `pkg/workloadrun`, and `pkg/certification` goldens were written by hand and passed on first run; `helm/nvcre/crds/nvcre.nvidia.com_workloadruns.yaml` is regenerated controller-gen output whose only diff is the corrected spelling in the description.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] API / CRDs
- [x] Controller / Reconcilers
- [x] Catalog / Workloads
- [x] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] `make manifests generate` run (if `*_types.go` was modified)
- [x] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
