### PR TITLE
fix(cli): implement workloadrun run --cleanup instead of silently discarding it

### DIFF
--- a/docs/cli-reference/workloadrun.md
+++ b/docs/cli-reference/workloadrun.md
@@ -19,9 +19,9 @@ nvcrectl workloadrun run [flags] <file>
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--wait` | `false` | Block until the workload completes |
-| `--timeout` | `30m` | Timeout for `--wait` |
+| `--timeout` | `30m` | Timeout for `--wait`. On timeout, the WorkloadRun is left running in the cluster unless `--cleanup` is set |
 | `--setup` | `false` | Install CRDs, controller, and LogProfiles before creating the WorkloadRun |
-| `--cleanup` | `false` | Delete the WorkloadRun and installed components after completion |
+| `--cleanup` | `false` | Delete the WorkloadRun, the namespace (when created by this run), and installed components after completion |
 | `--image` | — | Override controller image |
 | `--controller-pull-secret` | — | Token for controller registry auth during `--setup` (e.g. GitHub PAT for `ghcr.io`) — separate from workload image credentials |
 | `--workload-registry` | — | Registry server for workload image pull (e.g. `nvcr.io`, `ghcr.io`) — required when `--workload-registry-password` is set |
@@ -33,6 +33,8 @@ nvcrectl workloadrun run [flags] <file>
 | `--topology-key` | — | Node label key for topology grouping |
 | `--test-scale` | — | Override testScale (`intra-node`, `intra-rack`, `full-scale`) |
 | `--results-file` | — | Write results as JSON to this file path (requires `--wait`) |
+
+`--cleanup` runs on every exit path — success, failure, or `--wait` timeout — matching `certification run --cleanup`. It deletes the WorkloadRun only when this invocation created it (Kubernetes garbage collection then removes the owned Workflow, whose finalizer deletes the Jobs, workloads, and dependency resources), deletes the namespace only when this run created it, and, when combined with `--setup`, uninstalls the installed components after the cascade completes. On a `--wait` timeout the CLI prints a partial report from the still-live WorkloadRun before any cleanup runs. Without `--cleanup`, a `--wait` timeout stops only the CLI watch and the WorkloadRun continues running.
 
 ### Examples
 

--- a/pkg/workloadrun/run_cleanup_test.go
+++ b/pkg/workloadrun/run_cleanup_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadrun
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+func newWorkloadRunFakeClient(t testing.TB, objects ...client.Object) client.WithWatch {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvcrev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// wrDeleteErrorClient fails deletion of WorkloadRun objects to exercise the
+// cleanup warning path. All other operations pass through.
+type wrDeleteErrorClient struct {
+	client.WithWatch
+	err error
+}
+
+func (c wrDeleteErrorClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if _, ok := obj.(*nvcrev1alpha1.WorkloadRun); ok {
+		return c.err
+	}
+	return c.WithWatch.Delete(ctx, obj, opts...)
+}
+
+// wrCompletingClient marks a WorkloadRun as Succeeded at creation time,
+// simulating a controller that completes the run instantly, so --wait
+// observes a terminal state and prints a report.
+type wrCompletingClient struct {
+	client.WithWatch
+}
+
+func (c wrCompletingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if run, ok := obj.(*nvcrev1alpha1.WorkloadRun); ok {
+		run.Status.Conditions = []metav1.Condition{{
+			Type:               nvcrev1alpha1.WorkloadRunSucceeded,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WorkflowSucceeded",
+			Message:            "Workflow completed successfully",
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+	return c.WithWatch.Create(ctx, obj, opts...)
+}
+
+// wrElapsedRe matches trailing elapsed-time suffixes like "(5s)" or "(1m30s)"
+// that watch lines append; they depend on wall-clock timing and must be
+// normalized for golden-file stability.
+var wrElapsedRe = regexp.MustCompile(`\((\d+h)?(\d+m)?\d+(\.\d+)?s\)`)
+
+// normalizeWorkloadRunRunOutput strips report box-drawing characters and
+// elapsed-time suffixes, mirroring the certification run cleanup tests.
+func normalizeWorkloadRunRunOutput(output string) string {
+	output = wrElapsedRe.ReplaceAllString(output, "(elapsed)")
+	lines := make([]string, 0)
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.ContainsAny(line, "═─") {
+			continue
+		}
+		if strings.HasPrefix(line, "║") || strings.HasPrefix(line, "│") {
+			line = strings.TrimSpace(strings.Trim(line, "║│"))
+		} else {
+			line = strings.TrimRight(line, " \t")
+		}
+		if line == "" && (len(lines) == 0 || lines[len(lines)-1] == "") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n")) + "\n"
+}
+
+// TestExecuteWorkloadRunRunCleanup drives executeWorkloadRunRun with a fake
+// client and verifies the --cleanup semantics mirror certification run:
+// cleanup runs on every exit path, deletes the WorkloadRun only when this
+// invocation created it, deletes the namespace only when this invocation
+// created it, surfaces failures as warnings, and prints the report before
+// the deferred cleanup tears anything down.
+func TestExecuteWorkloadRunRunCleanup(t *testing.T) {
+	// Shorten the cleanup deletion poll so the fake-client cases don't block
+	// on the production 2s ticker.
+	oldInterval := wrDeletionPollInterval
+	wrDeletionPollInterval = 20 * time.Millisecond
+	t.Cleanup(func() { wrDeletionPollInterval = oldInterval })
+
+	p := testutil.TestCaseParser{
+		Subdir:         "run-cleanup",
+		ExpectedSuffix: ".txt",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			DoWait                bool   `json:"doWait"`
+			DoCleanup             bool   `json:"doCleanup"`
+			TimeoutSeconds        int    `json:"timeoutSeconds"`
+			NamespaceExists       bool   `json:"namespaceExists"`
+			RunPreexists          bool   `json:"runPreexists"`
+			DeleteError           string `json:"deleteError"`
+			CompleteOnCreate      bool   `json:"completeOnCreate"`
+			ExpectRunExists       bool   `json:"expectRunExists"`
+			ExpectNamespaceExists bool   `json:"expectNamespaceExists"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input_config.yaml"]), &input); err != nil {
+			return err
+		}
+
+		var run nvcrev1alpha1.WorkloadRun
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input_workloadrun.yaml"]), &run); err != nil {
+			return err
+		}
+
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node-0",
+			Labels: map[string]string{
+				"nvidia.com/gpu.present": "true",
+				"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
+			},
+		}}
+		objects := []client.Object{node}
+		if input.NamespaceExists {
+			objects = append(objects, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: run.Namespace},
+			})
+		}
+		if input.RunPreexists {
+			objects = append(objects, run.DeepCopy())
+		}
+
+		var wc = newWorkloadRunFakeClient(tc.T, objects...)
+		if input.CompleteOnCreate {
+			wc = wrCompletingClient{WithWatch: wc}
+		}
+		if input.DeleteError != "" {
+			wc = wrDeleteErrorClient{WithWatch: wc, err: errors.New(input.DeleteError)}
+		}
+
+		var out bytes.Buffer
+		cfg := &wrRunConfig{
+			run:         &run,
+			doWait:      input.DoWait,
+			doCleanup:   input.DoCleanup,
+			timeout:     time.Duration(input.TimeoutSeconds) * time.Second,
+			out:         &out,
+			watchClient: wc,
+		}
+
+		execErr := executeWorkloadRunRun(cfg)
+
+		// Post-conditions: the WorkloadRun and namespace exist exactly when the
+		// case says they should.
+		gotRun := &nvcrev1alpha1.WorkloadRun{}
+		getErr := wc.Get(context.Background(),
+			client.ObjectKey{Name: run.Name, Namespace: run.Namespace}, gotRun)
+		if input.ExpectRunExists {
+			assert.NoError(tc.T, getErr, "expected WorkloadRun to still exist")
+		} else {
+			assert.True(tc.T, apierrors.IsNotFound(getErr),
+				"expected WorkloadRun to be deleted, got: %v", getErr)
+		}
+		gotNS := &corev1.Namespace{}
+		nsErr := wc.Get(context.Background(), client.ObjectKey{Name: run.Namespace}, gotNS)
+		if input.ExpectNamespaceExists {
+			assert.NoError(tc.T, nsErr, "expected namespace to still exist")
+		} else {
+			assert.True(tc.T, apierrors.IsNotFound(nsErr),
+				"expected namespace to be deleted, got: %v", nsErr)
+		}
+
+		actual := out.String()
+		if execErr != nil {
+			actual += "--- error: " + execErr.Error() + "\n"
+		}
+		tc.Actual = normalizeWorkloadRunRunOutput(actual)
+		return nil
+	})
+}

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/expected.txt
@@ -1,0 +1,25 @@
+[namespace] Creating namespace wr-cleanup-ns...
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+WorkloadRun demo-run created in namespace wr-cleanup-ns.
+
+Waiting for completion (timeout: 0s)...
+
+WorkloadRun Report
+
+  Name:      demo-run
+
+workloadrun/demo-run
+Status:
+
+Summary
+Categories:   0/1 passed
+Failed Nodes: none
+Result:       RUNNING
+
+[cleanup] Cleaning up...
+[cleanup] Deleting WorkloadRun...
+[cleanup] Deleting namespace wr-cleanup-ns...
+  Waiting for namespace wr-cleanup-ns to terminate...
+  Namespace wr-cleanup-ns deleted.
+[cleanup] Done.
+--- error: timeout waiting for WorkloadRun demo-run

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/input_config.yaml
@@ -1,0 +1,10 @@
+# --wait times out immediately; a partial report from the still-live
+# WorkloadRun prints BEFORE cleanup destroys the evidence, then --cleanup
+# deletes the WorkloadRun and the namespace this run created. The timeout
+# error stays the exit status.
+doWait: true
+doCleanup: true
+timeoutSeconds: 0
+namespaceExists: false
+expectRunExists: false
+expectNamespaceExists: false

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-after-wait-timeout/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/expected.txt
@@ -1,0 +1,9 @@
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+WorkloadRun demo-run created in namespace wr-cleanup-ns.
+
+To check status:
+  kubectl get workloadrun demo-run -n wr-cleanup-ns
+[cleanup] Cleaning up...
+[cleanup] Deleting WorkloadRun...
+[cleanup] Warning: failed to delete WorkloadRun: simulated API failure
+[cleanup] Done (with warnings).

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/input_config.yaml
@@ -1,0 +1,8 @@
+# The delete call fails; cleanup reports a warning and finishes with
+# "Done (with warnings)." instead of aborting.
+doWait: false
+doCleanup: true
+deleteError: simulated API failure
+namespaceExists: true
+expectRunExists: true
+expectNamespaceExists: true

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-delete-warning/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/expected.txt
@@ -1,0 +1,21 @@
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+WorkloadRun demo-run created in namespace wr-cleanup-ns.
+
+Waiting for completion (timeout: 30s)...
+[watch] WorkloadRun succeeded. (elapsed)
+
+WorkloadRun Report
+
+  Name:      demo-run
+
+workloadrun/demo-run
+Status:
+
+Summary
+Categories:   0/1 passed
+Failed Nodes: none
+Result:       PASSED
+
+[cleanup] Cleaning up...
+[cleanup] Deleting WorkloadRun...
+[cleanup] Done.

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/input_config.yaml
@@ -1,0 +1,10 @@
+# The run completes while --wait watches; the report must be printed BEFORE
+# the deferred cleanup deletes the WorkloadRun (mirrors certification's
+# reports-before-cleanup test). The pre-existing namespace is preserved.
+doWait: true
+doCleanup: true
+timeoutSeconds: 30
+completeOnCreate: true
+namespaceExists: true
+expectRunExists: false
+expectNamespaceExists: true

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-report-before-delete/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/expected.txt
@@ -1,0 +1,4 @@
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+[cleanup] Cleaning up...
+[cleanup] Done.
+--- error: create WorkloadRun: workloadruns.nvcre.nvidia.com "demo-run" already exists

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/input_config.yaml
@@ -1,0 +1,8 @@
+# Creation fails (a WorkloadRun with the same name already exists). Cleanup
+# still runs but must NOT delete a WorkloadRun this invocation did not create.
+doWait: false
+doCleanup: true
+runPreexists: true
+namespaceExists: true
+expectRunExists: true
+expectNamespaceExists: true

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-skips-run-not-created/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/expected.txt
@@ -1,0 +1,8 @@
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+WorkloadRun demo-run created in namespace wr-cleanup-ns.
+
+To check status:
+  kubectl get workloadrun demo-run -n wr-cleanup-ns
+[cleanup] Cleaning up...
+[cleanup] Deleting WorkloadRun...
+[cleanup] Done.

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/input_config.yaml
@@ -1,0 +1,7 @@
+# --cleanup without --wait still tears down at command exit (same as
+# certification run). The pre-existing namespace is not touched.
+doWait: false
+doCleanup: true
+namespaceExists: true
+expectRunExists: false
+expectNamespaceExists: true

--- a/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/cleanup-without-wait/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/expected.txt
+++ b/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/expected.txt
@@ -1,0 +1,5 @@
+Discovered 1 GPU nodes with product: NVIDIA-H100-80GB-HBM3
+WorkloadRun demo-run created in namespace wr-cleanup-ns.
+
+To check status:
+  kubectl get workloadrun demo-run -n wr-cleanup-ns

--- a/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/input_config.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/input_config.yaml
@@ -1,0 +1,6 @@
+# Without --cleanup nothing is deleted and no cleanup output is printed.
+doWait: false
+doCleanup: false
+namespaceExists: true
+expectRunExists: true
+expectNamespaceExists: true

--- a/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/input_workloadrun.yaml
+++ b/pkg/workloadrun/testdata/run-cleanup/no-cleanup-leaves-run/input_workloadrun.yaml
@@ -1,0 +1,14 @@
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: demo-run
+  namespace: wr-cleanup-ns
+spec:
+  image: nvcr.io/nvidia/pytorch:24.01-py3
+  numNodes: 1
+  framework:
+    exec:
+      command: ["nvidia-smi"]
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -660,7 +661,8 @@ number of nodes is less than spec.numNodes, numNodes is automatically clamped.`,
 
 	cmd.Flags().BoolVar(&doWait, "wait", false, "Watch for completion")
 	cmd.Flags().BoolVar(&doSetup, "setup", false, "Install CRDs, controller, LogProfiles before creating")
-	cmd.Flags().BoolVar(&doCleanup, "cleanup", false, "Delete WorkloadRun and installed components after completion")
+	cmd.Flags().BoolVar(&doCleanup, "cleanup", false,
+		"Delete the WorkloadRun, the namespace (when created by this run), and installed components after completion")
 	cmd.Flags().StringVar(&controllerPullSecret, "controller-pull-secret", "",
 		"Token for controller registry authentication during --setup (e.g. GitHub PAT for ghcr.io) — separate from workload image credentials")
 	cmd.Flags().StringVar(&workloadRegistry, "workload-registry", "",
@@ -670,7 +672,8 @@ number of nodes is less than spec.numNodes, numNodes is automatically clamped.`,
 	cmd.Flags().StringVar(&workloadRegistryPassword, "workload-registry-password", "",
 		"Registry password or API key for workload image pull — creates an imagePullSecret in the WorkloadRun namespace")
 	cmd.Flags().StringVar(&controllerImage, "image", "", "Override controller image")
-	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute, "Wait timeout")
+	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute,
+		"Wait timeout (on timeout, the WorkloadRun is left running unless --cleanup is set)")
 	cmd.Flags().StringVar(&resultsFile, "results-file", "",
 		"Write report as JSON to this file path (requires --wait)")
 	cmd.Flags().StringVar(&nameOverride, "name", "",
@@ -688,9 +691,32 @@ number of nodes is less than spec.numNodes, numNodes is automatically clamped.`,
 	return cmd
 }
 
+// wrRunConfig captures the fully-resolved intent for a workloadrun run,
+// mirroring certRunConfig in pkg/certification. Built from CLI flags by
+// runWorkloadRunExecute, then consumed by executeWorkloadRunRun.
+type wrRunConfig struct {
+	run                      *nvcrev1alpha1.WorkloadRun
+	workloadRegistry         string // --workload-registry: workload registry hostname
+	workloadRegistryUsername string // --workload-registry-username: workload registry username
+	workloadRegistryPassword string // --workload-registry-password: workload registry password/token
+	controllerImage          string // --image: controller image for --setup
+	controllerPullSecret     string // --controller-pull-secret: controller registry token forwarded to setup init
+	doWait                   bool   // --wait: watch + report
+	doSetup                  bool   // --setup: runInit before create
+	doCleanup                bool   // --cleanup: delete run/ns + runReset after
+	timeout                  time.Duration
+	resultsFile              string // --results-file: path to write JSON report
+	configFlags              *kubeconfig.ConfigFlags
+	nodeList                 string // --node-list: used for numNodes clamping after discovery
+	topologyDomain           string // --topology-domain: used for auto topology key + numNodes
+	topologyKey              string // --topology-key: explicit topology label key
+	out                      io.Writer
+	watchClient              client.WithWatch // optional test client; production builds one from configFlags
+}
+
 func runWorkloadRunExecute(
 	file, namespace, workloadRegistry, workloadRegistryUsername, workloadRegistryPassword, controllerImage, controllerPullSecret string,
-	doWait, doSetup, _ bool, timeout time.Duration,
+	doWait, doSetup, doCleanup bool, timeout time.Duration,
 	resultsFile string, configFlags *kubeconfig.ConfigFlags,
 	nameOverride, nodeList, topologyDomain,
 	topologyKey, testScale string,
@@ -712,31 +738,76 @@ func runWorkloadRunExecute(
 		run.Namespace = defaultNS
 	}
 
-	out := os.Stderr
+	return executeWorkloadRunRun(&wrRunConfig{
+		run:                      run,
+		workloadRegistry:         workloadRegistry,
+		workloadRegistryUsername: workloadRegistryUsername,
+		workloadRegistryPassword: workloadRegistryPassword,
+		controllerImage:          controllerImage,
+		controllerPullSecret:     controllerPullSecret,
+		doWait:                   doWait,
+		doSetup:                  doSetup,
+		doCleanup:                doCleanup,
+		timeout:                  timeout,
+		resultsFile:              resultsFile,
+		configFlags:              configFlags,
+		nodeList:                 nodeList,
+		topologyDomain:           topologyDomain,
+		topologyKey:              topologyKey,
+		out:                      os.Stderr,
+	})
+}
 
-	// Build client.
-	wc, err := render.NewK8sWatchClient(configFlags)
-	if err != nil {
-		return fmt.Errorf("build client: %w", err)
+// executeWorkloadRunRun is the unified pipeline for workloadrun run. Setup,
+// wait, and cleanup are composable phases controlled by the config flags,
+// mirroring executeCertificationRun in pkg/certification.
+func executeWorkloadRunRun(cfg *wrRunConfig) error {
+	run := cfg.run
+	out := cfg.out
+
+	// Build client early so the cleanup defer can use it.
+	wc := cfg.watchClient
+	if wc == nil {
+		var err error
+		wc, err = render.NewK8sWatchClient(cfg.configFlags)
+		if err != nil {
+			return fmt.Errorf("build client: %w", err)
+		}
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// --- Cleanup defer (registered BEFORE setup so it runs on setup failures) ---
+	// It runs on every exit path — success, failure, or wait timeout — matching
+	// certification run --cleanup semantics.
+	runCreated := false
+	createdNamespace := ""
+
+	if cfg.doCleanup {
+		defer func() {
+			runWorkloadRunCleanup(wc, cfg, runCreated, createdNamespace)
+		}()
+	}
+
 	// Setup phase.
-	if doSetup {
+	if cfg.doSetup {
 		_, _ = fmt.Fprintln(out, "Installing NVCRE components...")
-		if initErr := setup.RunInit("", controllerImage, controllerPullSecret, "",
-			true, configFlags, "", os.Stdin, out); initErr != nil {
+		if initErr := setup.RunInit("", cfg.controllerImage, cfg.controllerPullSecret, "",
+			true, cfg.configFlags, "", os.Stdin, out); initErr != nil {
 			return fmt.Errorf("setup: %w", initErr)
 		}
 		_, _ = fmt.Fprintln(out, "Setup complete.")
 	}
 
-	// Create namespace if needed.
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: run.Namespace}}
-	if err := wc.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create namespace %s: %w", run.Namespace, err)
+	// Create namespace if needed, remembering whether this run created it so
+	// cleanup only deletes namespaces it owns.
+	wasNamespaceCreated, err := setup.EnsureNamespace(ctx, wc, run.Namespace, out)
+	if err != nil {
+		return err
+	}
+	if wasNamespaceCreated {
+		createdNamespace = run.Namespace
 	}
 
 	// Create pull secret before the WorkloadRun so pods can pull immediately.
@@ -744,9 +815,9 @@ func runWorkloadRunExecute(
 	// wasCreatedByUs is false when an existing secret was only updated (concurrent
 	// run) — do not delete on rollback in that case.
 	wasCreatedByUs := false
-	if workloadRegistryPassword != "" {
+	if cfg.workloadRegistryPassword != "" {
 		secretName, created, secretErr := setup.CreateImagePullSecret(ctx, wc,
-			run.Namespace, setup.WorkloadPullSecretName(run.Name), workloadRegistry, workloadRegistryUsername, workloadRegistryPassword)
+			run.Namespace, setup.WorkloadPullSecretName(run.Name), cfg.workloadRegistry, cfg.workloadRegistryUsername, cfg.workloadRegistryPassword)
 		if secretErr != nil {
 			return fmt.Errorf("create image pull secret: %w", secretErr)
 		}
@@ -759,7 +830,7 @@ func runWorkloadRunExecute(
 	// Resolve auto topology key before discovery. The __auto__ placeholder
 	// can't be used for node filtering, so we do a preliminary discovery
 	// without matchExpressions to detect the platform first.
-	if topologyDomain != "" && topologyKey == "" {
+	if cfg.topologyDomain != "" && cfg.topologyKey == "" {
 		prelimNodes, _, _ := cluster.DiscoverGPUNodes(ctx, wc, nil)
 		if len(prelimNodes) > 0 {
 			detectedPlatform := controller.DetectPlatform(prelimNodes)
@@ -788,10 +859,10 @@ func runWorkloadRunExecute(
 	// Auto-infer numNodes from target node count.
 	// --node-list: clamp down if fewer nodes than spec.
 	// --topology-domain: set to discovered count (all nodes in the domain).
-	if nodeList != "" && run.Spec.NumNodes > int32(len(nodes)) {
+	if cfg.nodeList != "" && run.Spec.NumNodes > int32(len(nodes)) {
 		run.Spec.NumNodes = int32(len(nodes))
 	}
-	if topologyDomain != "" {
+	if cfg.topologyDomain != "" {
 		run.Spec.NumNodes = int32(len(nodes))
 	}
 
@@ -807,6 +878,7 @@ func runWorkloadRunExecute(
 		}
 		return fmt.Errorf("create WorkloadRun: %w", err)
 	}
+	runCreated = true
 	_, _ = fmt.Fprintf(out, "WorkloadRun %s created in namespace %s.\n",
 		run.Name, run.Namespace)
 
@@ -814,48 +886,195 @@ func runWorkloadRunExecute(
 	// Only when wasCreatedByUs: if we only updated an existing secret we don't own
 	// it and must not manage its lifecycle.
 	if wasCreatedByUs {
-		sec := &corev1.Secret{}
-		if getErr := wc.Get(ctx, client.ObjectKey{Name: setup.WorkloadPullSecretName(run.Name), Namespace: run.Namespace}, sec); getErr != nil {
-			_, _ = fmt.Fprintf(out, "Warning: could not retrieve pull secret %q to set OwnerReference: %v\n",
-				setup.WorkloadPullSecretName(run.Name), getErr)
-		} else {
-			sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
-				APIVersion: "nvcre.nvidia.com/v1alpha1",
-				Kind:       "WorkloadRun",
-				Name:       run.Name,
-				UID:        run.UID,
-			})
-			if updateErr := wc.Update(ctx, sec); updateErr != nil {
-				_, _ = fmt.Fprintf(out, "Warning: could not set OwnerReference on pull secret %q — it will not be GC'd automatically: %v\n",
-					setup.WorkloadPullSecretName(run.Name), updateErr)
-			}
-		}
+		setPullSecretOwnerReference(ctx, wc, run, out)
 	}
 
-	if !doWait {
+	if !cfg.doWait {
 		_, _ = fmt.Fprintf(out, "\nTo check status:\n")
 		_, _ = fmt.Fprintf(out, "  kubectl get workloadrun %s -n %s\n", run.Name, run.Namespace)
 		return nil
 	}
 
 	// Wait for completion.
-	_, _ = fmt.Fprintf(out, "\nWaiting for completion (timeout: %s)...\n", timeout)
-	finalRun, waitErr := watchWorkloadRun(ctx, wc, run.Name, run.Namespace, timeout, out)
+	_, _ = fmt.Fprintf(out, "\nWaiting for completion (timeout: %s)...\n", cfg.timeout)
+	finalRun, waitErr := watchWorkloadRun(ctx, wc, run.Name, run.Namespace, cfg.timeout, out)
 
-	// Print report if we have a terminal WorkloadRun.
+	// A --wait timeout ends only the CLI watch; the WorkloadRun is still
+	// live. Retrieve it so a partial report prints before the deferred
+	// cleanup (if any) destroys the evidence — mirroring
+	// finishCertificationWait in pkg/certification.
+	if finalRun == nil && isWorkloadRunWaitTimeout(waitErr) {
+		current := &nvcrev1alpha1.WorkloadRun{}
+		key := client.ObjectKey{Name: run.Name, Namespace: run.Namespace}
+		if getErr := wc.Get(ctx, key, current); getErr != nil {
+			_, _ = fmt.Fprintf(out,
+				"Warning: could not retrieve WorkloadRun %q after timeout; partial report unavailable: %v\n",
+				run.Name, getErr)
+		} else {
+			finalRun = current
+		}
+	}
+
+	// Print the report from the best available state — the terminal
+	// WorkloadRun, or the still-running one after a timeout. This happens
+	// before the deferred cleanup runs, so the report reflects the live
+	// resources.
 	if finalRun != nil {
 		r := buildWorkloadRunReport(ctx, wc, finalRun)
 		report.Print(out, r)
-		if resultsFile != "" {
-			if err := report.WriteJSON(resultsFile, []*report.CertReport{r}); err != nil {
+		if cfg.resultsFile != "" {
+			if err := report.WriteJSON(cfg.resultsFile, []*report.CertReport{r}); err != nil {
 				_, _ = fmt.Fprintf(out, "Warning: failed to write results: %v\n", err)
 			} else {
-				_, _ = fmt.Fprintf(out, "Results written to %s\n", resultsFile)
+				_, _ = fmt.Fprintf(out, "Results written to %s\n", cfg.resultsFile)
 			}
 		}
 	}
 
 	return waitErr
+}
+
+// runWorkloadRunCleanup tears down what this invocation created, mirroring
+// the certification run cleanup defer: delete the WorkloadRun (only when this
+// run created it) and wait for the cascade, delete the namespace (only when
+// this run created it), then reset installed components when --setup was
+// given. Failures are reported as warnings; cleanup never aborts.
+func runWorkloadRunCleanup(wc client.Client, cfg *wrRunConfig, runCreated bool, createdNamespace string) {
+	out := cfg.out
+	run := cfg.run
+
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cleanupCancel()
+
+	_, _ = fmt.Fprintln(out, "[cleanup] Cleaning up...")
+	warnings := false
+
+	// Delete the WorkloadRun and wait for the cascade to finish. A WorkloadRun
+	// carries no finalizer of its own; Kubernetes GC deletes the owned
+	// Workflow, whose finalizer deletes Jobs, workloads, and dependencies.
+	// The controller needs its RBAC and Deployment to process that cascade,
+	// so we MUST wait for it to complete before running reset.
+	if runCreated {
+		_, _ = fmt.Fprintln(out, "[cleanup] Deleting WorkloadRun...")
+		if err := wc.Delete(cleanupCtx, run); err != nil && !apierrors.IsNotFound(err) {
+			_, _ = fmt.Fprintf(out, "[cleanup] Warning: failed to delete WorkloadRun: %v\n", err)
+			warnings = true
+		} else {
+			waitForWorkloadRunDeletion(cleanupCtx, wc, run.Name, run.Namespace, out)
+		}
+	}
+
+	// Note: the workload pull secret is owned by the WorkloadRun and will be
+	// garbage-collected automatically when the WorkloadRun is deleted above.
+	// No explicit deletion needed.
+
+	// Delete namespace if we created it, and wait for it to fully terminate
+	// so the next run doesn't fail with "namespace is being terminated".
+	if createdNamespace != "" {
+		_, _ = fmt.Fprintf(out, "[cleanup] Deleting namespace %s...\n", createdNamespace)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: createdNamespace}}
+		if err := wc.Delete(cleanupCtx, ns); err != nil && !apierrors.IsNotFound(err) {
+			_, _ = fmt.Fprintf(out, "[cleanup] Warning: failed to delete namespace %s: %v\n", createdNamespace, err)
+			warnings = true
+		} else {
+			setup.WaitForNamespaceDeletion(cleanupCtx, wc, createdNamespace, out)
+		}
+	}
+
+	// Reset all installed phases via runReset. SSA makes setup idempotent,
+	// so we reset everything unconditionally.
+	if cfg.doSetup {
+		if err := setup.RunReset("", true, cfg.configFlags, nil, out); err != nil {
+			_, _ = fmt.Fprintf(out, "[cleanup] Warning: reset failed: %v\n", err)
+			warnings = true
+		}
+	}
+
+	if warnings {
+		_, _ = fmt.Fprintln(out, "[cleanup] Done (with warnings).")
+	} else {
+		_, _ = fmt.Fprintln(out, "[cleanup] Done.")
+	}
+}
+
+// setPullSecretOwnerReference points the workload pull secret at the created
+// WorkloadRun so Kubernetes GC deletes the secret whenever the WorkloadRun is
+// deleted by any means. Failures only warn: the run itself is already created.
+func setPullSecretOwnerReference(ctx context.Context, wc client.Client, run *nvcrev1alpha1.WorkloadRun, out io.Writer) {
+	sec := &corev1.Secret{}
+	if getErr := wc.Get(ctx, client.ObjectKey{Name: setup.WorkloadPullSecretName(run.Name), Namespace: run.Namespace}, sec); getErr != nil {
+		_, _ = fmt.Fprintf(out, "Warning: could not retrieve pull secret %q to set OwnerReference: %v\n",
+			setup.WorkloadPullSecretName(run.Name), getErr)
+		return
+	}
+	sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "nvcre.nvidia.com/v1alpha1",
+		Kind:       "WorkloadRun",
+		Name:       run.Name,
+		UID:        run.UID,
+	})
+	if updateErr := wc.Update(ctx, sec); updateErr != nil {
+		_, _ = fmt.Fprintf(out, "Warning: could not set OwnerReference on pull secret %q — it will not be GC'd automatically: %v\n",
+			setup.WorkloadPullSecretName(run.Name), updateErr)
+	}
+}
+
+// wrDeletionPollInterval is how often cleanup polls for the deletion cascade
+// to complete. A variable so tests can shorten it instead of blocking on the
+// production ticker.
+var wrDeletionPollInterval = 2 * time.Second
+
+// waitForWorkloadRunDeletion waits for a deleted WorkloadRun and its child
+// Workflow (same name, per the WorkloadRun controller) to be fully gone.
+// The WorkloadRun itself has no finalizer, so it disappears quickly; the
+// cascade that matters is the owned Workflow, whose finalizer deletes Jobs,
+// workloads, and dependency resources. The timeout is generous because the
+// controller must process that finalizer before the Workflow goes away.
+//
+// Because the WorkloadRun has no finalizer to serialize the cascade (unlike
+// a Certification), there is a narrow window where a reconcile already in
+// flight creates the Workflow after both Gets observed NotFound. The residual
+// risk is sub-second against the poll interval and only matters when
+// --setup --cleanup resets the controller immediately afterwards.
+func waitForWorkloadRunDeletion(ctx context.Context, c client.Client, name, namespace string, out io.Writer) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(wrDeletionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_, _ = fmt.Fprintln(out, "[cleanup] Timed out waiting for deletion.")
+			return
+		case <-ticker.C:
+			run := &nvcrev1alpha1.WorkloadRun{}
+			if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, run); err == nil || !apierrors.IsNotFound(err) {
+				continue
+			}
+			workflow := &nvcrev1alpha1.Workflow{}
+			if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, workflow); apierrors.IsNotFound(err) {
+				return // fully cascaded
+			}
+		}
+	}
+}
+
+// workloadRunWaitTimeoutError identifies the CLI watch deadline without
+// changing the existing user-facing error text, mirroring
+// certificationWaitTimeoutError in pkg/certification.
+type workloadRunWaitTimeoutError struct {
+	name string
+}
+
+func (e *workloadRunWaitTimeoutError) Error() string {
+	return fmt.Sprintf("timeout waiting for WorkloadRun %s", e.name)
+}
+
+func isWorkloadRunWaitTimeout(err error) bool {
+	var timeoutErr *workloadRunWaitTimeoutError
+	return errors.As(err, &timeoutErr)
 }
 
 // watchWorkloadRun polls until the WorkloadRun reaches a terminal state.
@@ -881,7 +1100,7 @@ func watchWorkloadRun(
 		case <-ctx.Done():
 			return nil, fmt.Errorf("interrupted")
 		case <-deadline:
-			return nil, fmt.Errorf("timeout waiting for WorkloadRun %s", name)
+			return nil, &workloadRunWaitTimeoutError{name: name}
 		case <-heartbeat.C:
 			elapsed := time.Since(start).Truncate(time.Second)
 			_, _ = fmt.Fprintln(out, workloadRunWatchLine(&current, name, elapsed))


### PR DESCRIPTION
## Summary

Fixes #66

- `workloadrun run --cleanup` was accepted and then dropped on the floor: the executor bound the flag to `_`, so no teardown ever ran despite the help text promising it. `certification run --cleanup` already worked, so the two commands disagreed on the same flag.
- Implements cleanup by mirroring certification's semantics: the run path now goes through `executeWorkloadRunRun(cfg *wrRunConfig)` (same config-struct pipeline as `executeCertificationRun`), with a cleanup defer registered before the setup phase so it fires on every exit path — success, failure, or `--wait` timeout, and also when `--cleanup` is used without `--wait`.
- What gets deleted: the WorkloadRun (only when this invocation created it; children cascade via ownership — GC removes the owned Workflow, whose finalizer deletes Jobs, workloads, and dependencies), the namespace (only when this run created it — namespace creation now goes through `setup.EnsureNamespace` to track that), and, with `--setup`, the installed components via `setup.RunReset` after the cascade completes. Failures downgrade to `[cleanup] Warning:` lines and `Done (with warnings).`, never an abort.
- A `--wait` timeout no longer destroys the evidence: the watch returns a typed timeout error, the CLI re-fetches the still-live WorkloadRun, and a partial report prints before any cleanup runs — the same behavior `certification run` has. The timeout remains the exit status.
- Since a WorkloadRun has no finalizer (unlike a Certification), the deletion wait also polls the owned Workflow so a combined `--setup --cleanup` cannot reset the controller before the Workflow finalizer finishes — that would strand the Workflow. The narrow reconcile-in-flight window this leaves is documented at the wait function.
- Updated the `--cleanup`/`--timeout` flag help and `docs/cli-reference/workloadrun.md` to state the semantics, including the created-by-this-invocation guard on the WorkloadRun delete.
- Tests: new testutil golden suite (`pkg/workloadrun/testdata/run-cleanup/`, 6 cases) drives the executor with a fake client, covering the partial report plus cleanup after a `--wait` timeout, report-printed-before-cleanup ordering, cleanup without `--wait`, the created-by-us guards for both the run and the namespace, the delete-failure warning path, and the no-cleanup baseline. The deletion-wait poll interval is injectable so the suite runs in ~8s instead of blocking on the production 2s ticker. All goldens are new files for the new tests; `cleanup-after-wait-timeout/expected.txt` was regenerated once after adding the partial-report-on-timeout behavior — the only diff is the report block now printing before the `[cleanup]` lines, which is the point of that change. `make lint-fix`, `make build`, and the full `make test` (unit + integration) pass.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [x] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [x] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
