### PR TITLE
fix(controller): surface validation failures on WorkloadRun as ValidationFailed

### DIFF
--- a/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/expected.json
@@ -1,9 +1,9 @@
 {
-  "Workflow/test-workflow-validation-fail": {
+  "Workflow/test-workflow-hw-and-validation-fail": {
     "kind": "Workflow",
     "apiVersion": "nvcre.nvidia.com/v1alpha1",
     "metadata": {
-      "name": "test-workflow-validation-fail",
+      "name": "test-workflow-hw-and-validation-fail",
       "namespace": "default",
       "finalizers": [
         "nvcre.nvidia.com/workflow-finalizer"
@@ -66,8 +66,8 @@
           "status": "True",
           "observedGeneration": 1,
           "lastTransitionTime": null,
-          "reason": "JobValidationFailed",
-          "message": "1 groups failed across 1 iterations"
+          "reason": "JobHardwareFailed",
+          "message": "2 groups failed across 1 iterations; hardware failures occurred on one or more nodes"
         },
         {
           "type": "ValidationFailed",
@@ -84,9 +84,9 @@
         "name": "failed-nodes"
       },
       "orchestration": {
-        "totalNodes": 1,
+        "totalNodes": 2,
         "nodesPerJob": 1,
-        "totalGroups": 1,
+        "totalGroups": 2,
         "currentIteration": 1,
         "completedIterations": 1,
         "groups": [
@@ -99,7 +99,20 @@
             "jobRef": {
               "apiVersion": "nvcre.nvidia.com/v1alpha1",
               "kind": "Job",
-              "name": "test-workflow-validation-fail-job",
+              "name": "test-workflow-hw-and-validation-fail-job-0",
+              "namespace": "default"
+            }
+          },
+          {
+            "name": "group-1",
+            "nodes": [
+              "gpu-node-02"
+            ],
+            "phase": "Failed",
+            "jobRef": {
+              "apiVersion": "nvcre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-workflow-hw-and-validation-fail-job-1",
               "namespace": "default"
             }
           }

--- a/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/input_client_objects.yaml
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mixed failure: one group fails on hardware, another on threshold validation.
+# The Workflow must end Failed with the hardware reason (hardware takes
+# precedence) while still carrying the supplementary ValidationFailed
+# condition so the threshold miss is not lost (issue #67 review follow-up).
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-workflow-hw-and-validation-fail
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - python
+              - train.py
+            numNodes: 1
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+status:
+  orchestration:
+    totalNodes: 2
+    nodesPerJob: 1
+    totalGroups: 2
+    currentIteration: 1
+    groups:
+      - name: group-0
+        nodes:
+          - gpu-node-01
+        phase: Running
+        jobRef:
+          apiVersion: nvcre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-workflow-hw-and-validation-fail-job-0
+          namespace: default
+      - name: group-1
+        nodes:
+          - gpu-node-02
+        phase: Running
+        jobRef:
+          apiVersion: nvcre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-workflow-hw-and-validation-fail-job-1
+          namespace: default
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-workflow-hw-and-validation-fail-job-0
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: nvcre
+    nvcre.nvidia.com/workflow: test-workflow-hw-and-validation-fail
+    nvcre.nvidia.com/group: group-0
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - python
+          - train.py
+        numNodes: 1
+status:
+  conditions:
+    - type: InProgress
+      status: "False"
+      reason: WorkloadCompleted
+      message: "Workload has completed"
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Succeeded
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Failed
+      status: "True"
+      reason: WorkloadFailed
+      message: "Workload failed due to hardware failure"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: HardwareFailed
+      status: "True"
+      reason: NodeHealthCheckFailed
+      message: "Hardware failure detected on nodes: node-gpu-01"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+  failedNodes:
+    - name: node-gpu-01
+      reason: HardwareFailureDetected
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-workflow-hw-and-validation-fail-job-1
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: nvcre
+    nvcre.nvidia.com/workflow: test-workflow-hw-and-validation-fail
+    nvcre.nvidia.com/group: group-1
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - python
+          - train.py
+        numNodes: 1
+status:
+  conditions:
+    - type: InProgress
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadCompleted
+      message: "Workload has completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: ValidationFailed
+      status: "True"
+      reason: ThresholdViolation
+      message: 'Threshold "busBandwidthGBps" violated: measured 188.6700, expression: value >= 900'
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+  failedNodes:
+    - name: node-gpu-02
+      reason: ThresholdViolation
+      message: 'Threshold "busBandwidthGBps" violated: measured 188.6700, expression: value >= 900'

--- a/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-hardware-and-validation-failed/input_config.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: Workflow
+  name: test-workflow-hw-and-validation-fail
+  namespace: default
+  condition: Failed
+  reason: JobHardwareFailed
+collect:
+  - kind: Workflow
+    name: test-workflow-hw-and-validation-fail
+    namespace: default

--- a/cmd/integration/testdata/reconcile/workloadrun-validation-failed/expected.json
+++ b/cmd/integration/testdata/reconcile/workloadrun-validation-failed/expected.json
@@ -1,9 +1,9 @@
 {
-  "Workflow/test-workflow-validation-fail": {
+  "Workflow/test-wr-validation-fail": {
     "kind": "Workflow",
     "apiVersion": "nvcre.nvidia.com/v1alpha1",
     "metadata": {
-      "name": "test-workflow-validation-fail",
+      "name": "test-wr-validation-fail",
       "namespace": "default",
       "finalizers": [
         "nvcre.nvidia.com/workflow-finalizer"
@@ -99,11 +99,80 @@
             "jobRef": {
               "apiVersion": "nvcre.nvidia.com/v1alpha1",
               "kind": "Job",
-              "name": "test-workflow-validation-fail-job",
+              "name": "test-wr-validation-fail-job",
               "namespace": "default"
             }
           }
         ]
+      }
+    }
+  },
+  "WorkloadRun/test-wr-validation-fail": {
+    "kind": "WorkloadRun",
+    "apiVersion": "nvcre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-wr-validation-fail",
+      "namespace": "default"
+    },
+    "spec": {
+      "target": {
+        "nodeSelector": {
+          "nvidia.com/gpu.present": "true"
+        }
+      },
+      "image": "test-image:latest",
+      "framework": {
+        "exec": {
+          "command": [
+            "python",
+            "train.py"
+          ]
+        }
+      },
+      "numNodes": 1,
+      "thresholds": {
+        "busBandwidthGBps": "value \u003e= 900"
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "ValidationFailed",
+          "status": "True",
+          "lastTransitionTime": null,
+          "reason": "ThresholdViolation",
+          "message": "One or more Jobs failed performance threshold validation"
+        },
+        {
+          "type": "InProgress",
+          "status": "False",
+          "lastTransitionTime": null,
+          "reason": "Superseded",
+          "message": ""
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "lastTransitionTime": null,
+          "reason": "Superseded",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "True",
+          "lastTransitionTime": null,
+          "reason": "WorkflowValidationFailed",
+          "message": "1 groups failed across 1 iterations"
+        }
+      ],
+      "workflowRef": {
+        "name": "test-wr-validation-fail",
+        "namespace": "default"
+      },
+      "failedNodesRef": {
+        "apiGroup": null,
+        "kind": "ConfigMap",
+        "name": "failed-nodes"
       }
     }
   }

--- a/cmd/integration/testdata/reconcile/workloadrun-validation-failed/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workloadrun-validation-failed/input_client_objects.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# A WorkloadRun whose Workflow fails because the underlying Job violated a
+# performance threshold (Job Succeeded=True + ValidationFailed=True). The
+# Workflow controller must fail the Workflow with reason JobValidationFailed
+# AND set the supplementary ValidationFailed condition; the WorkloadRun
+# controller must mirror both: Failed with reason WorkflowValidationFailed
+# plus the independent ValidationFailed condition (issue #67).
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-wr-validation-fail
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - python
+              - train.py
+            numNodes: 1
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+status:
+  orchestration:
+    totalNodes: 1
+    nodesPerJob: 1
+    totalGroups: 1
+    currentIteration: 1
+    groups:
+      - name: group-0
+        nodes:
+          - gpu-node-01
+        phase: Running
+        jobRef:
+          apiVersion: nvcre.nvidia.com/v1alpha1
+          kind: Job
+          name: test-wr-validation-fail-job
+          namespace: default
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Job
+metadata:
+  name: test-wr-validation-fail-job
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: nvcre
+    nvcre.nvidia.com/workflow: test-wr-validation-fail
+    nvcre.nvidia.com/group: group-0
+spec:
+  workload:
+    trainJob:
+      runtimeRef:
+        kind: TrainingRuntime
+        name: test-runtime
+      trainer:
+        image: test-image:latest
+        command:
+          - python
+          - train.py
+        numNodes: 1
+status:
+  conditions:
+    - type: InProgress
+      status: "False"
+      reason: NotApplicable
+      lastTransitionTime: "2026-01-22T10:00:00Z"
+    - type: Succeeded
+      status: "True"
+      reason: WorkloadCompleted
+      message: "Workload has completed"
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+    - type: ValidationFailed
+      status: "True"
+      reason: ThresholdViolation
+      message: 'Threshold "busBandwidthGBps" violated: measured 188.6700, expression: value >= 900'
+      lastTransitionTime: "2026-01-22T10:05:00Z"
+  failedNodes:
+    - name: gpu-node-01
+      reason: ThresholdViolation
+      message: 'Threshold "busBandwidthGBps" violated: measured 188.6700, expression: value >= 900'
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: WorkloadRun
+metadata:
+  name: test-wr-validation-fail
+  namespace: default
+spec:
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+  image: test-image:latest
+  framework:
+    exec:
+      command:
+        - python
+        - train.py
+  numNodes: 1
+  thresholds:
+    busBandwidthGBps: "value >= 900"
+status:
+  workflowRef:
+    name: test-wr-validation-fail
+    namespace: default

--- a/cmd/integration/testdata/reconcile/workloadrun-validation-failed/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workloadrun-validation-failed/input_config.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: WorkloadRun
+  name: test-wr-validation-fail
+  namespace: default
+  condition: Failed
+  reason: WorkflowValidationFailed
+# The WorkloadRun controller's requeue interval is a fixed 15s (not tunable in
+# tests), so the terminal mirror can take a full interval after the Workflow
+# turns Failed.
+timeoutSeconds: 60
+collect:
+  - kind: WorkloadRun
+    name: test-wr-validation-fail
+    namespace: default
+  - kind: Workflow
+    name: test-wr-validation-fail
+    namespace: default

--- a/docs/api-reference/workflow.md
+++ b/docs/api-reference/workflow.md
@@ -16,7 +16,7 @@ _Generated from CRD schema — coming soon._
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `conditions` | []Condition | Exclusive set: `InProgress`, `Succeeded`, `Failed`. Independent (additive): `ValidationFailed` (aggregates Job validation failures; can be True alongside other states) |
+| `conditions` | []Condition | Exclusive set: `InProgress`, `Succeeded`, `Failed`. Independent (additive): `ValidationFailed` — aggregates Job validation failures; set True alongside `Failed` whenever any Job failed performance threshold validation, even when hardware failures determine the `Failed` reason. When the threshold miss is the only cause, `Failed` carries reason `JobValidationFailed` |
 | `namespace` | string | Resolved namespace where Jobs and dependencies are created |
 | `succeededNodesRef` | TypedLocalObjectReference | ConfigMap reference for the succeeded-nodes list |
 | `failedNodesRef` | TypedLocalObjectReference | ConfigMap reference for the failed-nodes list |

--- a/docs/api-reference/workloadrun.md
+++ b/docs/api-reference/workloadrun.md
@@ -52,7 +52,7 @@ _Generated from CRD schema — coming soon. Fields documented so far:_
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `conditions` | []Condition | Exclusive set: `InProgress`, `Succeeded`, `Failed`. Independent (additive): `ValidationFailed` (can be True alongside `Succeeded` — workload finished but violated a threshold) |
+| `conditions` | []Condition | Exclusive set: `InProgress`, `Succeeded`, `Failed`. Independent (additive): `ValidationFailed` — mirrored from the Workflow whenever any Job violated a performance threshold. When the threshold miss is the failure cause, `Failed` carries reason `WorkflowValidationFailed` so a threshold miss is distinguishable from an execution failure |
 | `workflowRef` | WorkflowReference | Reference to the underlying `Workflow` resource |
 | `detectedGPUArchitecture` | string | Auto-detected GPU type (e.g., `h100`, `gb200`) |
 | `detectedPlatform` | string | Auto-detected CSP platform (e.g., `aws`, `gcp`, `azure`) |

--- a/pkg/controller/testdata/apply-workflow-validation-failed/idempotent-already-set/expected.json
+++ b/pkg/controller/testdata/apply-workflow-validation-failed/idempotent-already-set/expected.json
@@ -1,0 +1,12 @@
+{
+  "changed": false,
+  "conditions": [
+    {
+      "type": "ValidationFailed",
+      "status": "True",
+      "lastTransitionTime": null,
+      "reason": "JobValidationFailed",
+      "message": "One or more Jobs failed performance threshold validation"
+    }
+  ]
+}

--- a/pkg/controller/testdata/apply-workflow-validation-failed/idempotent-already-set/input.yaml
+++ b/pkg/controller/testdata/apply-workflow-validation-failed/idempotent-already-set/input.yaml
@@ -1,0 +1,13 @@
+message: One or more Jobs failed performance threshold validation
+workflow:
+  metadata:
+    name: w
+  spec:
+    categories: []
+  status:
+    conditions:
+      - type: ValidationFailed
+        status: "True"
+        reason: JobValidationFailed
+        message: One or more Jobs failed performance threshold validation
+        lastTransitionTime: "2026-01-22T10:05:00Z"

--- a/pkg/controller/testdata/apply-workflow-validation-failed/sets-condition/expected.json
+++ b/pkg/controller/testdata/apply-workflow-validation-failed/sets-condition/expected.json
@@ -1,0 +1,26 @@
+{
+  "changed": true,
+  "conditions": [
+    {
+      "type": "InProgress",
+      "status": "False",
+      "lastTransitionTime": null,
+      "reason": "NotApplicable",
+      "message": ""
+    },
+    {
+      "type": "Failed",
+      "status": "True",
+      "lastTransitionTime": null,
+      "reason": "JobValidationFailed",
+      "message": "1 groups failed across 1 iterations"
+    },
+    {
+      "type": "ValidationFailed",
+      "status": "True",
+      "lastTransitionTime": null,
+      "reason": "JobValidationFailed",
+      "message": "One or more Jobs failed performance threshold validation"
+    }
+  ]
+}

--- a/pkg/controller/testdata/apply-workflow-validation-failed/sets-condition/input.yaml
+++ b/pkg/controller/testdata/apply-workflow-validation-failed/sets-condition/input.yaml
@@ -1,0 +1,17 @@
+message: One or more Jobs failed performance threshold validation
+workflow:
+  metadata:
+    name: w
+  spec:
+    categories: []
+  status:
+    conditions:
+      - type: InProgress
+        status: "False"
+        reason: NotApplicable
+        lastTransitionTime: "2026-01-22T10:00:00Z"
+      - type: Failed
+        status: "True"
+        reason: JobValidationFailed
+        message: 1 groups failed across 1 iterations
+        lastTransitionTime: "2026-01-22T10:05:00Z"

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -1722,11 +1722,12 @@ func (r *WorkflowReconciler) setFinalStatus(ctx context.Context, workflow *nvcre
 
 	if failedGroups > 0 {
 		isHardware := r.hasHardwareFailures(ctx, workflow)
+		hasValidation := r.hasValidationFailures(ctx, workflow)
 
 		reason := ReasonIterationsFailed
-		if r.hasHardwareFailures(ctx, workflow) {
+		if isHardware {
 			reason = ReasonJobHardwareFailed
-		} else if r.hasValidationFailures(ctx, workflow) {
+		} else if hasValidation {
 			reason = ReasonJobValidationFailed
 		}
 
@@ -1739,9 +1740,22 @@ func (r *WorkflowReconciler) setFinalStatus(ctx context.Context, workflow *nvcre
 			logf.FromContext(ctx).Error(err, "Failed to record succeeded nodes to ConfigMap")
 		}
 
-		return ctrl.Result{}, r.setWorkflowFailed(ctx, workflow, reason, msg,
+		extras := []func(*nvcrev1alpha1.Workflow) bool{
 			applySucceededNodesRef(workflow.Status.SucceededNodesRef),
-			applyFailedNodesRef(workflow.Status.FailedNodesRef))
+			applyFailedNodesRef(workflow.Status.FailedNodesRef),
+		}
+		if hasValidation {
+			// Supplementary quality signal alongside the exclusive Failed
+			// condition: it lets consumers (the WorkloadRun controller,
+			// certification reports) tell a threshold miss apart from an
+			// execution failure. Set whenever any Job failed threshold
+			// validation, even when hardware failures win the Failed reason,
+			// so mixed-failure runs do not lose the quality signal.
+			extras = append(extras, applyWorkflowValidationFailed(
+				"One or more Jobs failed performance threshold validation"))
+		}
+
+		return ctrl.Result{}, r.setWorkflowFailed(ctx, workflow, reason, msg, extras...)
 	}
 
 	msg := fmt.Sprintf("All %d iterations completed successfully", totalIter)
@@ -2025,6 +2039,25 @@ func applyFailedNodesRef(ref *corev1.TypedLocalObjectReference) func(*nvcrev1alp
 		}
 		w.Status.FailedNodesRef = ref
 		return true
+	}
+}
+
+// applyWorkflowValidationFailed returns an extra func for setWorkflowFailed that
+// sets the supplementary WorkflowValidationFailed condition alongside the
+// exclusive Failed condition. ValidationFailed is deliberately NOT part of the
+// exclusive InProgress/Succeeded/Failed trio (see workflow_types.go): it is an
+// independent quality signal that distinguishes "the workload ran but missed
+// its thresholds" from "the workload broke". Applied inside the
+// updateStatusWithRetry closure so it survives 409 conflict re-fetches.
+func applyWorkflowValidationFailed(message string) func(*nvcrev1alpha1.Workflow) bool {
+	return func(w *nvcrev1alpha1.Workflow) bool {
+		return meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               nvcrev1alpha1.WorkflowValidationFailed,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonJobValidationFailed,
+			Message:            message,
+			ObservedGeneration: w.GetGeneration(),
+		})
 	}
 }
 

--- a/pkg/controller/workflow_validation_failed_test.go
+++ b/pkg/controller/workflow_validation_failed_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+func TestApplyWorkflowValidationFailed(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "apply-workflow-validation-failed",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Message  string                 `json:"message"`
+			Workflow nvcrev1alpha1.Workflow `json:"workflow"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+		changed := applyWorkflowValidationFailed(input.Message)(&input.Workflow)
+		// SetStatusCondition stamps LastTransitionTime with wall-clock time on
+		// insert; zero it so the golden is deterministic.
+		for i := range input.Workflow.Status.Conditions {
+			input.Workflow.Status.Conditions[i].LastTransitionTime = metav1.Time{}
+		}
+		b, err := json.MarshalIndent(map[string]any{
+			"changed":    changed,
+			"conditions": input.Workflow.Status.Conditions,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/workloadrun_controller.go
+++ b/pkg/controller/workloadrun_controller.go
@@ -140,18 +140,10 @@ func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *n
 	run.Status.SucceededNodesRef = workflow.Status.SucceededNodesRef
 	run.Status.FailedNodesRef = workflow.Status.FailedNodesRef
 
-	// Mirror terminal conditions.
-	if condIsTrue(workflow.Status.Conditions, nvcrev1alpha1.WorkflowSucceeded) {
-		r.setWorkloadRunCondition(run, nvcrev1alpha1.WorkloadRunSucceeded, ReasonWorkflowSucceeded, "Workflow completed successfully")
-		return ctrl.Result{}, r.Status().Update(ctx, run)
-	}
-	if condIsTrue(workflow.Status.Conditions, nvcrev1alpha1.WorkflowFailed) {
-		msg := condMsg(workflow.Status.Conditions, nvcrev1alpha1.WorkflowFailed)
-		r.setWorkloadRunCondition(run, nvcrev1alpha1.WorkloadRunFailed, ReasonWorkflowFailed, msg)
-		return ctrl.Result{}, r.Status().Update(ctx, run)
-	}
-
-	// Mirror validation failed (independent condition).
+	// Mirror validation failed (independent condition) BEFORE the terminal
+	// mirrors below: the Workflow controller sets ValidationFailed alongside
+	// Failed, so mirroring it after the Failed early-return would leave this
+	// code unreachable in the only case it exists for (issue #67).
 	if condIsTrue(workflow.Status.Conditions, nvcrev1alpha1.WorkflowValidationFailed) {
 		msg := condMsg(workflow.Status.Conditions, nvcrev1alpha1.WorkflowValidationFailed)
 		meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
@@ -160,6 +152,27 @@ func (r *WorkloadRunReconciler) mirrorWorkflowStatus(ctx context.Context, run *n
 			Reason:  ReasonThresholdViolation,
 			Message: msg,
 		})
+	}
+
+	// Mirror terminal conditions.
+	if condIsTrue(workflow.Status.Conditions, nvcrev1alpha1.WorkflowSucceeded) {
+		r.setWorkloadRunCondition(run, nvcrev1alpha1.WorkloadRunSucceeded, ReasonWorkflowSucceeded, "Workflow completed successfully")
+		return ctrl.Result{}, r.Status().Update(ctx, run)
+	}
+	if condIsTrue(workflow.Status.Conditions, nvcrev1alpha1.WorkflowFailed) {
+		msg := condMsg(workflow.Status.Conditions, nvcrev1alpha1.WorkflowFailed)
+		// A threshold miss gets a distinguishing reason so consumers can tell
+		// "the run worked but missed its numbers" apart from "the run broke".
+		// Keyed off the Workflow's Failed reason, not the ValidationFailed
+		// condition, so a mixed hardware+validation failure keeps the generic
+		// reason (hardware takes precedence) while ValidationFailed above
+		// still carries the quality signal.
+		reason := ReasonWorkflowFailed
+		if condReason(workflow.Status.Conditions, nvcrev1alpha1.WorkflowFailed) == ReasonJobValidationFailed {
+			reason = ReasonWorkflowValidationFailed
+		}
+		r.setWorkloadRunCondition(run, nvcrev1alpha1.WorkloadRunFailed, reason, msg)
+		return ctrl.Result{}, r.Status().Update(ctx, run)
 	}
 
 	if err := r.Status().Update(ctx, run); err != nil {
@@ -572,6 +585,15 @@ func condMsg(conditions []metav1.Condition, condType string) string {
 	c := meta.FindStatusCondition(conditions, condType)
 	if c != nil {
 		return c.Message
+	}
+	return ""
+}
+
+// condReason returns the reason for a condition type.
+func condReason(conditions []metav1.Condition, condType string) string {
+	c := meta.FindStatusCondition(conditions, condType)
+	if c != nil {
+		return c.Reason
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

- `ValidationFailed` was declared on the Workflow API but never written: the Workflow controller only sets the exclusive InProgress/Succeeded/Failed trio, so a threshold violation ended as `Failed` with reason `JobValidationFailed` and nothing more.
- The WorkloadRun controller's mirror for that condition was additionally unreachable — it sat after the `WorkflowFailed` early return — so a threshold-violating run always surfaced as `Failed=WorkflowFailed`, indistinguishable from an execution failure.
- The Workflow controller now sets `ValidationFailed=True` (reason `JobValidationFailed`) as a supplementary, non-exclusive condition whenever any Job failed threshold validation — including mixed runs where hardware failures win the `Failed` reason, so the quality signal is never dropped. It rides in the same status write as `Failed` via the existing retry-safe extra-func mechanism. The exclusive trio is untouched.
- `mirrorWorkflowStatus` mirrors `ValidationFailed` before the terminal early-returns. The run's `Failed` reason is keyed off the Workflow's `Failed` reason: a pure threshold miss becomes `WorkflowValidationFailed`, while a mixed hardware+validation failure keeps `WorkflowFailed` (hardware takes precedence) with `ValidationFailed=True` alongside.
- New integration case `workloadrun-validation-failed`: a threshold-violating Job drives the Workflow to `Failed`/`ValidationFailed` and the WorkloadRun to `Failed` (reason `WorkflowValidationFailed`) plus `ValidationFailed=True`.
- New integration case `workflow-hardware-and-validation-failed`: one group fails on hardware, one on validation; the Workflow ends `Failed` (reason `JobHardwareFailed`) and still carries `ValidationFailed=True`.
- New golden-file unit test for the `applyWorkflowValidationFailed` helper (sets the condition; idempotent when already set).
- Regenerated `workflow-validation-failed/expected.json`: the only diff is the new supplementary `ValidationFailed` condition on the Workflow, which is the intended output of this change. The other goldens in this PR are new files for the new cases, reviewed field by field.
- Updated the Workflow and WorkloadRun condition tables in `docs/api-reference/` to describe the implemented behavior, including the mixed-failure case.
- `make lint-fix`, `make build`, and the full `make test` (unit + integration) pass.

Fixes #67

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [x] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
