### PR TITLE
fix(controller): exclude nodes with insufficient allocatable GPUs from partitioning

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -458,9 +458,10 @@ type OrchestrationStatus struct {
 
 	// excludedNodes lists nodes that matched the target but were dropped before
 	// scheduling, and exclusionReason says why. A Workflow can succeed while
-	// excluding nodes, so these record what was left untested. Today the only
-	// cause is a target set with more than one GPU architecture, where the run
-	// continues on the primary architecture alone.
+	// excluding nodes, so these record what was left untested. Causes: the node
+	// was cordoned, the target set has more than one GPU architecture and the
+	// run continued on the primary architecture alone, or the node reports
+	// fewer allocatable GPUs than the workload requests per node.
 	// +optional
 	ExcludedNodes []string `json:"excludedNodes,omitempty"`
 

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -296,6 +296,16 @@ func copyStatus(dst, src client.Object) bool { //nolint:gocyclo
 			d.Status = s.Status
 			return true
 		}
+	case *corev1.Node:
+		// Node fixtures carry status.allocatable so tests can model differing
+		// GPU capacity (issue #82). The API server allows status on Node
+		// create, but re-applying it here keeps fixtures working even where
+		// that changes.
+		s := src.(*corev1.Node)
+		if len(s.Status.Allocatable) > 0 || len(s.Status.Capacity) > 0 {
+			d.Status = s.Status
+			return true
+		}
 	case *trainerv1alpha1.TrainJob:
 		s := src.(*trainerv1alpha1.TrainJob)
 		if len(s.Status.Conditions) > 0 {

--- a/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/expected.json
@@ -1,0 +1,111 @@
+{
+  "Workflow/test-gpu-capacity": {
+    "kind": "Workflow",
+    "apiVersion": "nvcre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-gpu-capacity",
+      "namespace": "default",
+      "finalizers": [
+        "nvcre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "test-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "test-image:latest",
+                "command": [
+                  "python",
+                  "train.py"
+                ],
+                "numNodes": 2,
+                "resourcesPerNode": {
+                  "limits": {
+                    "nvidia.com/gpu": "2"
+                  },
+                  "requests": {
+                    "nvidia.com/gpu": "2"
+                  }
+                }
+              },
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true"
+          }
+        },
+        "execution": {},
+        "iterations": 1
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "JobRunning",
+          "message": "Iteration 1/1: 1 groups running"
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        }
+      ],
+      "orchestration": {
+        "totalNodes": 2,
+        "nodesPerJob": 2,
+        "totalGroups": 1,
+        "currentIteration": 1,
+        "detectedPlatform": "onprem",
+        "detectedGPUArchitecture": "h100",
+        "excludedNodes": [
+          "gpu-node-02-small"
+        ],
+        "exclusionReason": "1 node(s) matched the target but have insufficient GPU capacity, the workload requests 2 nvidia.com/gpu per node: gpu-node-02-small has 1",
+        "groups": [
+          {
+            "name": "group-0",
+            "nodes": [
+              "gpu-node-01",
+              "gpu-node-03"
+            ],
+            "phase": "Running",
+            "jobRef": {
+              "apiVersion": "nvcre.nvidia.com/v1alpha1",
+              "kind": "Job",
+              "name": "test-gpu-capacity-job",
+              "namespace": "default"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/input_client_objects.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Three nodes under one selector with the same gpu.product but different GPU
+# counts — the fleet from issue #82, where a cluster was expanded from
+# single-GPU to dual-GPU nodes. The workload requests 2 GPUs per node, so the
+# 1-GPU node can never schedule its pods. Before the capacity filter it was
+# partitioned into a group anyway and the run hung at InProgress/JobRunning
+# with the pods Pending forever; now it is excluded up front and recorded on
+# the status like a cordoned or wrong-architecture node. The under-capacity
+# node is declared in the middle so the case does not depend on name order.
+apiVersion: v1
+kind: Node
+metadata:
+  name: gpu-node-01
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: gpu-node-01
+status:
+  allocatable:
+    nvidia.com/gpu: "2"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: gpu-node-02-small
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: gpu-node-02-small
+status:
+  allocatable:
+    nvidia.com/gpu: "1"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: gpu-node-03
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: gpu-node-03
+status:
+  allocatable:
+    nvidia.com/gpu: "2"
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-gpu-capacity
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - python
+              - train.py
+            numNodes: 2
+            resourcesPerNode:
+              requests:
+                nvidia.com/gpu: "2"
+              limits:
+                nvidia.com/gpu: "2"
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"

--- a/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-insufficient-gpu-capacity/input_config.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: Workflow
+  name: test-gpu-capacity
+  namespace: default
+  condition: InProgress
+  reason: JobRunning
+collect:
+  - kind: Workflow
+    name: test-gpu-capacity
+    namespace: default

--- a/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/expected.json
+++ b/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/expected.json
@@ -1,0 +1,95 @@
+{
+  "Workflow/test-no-gpu-capacity": {
+    "kind": "Workflow",
+    "apiVersion": "nvcre.nvidia.com/v1alpha1",
+    "metadata": {
+      "name": "test-no-gpu-capacity",
+      "namespace": "default",
+      "finalizers": [
+        "nvcre.nvidia.com/workflow-finalizer"
+      ]
+    },
+    "spec": {
+      "jobTemplate": {
+        "spec": {
+          "workload": {
+            "trainJob": {
+              "runtimeRef": {
+                "name": "test-runtime",
+                "apiGroup": "trainer.kubeflow.org",
+                "kind": "TrainingRuntime"
+              },
+              "trainer": {
+                "image": "test-image:latest",
+                "command": [
+                  "python",
+                  "train.py"
+                ],
+                "numNodes": 1,
+                "resourcesPerNode": {
+                  "limits": {
+                    "nvidia.com/gpu": "8"
+                  },
+                  "requests": {
+                    "nvidia.com/gpu": "8"
+                  }
+                }
+              },
+              "suspend": false,
+              "managedBy": "trainer.kubeflow.org/trainjob-controller"
+            }
+          }
+        }
+      },
+      "orchestration": {
+        "target": {
+          "nodeSelector": {
+            "nvidia.com/gpu.present": "true"
+          }
+        },
+        "execution": {},
+        "iterations": 1
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "InProgress",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Succeeded",
+          "status": "False",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "NotApplicable",
+          "message": ""
+        },
+        {
+          "type": "Failed",
+          "status": "True",
+          "observedGeneration": 1,
+          "lastTransitionTime": null,
+          "reason": "PartitionError",
+          "message": "No node can supply the 8 nvidia.com/gpu the workload requests per node; best available is 2"
+        }
+      ],
+      "orchestration": {
+        "totalNodes": 0,
+        "nodesPerJob": 0,
+        "totalGroups": 0,
+        "detectedPlatform": "onprem",
+        "detectedGPUArchitecture": "h100",
+        "excludedNodes": [
+          "gpu-node-01",
+          "gpu-node-02"
+        ],
+        "exclusionReason": "2 node(s) matched the target but have insufficient GPU capacity, the workload requests 8 nvidia.com/gpu per node: gpu-node-01 has 1, gpu-node-02 has 2"
+      }
+    }
+  }
+}

--- a/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/input_client_objects.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/input_client_objects.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Every matching node reports fewer allocatable GPUs than the workload
+# requests per node. The run must fail up front naming the requirement and
+# the best available count, not partition into groups that can never
+# schedule and hang until the timeout (issue #82).
+apiVersion: v1
+kind: Node
+metadata:
+  name: gpu-node-01
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: gpu-node-01
+status:
+  allocatable:
+    nvidia.com/gpu: "1"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: gpu-node-02
+  labels:
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: "NVIDIA-H100"
+    kubernetes.io/hostname: gpu-node-02
+status:
+  allocatable:
+    nvidia.com/gpu: "2"
+---
+apiVersion: nvcre.nvidia.com/v1alpha1
+kind: Workflow
+metadata:
+  name: test-no-gpu-capacity
+  namespace: default
+spec:
+  jobTemplate:
+    spec:
+      workload:
+        trainJob:
+          runtimeRef:
+            kind: TrainingRuntime
+            name: test-runtime
+          trainer:
+            image: test-image:latest
+            command:
+              - python
+              - train.py
+            numNodes: 1
+            resourcesPerNode:
+              requests:
+                nvidia.com/gpu: "8"
+              limits:
+                nvidia.com/gpu: "8"
+  orchestration:
+    iterations: 1
+    target:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"

--- a/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/input_config.yaml
+++ b/cmd/integration/testdata/reconcile/workflow-no-gpu-capacity/input_config.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+waitFor:
+  kind: Workflow
+  name: test-no-gpu-capacity
+  namespace: default
+  condition: Failed
+  reason: PartitionError
+collect:
+  - kind: Workflow
+    name: test-no-gpu-capacity
+    namespace: default

--- a/docs/concepts/health-monitoring-remediation.md
+++ b/docs/concepts/health-monitoring-remediation.md
@@ -61,7 +61,7 @@ Each failed node entry carries a `reason`:
 | `WorkloadFailed` | The workload exited non-zero or stalled |
 
 <Note>
-Cordoned nodes are filtered **before** a Job runs, not attributed as `HardwareFailureDetected`. They appear in `status.orchestration.excludedNodes` and cause the run to be marked `INCOMPLETE` rather than `Failed`.
+Cordoned nodes and nodes reporting fewer allocatable GPUs than the workload requests per node are filtered **before** a Job runs, not attributed as `HardwareFailureDetected`. They appear in `status.orchestration.excludedNodes` with the reason in `exclusionReason` and cause the run to be marked `INCOMPLETE` rather than `Failed`. If **no** matching node can supply the requested GPU count, the run fails immediately with a message naming the requirement and the best available count instead of scheduling pods that would stay `Pending` forever.
 </Note>
 
 Different nodes in the same category can fail with different reasons. A node that fails in multiple categories appears in each category's failed-nodes ConfigMap, potentially with a different reason each time.

--- a/helm/nvcre/crds/nvcre.nvidia.com_workflows.yaml
+++ b/helm/nvcre/crds/nvcre.nvidia.com_workflows.yaml
@@ -7836,9 +7836,10 @@ spec:
                     description: |-
                       excludedNodes lists nodes that matched the target but were dropped before
                       scheduling, and exclusionReason says why. A Workflow can succeed while
-                      excluding nodes, so these record what was left untested. Today the only
-                      cause is a target set with more than one GPU architecture, where the run
-                      continues on the primary architecture alone.
+                      excluding nodes, so these record what was left untested. Causes: the node
+                      was cordoned, the target set has more than one GPU architecture and the
+                      run continued on the primary architecture alone, or the node reports
+                      fewer allocatable GPUs than the workload requests per node.
                     items:
                       type: string
                     type: array

--- a/pkg/controller/certification_capacityfilter_test.go
+++ b/pkg/controller/certification_capacityfilter_test.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// TestResolveNodesPerJobAfterCapacityFilter covers sizing a job on a fleet
+// with mixed GPU counts — the same class of problem as the architecture
+// filter, on a different axis (issue #82). Nodes reporting fewer allocatable
+// GPUs than gpusPerNode are dropped before resolveNodesPerJob, so the job is
+// sized against nodes that can actually run it; sizing against the whole set
+// partitioned unschedulable nodes into groups whose pods sat Pending forever.
+//
+// The all-nodes-too-small case pins the fail-fast: it must error with the
+// requirement and the best available count, never quietly size a job no node
+// can host.
+func TestResolveNodesPerJobAfterCapacityFilter(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "resolve-nodes-per-job-after-capacity-filter",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Nodes []struct {
+				Name            string `yaml:"name"`
+				AllocatableGPUs *int64 `yaml:"allocatableGPUs"`
+			} `yaml:"nodes"`
+			NodesPerJob *int32 `yaml:"nodesPerJob"`
+			GpusPerNode int32  `yaml:"gpusPerNode"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		nodes := make([]corev1.Node, 0, len(input.Nodes))
+		for _, n := range input.Nodes {
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name:   n.Name,
+				Labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"},
+			}}
+			if n.AllocatableGPUs != nil {
+				node.Status.Allocatable = corev1.ResourceList{
+					"nvidia.com/gpu": *resource.NewQuantity(*n.AllocatableGPUs, resource.DecimalSI),
+				}
+			}
+			nodes = append(nodes, node)
+		}
+
+		opts := nvcrev1alpha1.CategoryOptions{NodesPerJob: input.NodesPerJob}
+		cat := nvcrev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+
+		// The steps the Certification controller performs, in order: arch
+		// detection first (gpusPerNode derives from it), then the capacity
+		// filter with the resolved gpusPerNode, then sizing against survivors.
+		gpuArch, archNodes := detectGPUArchConsistent(nodes)
+
+		out := struct {
+			TotalNodes   int      `json:"totalNodes"`
+			CapableNodes []string `json:"capableNodes"`
+			// NodesPerJob resolved against the capacity-filter survivors.
+			NodesPerJob int32  `json:"nodesPerJob"`
+			Error       string `json:"error,omitempty"`
+		}{TotalNodes: len(nodes)}
+
+		capableNodes, err := dropUnderCapacityNodes(archNodes, cat, input.GpusPerNode)
+		if err != nil {
+			out.Error = err.Error()
+		}
+		for i := range capableNodes {
+			out.CapableNodes = append(out.CapableNodes, capableNodes[i].Name)
+		}
+
+		if err == nil {
+			npj, err := resolveNodesPerJob(capableNodes, cat, opts, nil, input.GpusPerNode, gpuArch)
+			if err != nil {
+				out.Error = err.Error()
+			}
+			out.NodesPerJob = npj
+		}
+
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(data) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -410,7 +410,12 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 		mlnxPerNode = *opts.MlnxPerNode
 	}
 
-	nodesPerJob, err := resolveNodesPerJob(archNodes, category, opts, entry, gpusPerNode, gpuArch)
+	capableNodes, err := dropUnderCapacityNodes(archNodes, category, gpusPerNode)
+	if err != nil {
+		return "", err
+	}
+
+	nodesPerJob, err := resolveNodesPerJob(capableNodes, category, opts, entry, gpusPerNode, gpuArch)
 	if err != nil {
 		return "", err
 	}
@@ -596,6 +601,44 @@ func ResolveOptions(global *nvcrev1alpha1.CategoryOptions, override *nvcrev1alph
 		resolved.MeasurementTimeout = override.MeasurementTimeout
 	}
 	return resolved
+}
+
+// dropUnderCapacityNodes removes nodes that cannot supply gpusPerNode before
+// the job is sized. A node reporting fewer allocatable GPUs than the per-node
+// request can never schedule the workload's pods, so counting it inflates
+// nodesPerJob and the resulting groups hang Pending forever (issue #82). It
+// runs after gpusPerNode is resolved, because that value derives from the GPU
+// architecture of the arch-filter survivors plus any explicit option — it
+// never depends on the node count, so filtering by it cannot loop back into
+// its own inputs.
+//
+// When no node can supply the request this is a hard error naming the
+// requirement and the best the fleet offers, never a quiet downsize: a job
+// sized for nodes that do not exist would partition into groups that cannot
+// schedule. The dropped names are discarded here for the same reason cordoned
+// names are (see createWorkflowForCategory): the Workflow repeats the filter
+// against the rendered spec and records them on its status, which is where the
+// report reads coverage from.
+//
+// The two tiers deliberately read the requirement from different sources.
+// This tier filters with the resolved catalog-default/option gpusPerNode; the
+// Workflow filters with the post-override rendered request (see
+// workloadGPUsPerNode), because overrides are only applied at that tier. An
+// override that raises the request therefore surfaces as a workflow-tier
+// PartitionError rather than this fail-fast — the Workflow's check is the
+// authoritative one, this one exists so the job is sized against nodes that
+// can run the common case.
+func dropUnderCapacityNodes(nodes []corev1.Node, cat nvcrev1alpha1.CertificateCategory, gpusPerNode int32) ([]corev1.Node, error) {
+	capableNodes, capacityExcluded := filterNodesByGPUCapacity(nodes, gpusPerNode)
+	if len(capableNodes) == 0 {
+		return nil, fmt.Errorf(
+			"%s/%s: no node can supply the %d nvidia.com/gpu the workload requests per node;"+
+				" best available is %d across %d matching node(s)."+
+				" Lower gpusPerNode or target nodes with more GPUs",
+			cat.Domain, cat.Variant, gpusPerNode,
+			maxAllocatableGPUs(capacityExcluded), len(capacityExcluded))
+	}
+	return capableNodes, nil
 }
 
 // resolveNodesPerJob determines the nodesPerJob for a category.

--- a/pkg/controller/exclusion_summary_test.go
+++ b/pkg/controller/exclusion_summary_test.go
@@ -14,8 +14,9 @@ import (
 
 // A node can be left uncertified for more than one reason at once, and the
 // report derives its INCOMPLETE verdict from this one list. So the summary has
-// to carry every cause: a fleet that is part cordoned and part
-// mixed-architecture must report both, not whichever was recorded last.
+// to carry every cause: a fleet that is part cordoned, part mixed-architecture
+// and part under GPU capacity must report all of them, not whichever was
+// recorded last.
 //
 // The empty case matters as much as the rest. A run that certified everything
 // it targeted must produce no list at all, because any list at all turns a
@@ -27,15 +28,25 @@ func TestExclusionSummary(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Cordoned     []string `yaml:"cordoned"`
-			ArchExcluded []string `yaml:"archExcluded"`
-			GPUArch      string   `yaml:"gpuArch"`
+			Cordoned         []string `yaml:"cordoned"`
+			ArchExcluded     []string `yaml:"archExcluded"`
+			GPUArch          string   `yaml:"gpuArch"`
+			CapacityExcluded []struct {
+				Node string `yaml:"node"`
+				Has  int64  `yaml:"has"`
+			} `yaml:"capacityExcluded"`
+			GpusPerNode int32 `yaml:"gpusPerNode"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
-		nodes, reason := exclusionSummary(input.Cordoned, input.ArchExcluded, input.GPUArch)
+		capExcluded := make([]gpuCapacityExclusion, 0, len(input.CapacityExcluded))
+		for _, e := range input.CapacityExcluded {
+			capExcluded = append(capExcluded, gpuCapacityExclusion{Node: e.Node, AllocatableGPUs: e.Has})
+		}
+
+		nodes, reason := exclusionSummary(input.Cordoned, input.ArchExcluded, input.GPUArch, capExcluded, input.GpusPerNode)
 
 		out := struct {
 			ExcludedNodes []string `json:"excludedNodes"`

--- a/pkg/controller/gpu_capacity_filter_test.go
+++ b/pkg/controller/gpu_capacity_filter_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// A node with fewer allocatable GPUs than the workload's per-node request can
+// never schedule the workload's pods. Before this filter existed such a node
+// was partitioned into a group anyway, its pods sat Pending forever, and the
+// run hung at InProgress with nothing naming the cause (issue #82).
+//
+// The missing-allocatable and zero-allocatable cases pin the deliberately
+// conservative choices: the resource is advertised asynchronously by the
+// device plugin, so a node that does not report it is kept, not dropped — and
+// a node reporting zero is kept too, because the kubelet zeroes the count
+// (rather than removing it) when the plugin endpoint goes away. Excluding on
+// either would shrink or terminally fail the run over a plugin restart.
+func TestFilterNodesByGPUCapacity(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "gpu-capacity-filter",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var input struct {
+			Nodes []struct {
+				Name string `yaml:"name"`
+				// AllocatableGPUs is the node's reported allocatable
+				// nvidia.com/gpu. Nil models a node that does not report the
+				// resource at all (device plugin not up yet).
+				AllocatableGPUs *int64 `yaml:"allocatableGPUs"`
+			} `yaml:"nodes"`
+			GpusPerNode int32 `yaml:"gpusPerNode"`
+		}
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
+			return err
+		}
+
+		given := make([]corev1.Node, 0, len(input.Nodes))
+		for _, n := range input.Nodes {
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			if n.AllocatableGPUs != nil {
+				node.Status.Allocatable = corev1.ResourceList{
+					"nvidia.com/gpu": *resource.NewQuantity(*n.AllocatableGPUs, resource.DecimalSI),
+				}
+			}
+			given = append(given, node)
+		}
+
+		kept, excluded := filterNodesByGPUCapacity(given, input.GpusPerNode)
+
+		keptNames := make([]string, 0, len(kept))
+		for i := range kept {
+			keptNames = append(keptNames, kept[i].Name)
+		}
+		excludedOut := make([]map[string]any, 0, len(excluded))
+		for _, e := range excluded {
+			excludedOut = append(excludedOut, map[string]any{
+				"node": e.Node,
+				"has":  e.AllocatableGPUs,
+			})
+		}
+
+		out := struct {
+			Kept     []string         `json:"kept"`
+			Excluded []map[string]any `json:"excluded"`
+			// BestAvailable is what an all-nodes-too-small failure names next
+			// to the requirement, so the golden pins it alongside the split.
+			BestAvailable int64 `json:"bestAvailable"`
+		}{Kept: keptNames, Excluded: excludedOut, BestAvailable: maxAllocatableGPUs(excluded)}
+
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}

--- a/pkg/controller/testdata/exclusion-summary/all-three-causes/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/all-three-causes/expected.json
@@ -1,0 +1,9 @@
+{
+  "excludedNodes": [
+    "node001",
+    "node007",
+    "node004"
+  ],
+  "exclusionReason": "1 node(s) matched the target but were unschedulable (cordoned): node001. target set has more than one GPU architecture; certified h100 only. 1 node(s) matched the target but have insufficient GPU capacity, the workload requests 8 nvidia.com/gpu per node: node004 has 4",
+  "verdictAfterPassingRun": "INCOMPLETE"
+}

--- a/pkg/controller/testdata/exclusion-summary/all-three-causes/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/all-three-causes/input.yaml
@@ -1,0 +1,12 @@
+# All three causes at once. Each is merged into the one list and the one
+# reason string, because the report derives its INCOMPLETE verdict from this
+# list alone and recording causes in turn lets the last overwrite the rest.
+cordoned:
+  - node001
+archExcluded:
+  - node007
+gpuArch: h100
+capacityExcluded:
+  - node: node004
+    has: 4
+gpusPerNode: 8

--- a/pkg/controller/testdata/exclusion-summary/capacity-only/expected.json
+++ b/pkg/controller/testdata/exclusion-summary/capacity-only/expected.json
@@ -1,0 +1,8 @@
+{
+  "excludedNodes": [
+    "node002",
+    "node003"
+  ],
+  "exclusionReason": "2 node(s) matched the target but have insufficient GPU capacity, the workload requests 2 nvidia.com/gpu per node: node002 has 1, node003 has 1",
+  "verdictAfterPassingRun": "INCOMPLETE"
+}

--- a/pkg/controller/testdata/exclusion-summary/capacity-only/input.yaml
+++ b/pkg/controller/testdata/exclusion-summary/capacity-only/input.yaml
@@ -1,0 +1,11 @@
+# Insufficient GPU capacity on its own: the issue #82 fleet, where two 1-GPU
+# nodes matched a target whose workload requests 2 GPUs per node. Before this
+# cause existed the nodes were partitioned anyway and the run hung silently;
+# now they are reported "has X" against the request so the operator sees the
+# shortfall instead of chasing a scheduler mystery.
+capacityExcluded:
+  - node: node002
+    has: 1
+  - node: node003
+    has: 1
+gpusPerNode: 2

--- a/pkg/controller/testdata/gpu-capacity-filter/all-nodes-below-request/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/all-nodes-below-request/expected.json
@@ -1,0 +1,14 @@
+{
+  "kept": [],
+  "excluded": [
+    {
+      "has": 1,
+      "node": "node001"
+    },
+    {
+      "has": 4,
+      "node": "node002"
+    }
+  ],
+  "bestAvailable": 4
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/all-nodes-below-request/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/all-nodes-below-request/input.yaml
@@ -1,0 +1,9 @@
+# Every node reports fewer GPUs than the request. Callers must fail with the
+# requirement and the best available count rather than partitioning into
+# groups that can never schedule; bestAvailable is what that message names.
+nodes:
+  - name: node001
+    allocatableGPUs: 1
+  - name: node002
+    allocatableGPUs: 4
+gpusPerNode: 8

--- a/pkg/controller/testdata/gpu-capacity-filter/exact-capacity-is-kept/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/exact-capacity-is-kept/expected.json
@@ -1,0 +1,8 @@
+{
+  "kept": [
+    "node001",
+    "node002"
+  ],
+  "excluded": [],
+  "bestAvailable": 0
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/exact-capacity-is-kept/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/exact-capacity-is-kept/input.yaml
@@ -1,0 +1,8 @@
+# The boundary: a node with exactly the requested count is sufficient. Only
+# strictly-fewer is a shortfall.
+nodes:
+  - name: node001
+    allocatableGPUs: 2
+  - name: node002
+    allocatableGPUs: 3
+gpusPerNode: 2

--- a/pkg/controller/testdata/gpu-capacity-filter/under-capacity-node-is-dropped/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/under-capacity-node-is-dropped/expected.json
@@ -1,0 +1,17 @@
+{
+  "kept": [
+    "node004",
+    "node005"
+  ],
+  "excluded": [
+    {
+      "has": 1,
+      "node": "node002"
+    },
+    {
+      "has": 1,
+      "node": "node003"
+    }
+  ],
+  "bestAvailable": 1
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/under-capacity-node-is-dropped/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/under-capacity-node-is-dropped/input.yaml
@@ -1,0 +1,13 @@
+# The issue #82 repro in miniature: one selector, one gpu.product, mixed GPU
+# counts. The 1-GPU nodes cannot satisfy a 2-GPU per-node request, so they must
+# be dropped before partitioning, not handed a group whose pods never schedule.
+nodes:
+  - name: node002
+    allocatableGPUs: 1
+  - name: node003
+    allocatableGPUs: 1
+  - name: node004
+    allocatableGPUs: 2
+  - name: node005
+    allocatableGPUs: 2
+gpusPerNode: 2

--- a/pkg/controller/testdata/gpu-capacity-filter/unreported-allocatable-is-kept/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/unreported-allocatable-is-kept/expected.json
@@ -1,0 +1,8 @@
+{
+  "kept": [
+    "node001",
+    "node002"
+  ],
+  "excluded": [],
+  "bestAvailable": 0
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/unreported-allocatable-is-kept/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/unreported-allocatable-is-kept/input.yaml
@@ -1,0 +1,9 @@
+# A node that reports no allocatable nvidia.com/gpu at all is kept. The device
+# plugin advertises the resource asynchronously, so absence means "unknown",
+# and dropping the node over a plugin restart would spuriously shrink the run
+# and downgrade a clean PASSED to INCOMPLETE.
+nodes:
+  - name: node001
+  - name: node002
+    allocatableGPUs: 8
+gpusPerNode: 8

--- a/pkg/controller/testdata/gpu-capacity-filter/zero-allocatable-is-kept/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/zero-allocatable-is-kept/expected.json
@@ -1,0 +1,13 @@
+{
+  "kept": [
+    "node001",
+    "node003"
+  ],
+  "excluded": [
+    {
+      "has": 1,
+      "node": "node002"
+    }
+  ],
+  "bestAvailable": 1
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/zero-allocatable-is-kept/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/zero-allocatable-is-kept/input.yaml
@@ -1,0 +1,14 @@
+# A node reporting zero allocatable nvidia.com/gpu is kept, like one that
+# reports nothing: the kubelet zeroes an extended resource when the device
+# plugin endpoint goes away rather than removing it, so on a GPU-labeled node
+# a zero is a plugin restart in a different encoding. Excluding on it would
+# turn a self-healing Pending into a terminal failure. Only a positive count
+# below the request is a stable statement about the hardware.
+nodes:
+  - name: node001
+    allocatableGPUs: 0
+  - name: node002
+    allocatableGPUs: 1
+  - name: node003
+    allocatableGPUs: 2
+gpusPerNode: 2

--- a/pkg/controller/testdata/gpu-capacity-filter/zero-request-keeps-everything/expected.json
+++ b/pkg/controller/testdata/gpu-capacity-filter/zero-request-keeps-everything/expected.json
@@ -1,0 +1,8 @@
+{
+  "kept": [
+    "node001",
+    "node002"
+  ],
+  "excluded": [],
+  "bestAvailable": 0
+}

--- a/pkg/controller/testdata/gpu-capacity-filter/zero-request-keeps-everything/input.yaml
+++ b/pkg/controller/testdata/gpu-capacity-filter/zero-request-keeps-everything/input.yaml
@@ -1,0 +1,8 @@
+# A workload that requests no GPUs imposes no per-node GPU requirement, so
+# nothing is filtered — not even a node that reports zero allocatable GPUs.
+nodes:
+  - name: node001
+    allocatableGPUs: 0
+  - name: node002
+    allocatableGPUs: 8
+gpusPerNode: 0

--- a/pkg/controller/testdata/not-enough-nodes-message/arch-and-capacity-both-excluded/expected.json
+++ b/pkg/controller/testdata/not-enough-nodes-message/arch-and-capacity-both-excluded/expected.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not enough schedulable nodes: need 4, found 2. 1 node(s) matched the target but were excluded for not being GPU architecture h100: node003. 1 node(s) matched the target but were excluded for having fewer than the 2 allocatable nvidia.com/gpu the workload requests per node: node002 has 1. Set nodesPerJob to 2, or narrow the target to one architecture, or lower gpusPerNode"
+}

--- a/pkg/controller/testdata/not-enough-nodes-message/arch-and-capacity-both-excluded/input.yaml
+++ b/pkg/controller/testdata/not-enough-nodes-message/arch-and-capacity-both-excluded/input.yaml
@@ -1,0 +1,13 @@
+# Both filters contributed to the shortfall: one node dropped for a different
+# GPU architecture, one for insufficient GPU capacity. Both causes are named,
+# and the "Set nodesPerJob to N" advice appears once with every applicable
+# remedy after it — not once per cause.
+needed: 4
+found: 2
+gpuArch: h100
+archExcluded:
+  - node003
+capacityExcluded:
+  - node: node002
+    has: 1
+gpusPerNode: 2

--- a/pkg/controller/testdata/not-enough-nodes-message/capacity-excluded-nodes-are-named/expected.json
+++ b/pkg/controller/testdata/not-enough-nodes-message/capacity-excluded-nodes-are-named/expected.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not enough schedulable nodes: need 4, found 3. 1 node(s) matched the target but were excluded for having fewer than the 2 allocatable nvidia.com/gpu the workload requests per node: node002 has 1. Set nodesPerJob to 3, or lower gpusPerNode"
+}

--- a/pkg/controller/testdata/not-enough-nodes-message/capacity-excluded-nodes-are-named/input.yaml
+++ b/pkg/controller/testdata/not-enough-nodes-message/capacity-excluded-nodes-are-named/input.yaml
@@ -1,0 +1,9 @@
+# The shortfall was caused by the GPU capacity filter, not by cordons or
+# taints. The message must name the dropped nodes with what they report so
+# the operator is not sent chasing schedulability.
+needed: 4
+found: 3
+capacityExcluded:
+  - node: node002
+    has: 1
+gpusPerNode: 2

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/all-nodes-too-small-errors/expected.json
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/all-nodes-too-small-errors/expected.json
@@ -1,0 +1,6 @@
+{
+  "totalNodes": 2,
+  "capableNodes": null,
+  "nodesPerJob": 0,
+  "error": "communication/nccl-all-reduce: no node can supply the 8 nvidia.com/gpu the workload requests per node; best available is 4 across 2 matching node(s). Lower gpusPerNode or target nodes with more GPUs"
+}

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/all-nodes-too-small-errors/input.yaml
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/all-nodes-too-small-errors/input.yaml
@@ -1,0 +1,10 @@
+# No node can supply the request. This must be a hard error naming the
+# requirement and the best available count — not a job quietly sized to zero
+# capable nodes, and not a partition that can never schedule.
+nodes:
+  - name: node001
+    allocatableGPUs: 1
+  - name: node002
+    allocatableGPUs: 4
+nodesPerJob: 2
+gpusPerNode: 8

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/mixed-capacity-sizes-against-survivors/expected.json
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/mixed-capacity-sizes-against-survivors/expected.json
@@ -1,0 +1,10 @@
+{
+  "totalNodes": 6,
+  "capableNodes": [
+    "node004",
+    "node005",
+    "node006",
+    "node007"
+  ],
+  "nodesPerJob": 4
+}

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/mixed-capacity-sizes-against-survivors/input.yaml
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/mixed-capacity-sizes-against-survivors/input.yaml
@@ -1,0 +1,20 @@
+# The issue #82 fleet: six nodes under one selector and one gpu.product, two
+# of them with a single GPU. With gpusPerNode 2 and nodesPerJob 4 the old code
+# partitioned node002/node003 into a group anyway and their pods sat Pending
+# forever. Sized against the four capable survivors, nodesPerJob 4 fits
+# exactly and every group can schedule.
+nodes:
+  - name: node002
+    allocatableGPUs: 1
+  - name: node003
+    allocatableGPUs: 1
+  - name: node004
+    allocatableGPUs: 2
+  - name: node005
+    allocatableGPUs: 2
+  - name: node006
+    allocatableGPUs: 2
+  - name: node007
+    allocatableGPUs: 2
+nodesPerJob: 4
+gpusPerNode: 2

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/unreported-allocatable-still-counts/expected.json
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/unreported-allocatable-still-counts/expected.json
@@ -1,0 +1,8 @@
+{
+  "totalNodes": 2,
+  "capableNodes": [
+    "node001",
+    "node002"
+  ],
+  "nodesPerJob": 2
+}

--- a/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/unreported-allocatable-still-counts/input.yaml
+++ b/pkg/controller/testdata/resolve-nodes-per-job-after-capacity-filter/unreported-allocatable-still-counts/input.yaml
@@ -1,0 +1,9 @@
+# A node that does not report allocatable nvidia.com/gpu is kept and counted
+# for sizing: the device plugin advertises the resource asynchronously, and
+# dropping the node over a restart would shrink the run for no real shortfall.
+nodes:
+  - name: node001
+  - name: node002
+    allocatableGPUs: 8
+nodesPerJob: 2
+gpusPerNode: 8

--- a/pkg/controller/testdata/workload-gpus-per-node/largest-request-wins/expected.json
+++ b/pkg/controller/testdata/workload-gpus-per-node/largest-request-wins/expected.json
@@ -1,0 +1,3 @@
+{
+  "gpusPerNode": 8
+}

--- a/pkg/controller/testdata/workload-gpus-per-node/largest-request-wins/input.yaml
+++ b/pkg/controller/testdata/workload-gpus-per-node/largest-request-wins/input.yaml
@@ -1,0 +1,45 @@
+# The launcher requests fewer GPUs than the workers. A node has to satisfy the
+# largest single-pod request, so the worker's count is the binding one.
+jobTemplate:
+  spec:
+    workload:
+      trainJob:
+        runtimeRef:
+          kind: TrainingRuntime
+          name: mpi-runtime
+        trainer:
+          image: test-image:latest
+          numNodes: 2
+dependencies:
+- apiVersion: trainer.kubeflow.org/v1alpha1
+  kind: TrainingRuntime
+  metadata:
+    name: mpi-runtime
+  spec:
+    template:
+      spec:
+        replicatedJobs:
+        - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: node
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "8"
+                      requests:
+                        nvidia.com/gpu: "8"
+        - name: launcher
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: launcher
+                    resources:
+                      requests:
+                        nvidia.com/gpu: "1"
+orchestration:
+  iterations: 1

--- a/pkg/controller/testdata/workload-gpus-per-node/no-gpu-request/expected.json
+++ b/pkg/controller/testdata/workload-gpus-per-node/no-gpu-request/expected.json
@@ -1,0 +1,3 @@
+{
+  "gpusPerNode": 0
+}

--- a/pkg/controller/testdata/workload-gpus-per-node/no-gpu-request/input.yaml
+++ b/pkg/controller/testdata/workload-gpus-per-node/no-gpu-request/input.yaml
@@ -1,0 +1,17 @@
+# Nothing requests GPUs, so there is no per-node requirement and the capacity
+# filter must not drop anything.
+jobTemplate:
+  spec:
+    workload:
+      trainJob:
+        runtimeRef:
+          kind: TrainingRuntime
+          name: test-runtime
+        trainer:
+          image: test-image:latest
+          numNodes: 1
+orchestration:
+  iterations: 1
+  target:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"

--- a/pkg/controller/testdata/workload-gpus-per-node/trainer-resources-per-node/expected.json
+++ b/pkg/controller/testdata/workload-gpus-per-node/trainer-resources-per-node/expected.json
@@ -1,0 +1,3 @@
+{
+  "gpusPerNode": 4
+}

--- a/pkg/controller/testdata/workload-gpus-per-node/trainer-resources-per-node/input.yaml
+++ b/pkg/controller/testdata/workload-gpus-per-node/trainer-resources-per-node/input.yaml
@@ -1,0 +1,19 @@
+# Hand-written Workflows put the request on trainer.resourcesPerNode.
+jobTemplate:
+  spec:
+    workload:
+      trainJob:
+        runtimeRef:
+          kind: TrainingRuntime
+          name: test-runtime
+        trainer:
+          image: test-image:latest
+          numNodes: 2
+          resourcesPerNode:
+            requests:
+              nvidia.com/gpu: "4"
+              cpu: "64"
+            limits:
+              nvidia.com/gpu: "4"
+orchestration:
+  iterations: 1

--- a/pkg/controller/testdata/workload-gpus-per-node/training-runtime-dependency/expected.json
+++ b/pkg/controller/testdata/workload-gpus-per-node/training-runtime-dependency/expected.json
@@ -1,0 +1,3 @@
+{
+  "gpusPerNode": 2
+}

--- a/pkg/controller/testdata/workload-gpus-per-node/training-runtime-dependency/input.yaml
+++ b/pkg/controller/testdata/workload-gpus-per-node/training-runtime-dependency/input.yaml
@@ -1,0 +1,49 @@
+# Catalog entries render the request into the TrainingRuntime dependency that
+# templates the worker pods, not into the jobTemplate itself. The PVC's
+# storage request sits inside a "requests" map too and must not be misread,
+# and the gpu.product nodeSelector must not be mistaken for a GPU request.
+jobTemplate:
+  spec:
+    workload:
+      trainJob:
+        runtimeRef:
+          kind: TrainingRuntime
+          name: nccl-runtime
+        trainer:
+          image: test-image:latest
+          numNodes: 2
+orchestration:
+  iterations: 1
+  target:
+    nodeSelector:
+      nvidia.com/gpu.product: NVIDIA-H100
+dependencies:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: scratch
+  spec:
+    accessModes: ["ReadWriteMany"]
+    resources:
+      requests:
+        storage: 100Gi
+- apiVersion: trainer.kubeflow.org/v1alpha1
+  kind: TrainingRuntime
+  metadata:
+    name: nccl-runtime
+  spec:
+    template:
+      spec:
+        replicatedJobs:
+        - name: node
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: node
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "2"
+                      requests:
+                        nvidia.com/gpu: "2"

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -194,10 +195,11 @@ func (r *WorkflowReconciler) reconcileJob(ctx context.Context, workflow *nvcrev1
 // says why. The report turns a non-empty list into an INCOMPLETE verdict, so
 // this is what stops a partly-certified fleet reporting a clean PASSED.
 //
-// Both causes can apply to one run, which is why they are merged rather than
-// assigned in turn: on a fleet that is part cordoned and part mixed-architecture,
-// writing each cause as it is found lets the second silently drop the first.
-func exclusionSummary(cordoned, archExcluded []string, gpuArch string) ([]string, string) {
+// All three causes can apply to one run, which is why they are merged rather
+// than assigned in turn: on a fleet that is part cordoned and part
+// mixed-architecture, writing each cause as it is found lets the second
+// silently drop the first.
+func exclusionSummary(cordoned, archExcluded []string, gpuArch string, capacityExcluded []gpuCapacityExclusion, gpusPerNode int32) ([]string, string) {
 	var nodes, reasons []string
 
 	if len(cordoned) > 0 {
@@ -214,6 +216,15 @@ func exclusionSummary(cordoned, archExcluded []string, gpuArch string) ([]string
 			gpuArch))
 	}
 
+	if len(capacityExcluded) > 0 {
+		for _, e := range capacityExcluded {
+			nodes = append(nodes, e.Node)
+		}
+		reasons = append(reasons, fmt.Sprintf(
+			"%d node(s) matched the target but have insufficient GPU capacity, the workload requests %d nvidia.com/gpu per node: %s",
+			len(capacityExcluded), gpusPerNode, gpuShortfallDetail(capacityExcluded)))
+	}
+
 	if len(nodes) == 0 {
 		return nil, ""
 	}
@@ -223,20 +234,46 @@ func exclusionSummary(cordoned, archExcluded []string, gpuArch string) ([]string
 	return nodes, strings.Join(reasons, ". ")
 }
 
+// gpuShortfallDetail formats capacity exclusions as "node002 has 1, node003
+// has 1", so every message about them says what each node actually reports
+// next to what was needed rather than only naming the node.
+func gpuShortfallDetail(excluded []gpuCapacityExclusion) string {
+	parts := make([]string, 0, len(excluded))
+	for _, e := range excluded {
+		parts = append(parts, fmt.Sprintf("%s has %d", e.Node, e.AllocatableGPUs))
+	}
+	return strings.Join(parts, ", ")
+}
+
 // notEnoughNodesMessage explains a node shortfall. "Schedulable" is Kubernetes
 // vocabulary for cordons, taints and capacity, so the bare form sends an operator
 // looking at the wrong thing when the real cause is that a heterogeneous target
-// was filtered to one GPU architecture. When that is what happened, say so and
-// name the nodes that were dropped.
-func notEnoughNodesMessage(needed, found int, gpuArch string, archExcluded []string) string {
-	base := fmt.Sprintf("Not enough schedulable nodes: need %d, found %d", needed, found)
-	if len(archExcluded) == 0 {
-		return base
+// was filtered to one GPU architecture or that under-capacity nodes were
+// dropped. When that is what happened, say so and name the nodes that were
+// dropped. Causes and remedies are collected separately so that when both
+// filters contributed, the "Set nodesPerJob to N" advice appears once with
+// every applicable remedy after it, not once per cause.
+func notEnoughNodesMessage(needed, found int, gpuArch string, archExcluded []string, capacityExcluded []gpuCapacityExclusion, gpusPerNode int32) string {
+	msg := fmt.Sprintf("Not enough schedulable nodes: need %d, found %d", needed, found)
+	var causes, remedies []string
+	if len(archExcluded) > 0 {
+		causes = append(causes, fmt.Sprintf(
+			"%d node(s) matched the target but were excluded for not being GPU architecture %s: %s",
+			len(archExcluded), gpuArch, strings.Join(archExcluded, ", ")))
+		remedies = append(remedies, "narrow the target to one architecture")
 	}
-	return fmt.Sprintf(
-		"%s. %d node(s) matched the target but were excluded for not being GPU architecture %s: %s. "+
-			"Set nodesPerJob to %d, or narrow the target to one architecture",
-		base, len(archExcluded), gpuArch, strings.Join(archExcluded, ", "), found)
+	if len(capacityExcluded) > 0 {
+		causes = append(causes, fmt.Sprintf(
+			"%d node(s) matched the target but were excluded for having fewer than the %d allocatable "+
+				"nvidia.com/gpu the workload requests per node: %s",
+			len(capacityExcluded), gpusPerNode, gpuShortfallDetail(capacityExcluded)))
+		remedies = append(remedies, "lower gpusPerNode")
+	}
+	if len(causes) == 0 {
+		return msg
+	}
+	return fmt.Sprintf("%s. %s. Set nodesPerJob to %d, or %s",
+		msg, strings.Join(causes, ". "), found, strings.Join(remedies, ", or "))
 }
 
 // discoverAndPartition discovers target nodes, auto-detects nodesPerJob, and partitions nodes into groups.
@@ -302,10 +339,11 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	}
 	orch.DetectedGPUArchitecture = gpuArch
 
-	// Record the dropped nodes on the status, not just in an event. A run that
-	// excludes nodes still reports Succeeded, so without this the report says
-	// PASSED and never mentions what went untested.
-	orch.ExcludedNodes, orch.ExclusionReason = exclusionSummary(cordoned, archExcluded, gpuArch)
+	// Record the cordon and architecture exclusions before overrides run, so a
+	// failure in override application still leaves the coverage record behind.
+	// The GPU capacity check below has to read the post-override spec, so the
+	// summary is recomputed with the full set once that filter has run.
+	orch.ExcludedNodes, orch.ExclusionReason = exclusionSummary(cordoned, archExcluded, gpuArch, nil, 0)
 
 	// Apply overrides now that platform/gpuArch are known, before computing nodesPerJob.
 	// This is the authoritative call — emit events, log details, and populate status.
@@ -314,13 +352,52 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	if err != nil {
 		r.eventf(workflow, corev1.EventTypeWarning, "OverrideError", "Override failed: %v", err)
 		if statusErr := r.setWorkflowFailed(ctx, workflow, "OverrideError",
-			fmt.Sprintf("Failed to apply overrides: %v", err)); statusErr != nil {
+			fmt.Sprintf("Failed to apply overrides: %v", err),
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update Workflow status after override failure")
 		}
 		return ctrl.Result{}, err
 	}
 	orch.AppliedOverrides = applied
 	r.logOverrideResults(ctx, workflow, applied, octx)
+
+	// Drop nodes that cannot supply the workload's per-node GPU request. A node
+	// with fewer allocatable GPUs than the pods ask for is partitioned into a
+	// group whose pods stay Pending forever, and the run hangs at
+	// InProgress/JobRunning with nothing naming the cause (issue #82). The
+	// check runs after override application because overrides can rewrite the
+	// resources block, and workloadGPUsPerNode must see the request the pods
+	// will actually make; it cannot run inside discoverTargetNodes because the
+	// request is only known once the spec is fully resolved.
+	gpusPerNode := workloadGPUsPerNode(&workflow.Spec)
+	capableNodes, capacityExcluded := filterNodesByGPUCapacity(nodes, gpusPerNode)
+	if len(capacityExcluded) > 0 {
+		log.Info("Nodes with insufficient GPU capacity excluded from certification",
+			"gpusPerNode", gpusPerNode, "excluded", gpuShortfallDetail(capacityExcluded))
+		r.eventf(workflow, corev1.EventTypeWarning, "InsufficientGPUCapacity",
+			"Excluded %d node(s) with fewer than %d allocatable nvidia.com/gpu: %s",
+			len(capacityExcluded), gpusPerNode, gpuShortfallDetail(capacityExcluded))
+		nodes = capableNodes
+	}
+
+	// Record the dropped nodes on the status, not just in an event. A run that
+	// excludes nodes still reports Succeeded, so without this the report says
+	// PASSED and never mentions what went untested.
+	orch.ExcludedNodes, orch.ExclusionReason = exclusionSummary(cordoned, archExcluded, gpuArch, capacityExcluded, gpusPerNode)
+
+	// Every surviving node was dropped for capacity. Fail with the requirement
+	// and the best the fleet offers instead of partitioning into groups that
+	// can never schedule.
+	if len(nodes) == 0 {
+		msg := fmt.Sprintf(
+			"No node can supply the %d nvidia.com/gpu the workload requests per node; best available is %d",
+			gpusPerNode, maxAllocatableGPUs(capacityExcluded))
+		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError, msg,
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{}, fmt.Errorf("%s", msg)
+	}
 
 	// Create workflow-scoped dependencies AFTER overrides are applied.
 	// Override dependency merges (e.g. EFA resources into TrainingRuntime) have
@@ -331,7 +408,8 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	if err := r.ensureWorkflowDependencies(ctx, workflow); err != nil {
 		log.Error(err, "Failed to create dependencies")
 		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonDependencyCreationError,
-			fmt.Sprintf("Failed to create dependency: %v", err)); statusErr != nil {
+			fmt.Sprintf("Failed to create dependency: %v", err),
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -341,7 +419,8 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	adapter, err := workload.ForSpec(&workflow.Spec.JobTemplate.Spec.Workload)
 	if err != nil {
 		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError,
-			fmt.Sprintf("Failed to determine workload adapter: %v", err)); statusErr != nil {
+			fmt.Sprintf("Failed to determine workload adapter: %v", err),
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -350,7 +429,8 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	nodesPerJob, err := adapter.NodesRequired(&workflow.Spec.JobTemplate.Spec.Workload)
 	if err != nil {
 		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError,
-			fmt.Sprintf("Failed to detect nodesPerJob: %v", err)); statusErr != nil {
+			fmt.Sprintf("Failed to detect nodesPerJob: %v", err),
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -359,8 +439,9 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 		nodesPerJob = len(nodes)
 	}
 	if nodesPerJob > len(nodes) {
-		msg := notEnoughNodesMessage(nodesPerJob, len(nodes), gpuArch, archExcluded)
-		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError, msg); statusErr != nil {
+		msg := notEnoughNodesMessage(nodesPerJob, len(nodes), gpuArch, archExcluded, capacityExcluded, gpusPerNode)
+		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError, msg,
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, fmt.Errorf("%s", msg)
@@ -401,7 +482,8 @@ func (r *WorkflowReconciler) discoverAndPartition(ctx context.Context, workflow 
 	}
 	if err != nil {
 		if statusErr := r.setWorkflowFailed(ctx, workflow, ReasonPartitionError,
-			fmt.Sprintf("Failed to partition nodes: %v", err)); statusErr != nil {
+			fmt.Sprintf("Failed to partition nodes: %v", err),
+			applyExclusionRecord(orch.ExcludedNodes, orch.ExclusionReason)); statusErr != nil {
 			log.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -2005,6 +2087,33 @@ func applySucceededNodesRef(ref *corev1.TypedLocalObjectReference) func(*nvcrev1
 			return false
 		}
 		w.Status.SucceededNodesRef = ref
+		return true
+	}
+}
+
+// applyExclusionRecord returns an extra func suitable for setWorkflowFailed
+// that re-applies the excludedNodes/exclusionReason coverage record inside the
+// updateStatusWithRetry closure. discoverAndPartition writes the record onto
+// the in-memory orchestration status and then fails; without this, a 409
+// conflict re-fetches the object in place (wiping the orchestration fields)
+// and the retry re-applies only the conditions — and since the Workflow is
+// terminal afterwards, nothing ever recomputes the record. The values are
+// captured, not read through the orchestration pointer, because the re-fetch
+// overwrites what that pointer refers to.
+func applyExclusionRecord(excludedNodes []string, exclusionReason string) func(*nvcrev1alpha1.Workflow) bool {
+	if len(excludedNodes) == 0 && exclusionReason == "" {
+		return nil
+	}
+	return func(w *nvcrev1alpha1.Workflow) bool {
+		if w.Status.Orchestration == nil {
+			w.Status.Orchestration = &nvcrev1alpha1.OrchestrationStatus{}
+		}
+		orch := w.Status.Orchestration
+		if slices.Equal(orch.ExcludedNodes, excludedNodes) && orch.ExclusionReason == exclusionReason {
+			return false
+		}
+		orch.ExcludedNodes = excludedNodes
+		orch.ExclusionReason = exclusionReason
 		return true
 	}
 }

--- a/pkg/controller/workflow_detect.go
+++ b/pkg/controller/workflow_detect.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"math"
 	"reflect"
 	"slices"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/google/cel-go/cel"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -130,6 +132,151 @@ func excludedNodeNames(all, kept []corev1.Node) []string {
 		}
 	}
 	return out
+}
+
+// gpuCapacityExclusion names a node dropped for reporting fewer allocatable
+// GPUs than the workload requests per node, along with what it does report so
+// exclusion messages can say "has X, needs Y" instead of just naming the node.
+type gpuCapacityExclusion struct {
+	Node string
+	// AllocatableGPUs is the node's reported allocatable nvidia.com/gpu count.
+	AllocatableGPUs int64
+}
+
+// filterNodesByGPUCapacity splits nodes into those that can satisfy a per-node
+// request of gpusPerNode and those that report fewer allocatable
+// nvidia.com/gpu. An under-capacity node can never schedule the workload's
+// pods, so partitioning it into a group leaves that group Pending until the
+// run times out with nothing naming the cause (issue #82).
+//
+// A node that does not report allocatable nvidia.com/gpu at all is kept, not
+// excluded: the resource is advertised asynchronously by the device plugin, so
+// its absence means "unknown", and dropping a node over a plugin restart would
+// spuriously shrink the run and flip a clean PASSED to INCOMPLETE.
+//
+// A reported count of zero is treated the same way. The kubelet does not
+// remove an extended resource when its device plugin endpoint goes away — it
+// zeroes the count — so on a GPU-labeled node a zero is the restart window in
+// a different encoding, not a statement about the hardware. Excluding on it
+// would turn a self-healing Pending (pods schedule once the plugin
+// re-advertises) into a terminal failure or a permanent INCOMPLETE. Only a
+// positive count below the request is a stable "this node has fewer GPUs"
+// report, which is the failure issue #82 is about.
+//
+// A gpusPerNode of zero or less means the workload requests no GPUs, so
+// nothing is filtered.
+func filterNodesByGPUCapacity(nodes []corev1.Node, gpusPerNode int32) ([]corev1.Node, []gpuCapacityExclusion) {
+	if gpusPerNode <= 0 {
+		return nodes, nil
+	}
+	kept := make([]corev1.Node, 0, len(nodes))
+	var excluded []gpuCapacityExclusion
+	for _, n := range nodes {
+		q, ok := n.Status.Allocatable[corev1.ResourceName("nvidia.com/gpu")]
+		if ok {
+			if count, exact := q.AsInt64(); exact && count > 0 && count < int64(gpusPerNode) {
+				excluded = append(excluded, gpuCapacityExclusion{Node: n.Name, AllocatableGPUs: count})
+				continue
+			}
+		}
+		kept = append(kept, n)
+	}
+	return kept, excluded
+}
+
+// maxAllocatableGPUs returns the largest allocatable GPU count among the
+// exclusions, so an all-nodes-too-small failure can name the best the fleet
+// has to offer next to what the workload asked for.
+func maxAllocatableGPUs(excluded []gpuCapacityExclusion) int64 {
+	var best int64
+	for _, e := range excluded {
+		best = max(best, e.AllocatableGPUs)
+	}
+	return best
+}
+
+// workloadGPUsPerNode returns the number of GPUs each node must supply for the
+// workflow's pods to schedule. It is read back from the rendered spec rather
+// than re-derived from architecture defaults so it is exactly the value the
+// pod resources will request: an operator-supplied gpusPerNode override or an
+// override patch that rewrites the resources block is already baked in here,
+// where a re-derivation from gpu.ParseProduct defaults would disagree with it.
+//
+// The request can live in different places depending on how the spec was
+// built — trainer.resourcesPerNode on a hand-written Workflow, or the
+// TrainingRuntime dependency that templates the worker pods for catalog
+// entries and WorkloadRuns — so this walks the job template and every
+// dependency and returns the largest nvidia.com/gpu quantity found. Every
+// dependency is walked, not only the runtime named by trainJob.runtimeRef:
+// rendered specs today ship exactly the runtime the job template references,
+// so the two are the same set, and if a spec ever carried an unreferenced
+// GPU-requesting dependency this errs toward over-requiring (excluding a node
+// that might have scheduled) rather than under-requiring (partitioning a node
+// whose pods can never schedule, the silent hang this filter exists to
+// prevent). Returns 0 when nothing requests GPUs, which callers treat as "no
+// per-node GPU requirement".
+func workloadGPUsPerNode(spec *nvcrev1alpha1.WorkflowSpec) int32 {
+	var found int64
+	if b, err := json.Marshal(&spec.JobTemplate); err == nil {
+		var doc any
+		if json.Unmarshal(b, &doc) == nil {
+			found = max(found, maxGPURequest(doc))
+		}
+	}
+	for i := range spec.Dependencies {
+		var doc any
+		if json.Unmarshal(spec.Dependencies[i].Raw, &doc) == nil {
+			found = max(found, maxGPURequest(doc))
+		}
+	}
+	if found > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(found)
+}
+
+// maxGPURequest walks a decoded JSON document for resource requirement blocks
+// and returns the largest nvidia.com/gpu quantity found. Only values inside a
+// "requests" or "limits" map count, so a label or topology key that happens to
+// mention the resource name is never misread as a request.
+func maxGPURequest(doc any) int64 {
+	var found int64
+	switch v := doc.(type) {
+	case map[string]any:
+		for key, val := range v {
+			if key == "requests" || key == "limits" {
+				if rl, ok := val.(map[string]any); ok {
+					if q, ok := rl["nvidia.com/gpu"]; ok {
+						found = max(found, gpuQuantityValue(q))
+					}
+				}
+			}
+			found = max(found, maxGPURequest(val))
+		}
+	case []any:
+		for _, item := range v {
+			found = max(found, maxGPURequest(item))
+		}
+	}
+	return found
+}
+
+// gpuQuantityValue parses a JSON resource quantity — a string like "8" or a
+// bare number — into a GPU count. Anything unparseable or non-positive is 0.
+func gpuQuantityValue(v any) int64 {
+	switch q := v.(type) {
+	case string:
+		if qty, err := resource.ParseQuantity(q); err == nil {
+			if n, ok := qty.AsInt64(); ok && n > 0 {
+				return n
+			}
+		}
+	case float64:
+		if q > 0 {
+			return int64(q)
+		}
+	}
+	return 0
 }
 
 // detectGPUArchConsistent detects the GPU architecture and filters out nodes

--- a/pkg/controller/workflow_nodeshortfall_test.go
+++ b/pkg/controller/workflow_nodeshortfall_test.go
@@ -14,8 +14,8 @@ import (
 
 // TestNotEnoughNodesMessage covers the wording of a node shortfall. The bare
 // message talks about schedulability, which is Kubernetes vocabulary for cordons
-// and taints, so on a heterogeneous target it sends the operator to look at the
-// wrong thing. Cases cover both shapes.
+// and taints, so when the real cause is an architecture or GPU capacity filter
+// it sends the operator to look at the wrong thing. Cases cover each shape.
 func TestNotEnoughNodesMessage(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "not-enough-nodes-message",
@@ -23,16 +23,26 @@ func TestNotEnoughNodesMessage(t *testing.T) {
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
-			Needed       int      `yaml:"needed"`
-			Found        int      `yaml:"found"`
-			GPUArch      string   `yaml:"gpuArch"`
-			ArchExcluded []string `yaml:"archExcluded"`
+			Needed           int      `yaml:"needed"`
+			Found            int      `yaml:"found"`
+			GPUArch          string   `yaml:"gpuArch"`
+			ArchExcluded     []string `yaml:"archExcluded"`
+			CapacityExcluded []struct {
+				Node string `yaml:"node"`
+				Has  int64  `yaml:"has"`
+			} `yaml:"capacityExcluded"`
+			GpusPerNode int32 `yaml:"gpusPerNode"`
 		}
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &input); err != nil {
 			return err
 		}
 
-		got := notEnoughNodesMessage(input.Needed, input.Found, input.GPUArch, input.ArchExcluded)
+		capExcluded := make([]gpuCapacityExclusion, 0, len(input.CapacityExcluded))
+		for _, e := range input.CapacityExcluded {
+			capExcluded = append(capExcluded, gpuCapacityExclusion{Node: e.Node, AllocatableGPUs: e.Has})
+		}
+
+		got := notEnoughNodesMessage(input.Needed, input.Found, input.GPUArch, input.ArchExcluded, capExcluded, input.GpusPerNode)
 
 		data, err := json.MarshalIndent(struct {
 			Message string `json:"message"`

--- a/pkg/controller/workload_gpus_test.go
+++ b/pkg/controller/workload_gpus_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+)
+
+// The GPU capacity filter has to use the exact per-node GPU count the pods
+// will request, and that value lives in different places depending on how the
+// spec was built: catalog entries and WorkloadRuns put it in the
+// TrainingRuntime dependency that templates the worker pods, hand-written
+// Workflows in trainer.resourcesPerNode. Re-deriving it from architecture
+// defaults would disagree with an operator's gpusPerNode override, so it is
+// read back from the rendered spec instead. These cases pin each location, the
+// largest-wins rule, and that resource names in labels or nodeSelectors are
+// never misread as requests.
+func TestWorkloadGPUsPerNode(t *testing.T) {
+	p := testutil.TestCaseParser{
+		Subdir:         "workload-gpus-per-node",
+		ExpectedSuffix: ".json",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var spec nvcrev1alpha1.WorkflowSpec
+		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &spec); err != nil {
+			return err
+		}
+
+		got := workloadGPUsPerNode(&spec)
+
+		b, err := json.MarshalIndent(struct {
+			GpusPerNode int32 `json:"gpusPerNode"`
+		}{GpusPerNode: got}, "", "  ")
+		if err != nil {
+			return err
+		}
+		tc.Actual = string(b) + "\n"
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #82

On a fleet where nodes have different GPU counts, nodes with fewer allocatable `nvidia.com/gpu` than the workload requests per node were partitioned into groups anyway. Their pods could never schedule, so the run hung at `InProgress/JobRunning` until the timeout with nothing naming the cause.

- Add a GPU capacity filter in both places the architecture filter already runs: the Certification drops under-capacity nodes after `gpusPerNode` is resolved and before `resolveNodesPerJob`, so the job is sized against nodes that can actually run it; the Workflow drops them after overrides are applied and partitions only the survivors.
- The Workflow reads the per-node requirement back from the rendered spec (largest `nvidia.com/gpu` request across `trainer.resourcesPerNode` and the dependency TrainingRuntimes), so the check uses exactly the value the pods will request — an operator's `gpusPerNode` override or an override patch that rewrites the resources block is already baked in. There is no ordering loop: `gpusPerNode` never depends on the node count.
- Dropped nodes land in `status.orchestration.excludedNodes` with a `"has X, needs Y"` reason, so a passing run over a partly-tested fleet reports `INCOMPLETE` instead of a clean `PASSED`. The record is re-applied inside the status-update retry closure, so a 409 conflict on a terminal write can't silently lose it. An `InsufficientGPUCapacity` warning event is emitted, and the node-shortfall message names the dropped nodes — when both the architecture and capacity filters contributed, the "Set nodesPerJob to N" advice appears once with both remedies rather than once per cause.
- If no matching node can supply the request, both tiers fail up front with the requirement and the best available count (`Failed/PartitionError` on the Workflow) instead of scheduling pods that would stay `Pending` forever.
- Only a stable, positive shortfall excludes a node. Missing allocatable is kept — the device plugin advertises the resource asynchronously — and so is an explicit zero, because the kubelet zeroes an extended resource rather than removing it when the plugin endpoint goes away; excluding on zero would turn a self-healing Pending during a plugin restart into a terminal failure.

Tests: testutil golden unit tests for the filter (`gpu-capacity-filter`, 6 cases including the zero-allocatable boundary), the rendered-spec extraction (`workload-gpus-per-node`, 4 cases), Certification sizing against survivors including the issue's 6-node repro and the all-too-small error (`resolve-nodes-per-job-after-capacity-filter`, 3 cases), plus new cases for `exclusion-summary` and `not-enough-nodes-message` (including the combined arch+capacity message shape). Two new integration cases: `workflow-insufficient-gpu-capacity` (one 1-GPU node excluded and recorded, the two capable nodes form the group) and `workflow-no-gpu-capacity` (all nodes too small fails with the requirement and best available). The integration harness now applies Node `status.allocatable` from fixtures.

Goldens: no pre-existing golden changed — every new golden belongs to a new test case and was reviewed against the intended output before generation. The only regenerated non-test artifact is the Workflow CRD, from updating the stale `excludedNodes` doc comment (it claimed heterogeneous architecture was the only cause) to list all three causes.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] `make manifests generate` run (if `*_types.go` was modified)
- [x] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
