### PR TITLE
fix(setup): apply chart CRDs on every init run to prevent schema drift on upgrade

### DIFF
--- a/docs/cli-reference/setup.md
+++ b/docs/cli-reference/setup.md
@@ -25,6 +25,8 @@ Runs two phases in order:
 
 Use `--skip-phases=deps` to skip Kubeflow Trainer if it is already installed.
 
+The `helm` phase reconciles the NVCRE CRDs on every run: it extracts the CRD manifests from the same chart version it is about to install (`helm show crds`) and server-side-applies them (field manager `nvcrectl-setup`, force ownership) before running `helm upgrade --install`. Helm itself applies a chart's `crds/` directory only on the *first* install, so without this step an upgrade would leave the installed CRDs at the old schema. Server-side apply is idempotent, so a fresh install and an unchanged re-run behave exactly as before.
+
 ### Retry behavior and automatic recovery
 
 `setup init` converges from any partial state, so re-running it after a failure is always safe to try:

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -35,7 +35,7 @@ nvcrectl setup init --image-pull-secret $GITHUB_TOKEN
 `setup init` runs two phases:
 
 1. **deps** — Kubeflow Trainer (required for `TrainJob` workloads)
-2. **helm** — the NVCRE Helm chart: CRDs, controller Deployment, RBAC, metrics Service/ServiceMonitor, and built-in LogProfiles
+2. **helm** — the NVCRE Helm chart: CRDs, controller Deployment, RBAC, metrics Service/ServiceMonitor, and built-in LogProfiles. The CRDs are server-side-applied from the chart before the Helm release is installed or upgraded, on every run — Helm alone would only install them once and never update them.
 
 The Helm chart is pulled from GHCR at the CLI's own version, so a tagged release needs no version flag. **Dev builds (built from `main`) require `--version`** to name the chart version explicitly:
 
@@ -236,14 +236,19 @@ readinessProbe:
 ## Upgrades
 
 1. Review the release notes for breaking changes.
-2. Upgrade the Helm release (log in to `ghcr.io` first, as above):
+2. Apply the new chart version's CRDs. Helm never updates CRDs on `helm upgrade` — it applies a chart's `crds/` directory only on the first install — so skipping this step leaves the installed CRDs at the old schema:
+   ```bash
+   helm show crds oci://ghcr.io/nvidia/nvcre --version <new-version> \
+     | kubectl apply --server-side --force-conflicts -f -
+   ```
+3. Upgrade the Helm release (log in to `ghcr.io` first, as above):
    ```bash
    helm upgrade nvcre \
      oci://ghcr.io/nvidia/nvcre \
      --version <new-version> \
      --namespace nvcre
    ```
-3. Verify the rollout:
+4. Verify the rollout:
    ```bash
    kubectl rollout status -n nvcre deploy/nvcre-manager
    ```
@@ -254,7 +259,7 @@ To roll back:
 helm rollback nvcre <revision> --namespace nvcre
 ```
 
-If you installed with `nvcrectl setup init`, upgrade by installing the new CLI version and re-running `nvcrectl setup init`.
+If you installed with `nvcrectl setup init`, upgrade by installing the new CLI version and re-running `nvcrectl setup init` — it reconciles the CRDs from the chart on every run before upgrading the Helm release, so no manual CRD step is needed.
 
 ## Uninstall and cleanup
 

--- a/pkg/setup/crds.go
+++ b/pkg/setup/crds.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// crdFieldManager is the server-side-apply field manager `setup init` uses
+// when reconciling the chart CRDs.
+const crdFieldManager = "nvcrectl-setup"
+
+// fetchChartCRDs runs `helm show crds` against the same OCI chart source and
+// version installHelmRelease deploys, and returns the chart's crds/ directory
+// as one multi-document YAML stream. Only stdout is treated as manifest data;
+// stderr (registry warnings and errors) is surfaced separately on failure so
+// it can never corrupt the YAML stream.
+func fetchChartCRDs(helmPath, chartVersion string, out io.Writer) ([]byte, error) {
+	args := []string{"show", "crds", helmChartOCI, "--version", chartVersion}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(helmPath, args...) // #nosec G204 -- helmPath and args come from this CLI, not from untrusted input
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		_, _ = io.Copy(out, &stderr)
+		printGHCR403Hint(out, stderr.String())
+		return nil, fmt.Errorf("helm show crds: %w", err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// applyChartCRDs server-side-applies every CustomResourceDefinition document
+// in manifests with force ownership. Helm applies a chart's crds/ directory
+// only on the first install, so `helm upgrade --install` alone leaves the
+// CRDs at the schema of whichever version first installed them (issue #145).
+// Reconciling them from the chart before every upgrade closes that gap;
+// server-side apply is idempotent, so a fresh install and an unchanged
+// re-run are unaffected.
+//
+// Known limitation: SSA only removes a field once no manager owns it. The
+// managedFields entry helm left behind on first install co-owns every field
+// it created, and helm never re-applies CRDs, so a schema field that a
+// future chart version REMOVES will linger on the installed CRD until
+// something clears helm's ownership. That is strictly better than the
+// pre-#145 behavior (no update at all), and new/changed fields — the actual
+// drift in issue #145 — are fully reconciled.
+func applyChartCRDs(ctx context.Context, c client.Client, manifests []byte, out io.Writer) error {
+	reader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(manifests)))
+	applied := 0
+	for {
+		doc, readErr := reader.Read()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return fmt.Errorf("read chart CRD stream: %w", readErr)
+		}
+
+		// A document may be blank or comment-only (helm show crds emits a
+		// separator per crds/ file, and the files carry leading separators of
+		// their own); probing with a map skips those without tripping on the
+		// missing kind.
+		var probe map[string]any
+		if err := sigsyaml.Unmarshal(doc, &probe); err != nil {
+			return fmt.Errorf("parse chart CRD document: %w", err)
+		}
+		if len(probe) == 0 {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{Object: probe}
+		if obj.GetKind() != "CustomResourceDefinition" {
+			continue
+		}
+		if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(obj),
+			client.FieldOwner(crdFieldManager), client.ForceOwnership); err != nil {
+			return fmt.Errorf("apply CRD %s: %w", obj.GetName(), err)
+		}
+		_, _ = fmt.Fprintf(out, "  CRD %s applied.\n", obj.GetName())
+		applied++
+	}
+	if applied == 0 {
+		return errors.New("chart contains no CustomResourceDefinition documents")
+	}
+	return nil
+}

--- a/pkg/setup/crds_test.go
+++ b/pkg/setup/crds_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// TestApplyChartCRDs drives the CRD reconciliation step of the [helm] phase
+// (issue #145) against a real apiserver: envtest provides real server-side
+// apply and field ownership, the same fixture shape as
+// TestClassifierMatchesRealSSAConflict. Each case pre-applies any
+// input_existing.yaml objects as field manager "helm" to stand in for the
+// ownership a previous install left behind. (A real helm install creates
+// CRDs with an Update operation rather than Apply; the force-ownership
+// conflict path under test is the same either way, but the applyManagers
+// column in the goldens reflects this Apply-based fixture, not the exact
+// managedFields a real install would leave.) The case then feeds
+// input_crds.yaml through applyChartCRDs one or more times. The golden file
+// holds the printed transcript plus a summary of every CRD named in the
+// inputs (generation, served versions, spec schema properties, apply field
+// managers), so a skipped schema update, a lost field, or a non-idempotent
+// re-run shows up as a diff.
+//
+// The test needs KUBEBUILDER_ASSETS (as cmd/integration does); `make test`
+// exports it for the unit run too. The test skips when it is unset so a
+// plain `go test ./pkg/setup/` still passes without envtest binaries.
+func TestApplyChartCRDs(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping envtest CRD apply fixture")
+	}
+
+	suite := &testutil.IntegrationTestSuite{}
+	suite.SetupTestSuite(t)
+	defer suite.TearDownTestSuite(t)
+
+	ctx := context.Background()
+	c := suite.Client
+
+	p := testutil.TestCaseParser{
+		Subdir:         "apply-chart-crds",
+		ExpectedSuffix: ".txt",
+	}
+	p.TestDir(t, func(tc *testutil.TestCase) error {
+		var in struct {
+			// Rounds is how many times applyChartCRDs runs against the same
+			// manifests (default 1); 2 exercises the idempotent re-run.
+			Rounds int `yaml:"rounds"`
+		}
+		if raw := tc.Inputs["input.yaml"]; raw != "" {
+			if err := sigsyaml.Unmarshal([]byte(raw), &in); err != nil {
+				return err
+			}
+		}
+		if in.Rounds == 0 {
+			in.Rounds = 1
+		}
+
+		for _, doc := range splitYAMLDocuments([]byte(tc.Inputs["input_existing.yaml"])) {
+			obj, err := decodeUnstructured(doc)
+			if err != nil {
+				return fmt.Errorf("decode existing object: %w", err)
+			}
+			if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(obj),
+				client.FieldOwner("helm")); err != nil {
+				return fmt.Errorf("pre-apply existing object: %w", err)
+			}
+		}
+
+		var buf bytes.Buffer
+		for round := 1; round <= in.Rounds; round++ {
+			_, _ = fmt.Fprintf(&buf, "--- apply round %d ---\n", round)
+			if err := applyChartCRDs(ctx, c, []byte(tc.Inputs["input_crds.yaml"]), &buf); err != nil {
+				return err
+			}
+		}
+
+		buf.WriteString("--- cluster state ---\n")
+		for _, name := range inputCRDNames(tc.Inputs) {
+			line, err := summarizeCRD(ctx, c, name)
+			if err != nil {
+				return err
+			}
+			buf.WriteString(line)
+		}
+		tc.Actual = buf.String()
+		return nil
+	})
+}
+
+// inputCRDNames collects the metadata.name of every CustomResourceDefinition
+// document across the case's input files, sorted and deduplicated. Documents
+// that are not CRDs (or not decodable) are skipped.
+func inputCRDNames(inputs map[string]string) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, key := range []string{"input_existing.yaml", "input_crds.yaml"} {
+		for _, doc := range splitYAMLDocuments([]byte(inputs[key])) {
+			obj, err := decodeUnstructured(doc)
+			if err != nil || obj.GetKind() != "CustomResourceDefinition" {
+				continue
+			}
+			if name := obj.GetName(); name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// summarizeCRD renders one deterministic line about the live CRD: generation
+// (bumps only when the spec actually changed), served version names, the
+// sorted spec-schema property names of the first version, and the sorted
+// field managers whose operation is Apply. Update-operation managers (the
+// apiserver's own status writes) are excluded because their timing is racy.
+func summarizeCRD(ctx context.Context, c client.Client, name string) (string, error) {
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+	if err := c.Get(ctx, client.ObjectKey{Name: name}, crd); err != nil {
+		return "", fmt.Errorf("get CRD %s: %w", name, err)
+	}
+
+	var versions, props []string
+	specVersions, _, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	for i, v := range specVersions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := vm["name"].(string); name != "" {
+			versions = append(versions, name)
+		}
+		if i == 0 {
+			propsMap, _, _ := unstructured.NestedMap(vm,
+				"schema", "openAPIV3Schema", "properties", "spec", "properties")
+			for k := range propsMap {
+				props = append(props, k)
+			}
+			sort.Strings(props)
+		}
+	}
+
+	managerSet := map[string]bool{}
+	for _, mf := range crd.GetManagedFields() {
+		if mf.Operation == metav1.ManagedFieldsOperationApply {
+			managerSet[mf.Manager] = true
+		}
+	}
+	managers := make([]string, 0, len(managerSet))
+	for m := range managerSet {
+		managers = append(managers, m)
+	}
+	sort.Strings(managers)
+
+	return fmt.Sprintf(
+		"crd: %s generation=%d versions=[%s] specProperties=[%s] applyManagers=[%s]\n",
+		name, crd.GetGeneration(), strings.Join(versions, " "),
+		strings.Join(props, " "), strings.Join(managers, " ")), nil
+}

--- a/pkg/setup/helm.go
+++ b/pkg/setup/helm.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -92,6 +95,10 @@ func ensureHelm() (string, error) {
 }
 
 type helmInstallParams struct {
+	// ctx and c are used to server-side-apply the chart CRDs before the
+	// helm upgrade runs (issue #145).
+	ctx             context.Context
+	c               client.Client
 	version         string
 	kubeconfig      string
 	kubeContext     string
@@ -102,7 +109,8 @@ type helmInstallParams struct {
 	out             io.Writer
 }
 
-// installHelmRelease installs or upgrades NVCRE via the helm CLI. It returns
+// installHelmRelease installs or upgrades NVCRE via the helm CLI, after
+// reconciling the chart CRDs with server-side apply (issue #145). It returns
 // the captured helm transcript so RunInit can classify a failure the same
 // way the [deps] phase does (ADR-073) — symmetric error reporting, but with
 // no automatic recovery arm.
@@ -122,6 +130,20 @@ func installHelmRelease(p helmInstallParams) (string, error) {
 			return "", err
 		}
 		defer helmRegistryLogout(helmPath, defaultImageRegistry, p.out)
+	}
+
+	// Helm applies the chart's crds/ directory only on the first install, so
+	// `helm upgrade --install` alone would leave the CRDs at the old schema
+	// after an upgrade (issue #145). Reconcile them from the same chart
+	// source on every run; server-side apply is idempotent, so first-install
+	// behavior is unchanged.
+	_, _ = fmt.Fprintf(p.out, "[helm] Applying NVCRE CRDs from chart version %s...\n", chartVersion)
+	crds, err := fetchChartCRDs(helmPath, chartVersion, p.out)
+	if err != nil {
+		return "", err
+	}
+	if err := applyChartCRDs(p.ctx, p.c, crds, p.out); err != nil {
+		return "", err
 	}
 
 	imageName, imageTag := parseImage(p.image)
@@ -400,13 +422,19 @@ func runHelmCapture(helmPath string, args []string, out io.Writer) (string, erro
 	if err := cmd.Run(); err != nil {
 		output := buf.String()
 		_, _ = io.Copy(out, &buf)
-		if strings.Contains(output, "403") {
-			_, _ = fmt.Fprintln(out, "\nHint: GHCR returned 403. Your token may be missing the read:packages scope.")
-			_, _ = fmt.Fprintln(out, "      Run: gh auth refresh -s read:packages")
-		}
+		printGHCR403Hint(out, output)
 		return output, fmt.Errorf("helm %s: %w", args[0], err)
 	}
 	return buf.String(), nil
+}
+
+// printGHCR403Hint prints the read:packages remediation hint when a failed
+// helm transcript contains a GHCR 403.
+func printGHCR403Hint(out io.Writer, output string) {
+	if strings.Contains(output, "403") {
+		_, _ = fmt.Fprintln(out, "\nHint: GHCR returned 403. Your token may be missing the read:packages scope.")
+		_, _ = fmt.Fprintln(out, "      Run: gh auth refresh -s read:packages")
+	}
 }
 
 // helmRegistryLogin logs in to an OCI registry.

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -100,7 +100,11 @@ Use --auto-approve to skip the confirmation prompt (for CI/automation).
 Re-running init is safe: a Kubeflow Trainer release already deployed at the
 pinned version is skipped, and a release wedged by webhook Secret
 field-ownership conflicts (issue #180) is recovered automatically when no
-Trainer workloads exist, or the manual procedure is printed.`,
+Trainer workloads exist, or the manual procedure is printed.
+
+The NVCRE CRDs are server-side-applied from the chart before every Helm
+upgrade, so re-running init after a version bump also updates the CRD
+schemas (Helm alone only installs CRDs on the first install).`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunInit(version, image, imagePullSecret, skipPhases, autoApprove,
@@ -196,6 +200,8 @@ func RunInit(
 		return fmt.Errorf("[helm] %w", err)
 	}
 	if nvcreOutput, err := installHelmRelease(helmInstallParams{
+		ctx:             ctx,
+		c:               c,
 		version:         version,
 		kubeconfig:      kubeconfigPath,
 		kubeContext:     kubeContext,

--- a/pkg/setup/testdata/apply-chart-crds/fresh-install-creates/expected.txt
+++ b/pkg/setup/testdata/apply-chart-crds/fresh-install-creates/expected.txt
@@ -1,0 +1,6 @@
+--- apply round 1 ---
+  CRD widgets.fresh.nvcre.example.com applied.
+  CRD gadgets.fresh.nvcre.example.com applied.
+--- cluster state ---
+crd: gadgets.fresh.nvcre.example.com generation=1 versions=[v1] specProperties=[enabled] applyManagers=[nvcrectl-setup]
+crd: widgets.fresh.nvcre.example.com generation=1 versions=[v1alpha1] specProperties=[size] applyManagers=[nvcrectl-setup]

--- a/pkg/setup/testdata/apply-chart-crds/fresh-install-creates/input_crds.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/fresh-install-creates/input_crds.yaml
@@ -1,0 +1,65 @@
+---
+# Source: crds/widgets.yaml — helm show crds emits a separator per crds/
+# file and the files carry leading separators of their own, so blank and
+# comment-only documents must be skipped without error.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.fresh.nvcre.example.com
+spec:
+  group: fresh.nvcre.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  type: integer
+---
+# A non-CRD document must be skipped, not applied.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-a-crd
+  namespace: default
+data:
+  key: value
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gadgets.fresh.nvcre.example.com
+spec:
+  group: fresh.nvcre.example.com
+  names:
+    kind: Gadget
+    listKind: GadgetList
+    plural: gadgets
+    singular: gadget
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                enabled:
+                  type: boolean

--- a/pkg/setup/testdata/apply-chart-crds/invalid-document-fails/error
+++ b/pkg/setup/testdata/apply-chart-crds/invalid-document-fails/error
@@ -1,0 +1,1 @@
+parse chart CRD document

--- a/pkg/setup/testdata/apply-chart-crds/invalid-document-fails/input_crds.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/invalid-document-fails/input_crds.yaml
@@ -1,0 +1,1 @@
+not: [valid: yaml:

--- a/pkg/setup/testdata/apply-chart-crds/no-crds-fails/error
+++ b/pkg/setup/testdata/apply-chart-crds/no-crds-fails/error
@@ -1,0 +1,1 @@
+chart contains no CustomResourceDefinition documents

--- a/pkg/setup/testdata/apply-chart-crds/no-crds-fails/input_crds.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/no-crds-fails/input_crds.yaml
@@ -1,0 +1,9 @@
+# A chart CRD stream with no CustomResourceDefinition documents means the
+# fetch went wrong; failing loudly beats silently skipping the reconcile.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-a-crd
+  namespace: default
+data:
+  key: value

--- a/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/expected.txt
+++ b/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/expected.txt
@@ -1,0 +1,6 @@
+--- apply round 1 ---
+  CRD widgets.rerun.nvcre.example.com applied.
+--- apply round 2 ---
+  CRD widgets.rerun.nvcre.example.com applied.
+--- cluster state ---
+crd: widgets.rerun.nvcre.example.com generation=1 versions=[v1alpha1] specProperties=[size] applyManagers=[nvcrectl-setup]

--- a/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/input.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/input.yaml
@@ -1,0 +1,3 @@
+# Re-running setup init applies the same chart CRDs again; the second apply
+# must succeed and must not bump the CRD generation.
+rounds: 2

--- a/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/input_crds.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/rerun-idempotent/input_crds.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.rerun.nvcre.example.com
+spec:
+  group: rerun.nvcre.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  type: integer

--- a/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/expected.txt
+++ b/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/expected.txt
@@ -1,0 +1,4 @@
+--- apply round 1 ---
+  CRD widgets.upgrade.nvcre.example.com applied.
+--- cluster state ---
+crd: widgets.upgrade.nvcre.example.com generation=2 versions=[v1alpha1] specProperties=[color size] applyManagers=[helm nvcrectl-setup]

--- a/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/input_crds.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/input_crds.yaml
@@ -1,0 +1,29 @@
+# The new chart version adds the "color" property. Before issue #145 the
+# upgrade never touched the installed CRD, so the field stayed absent.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.upgrade.nvcre.example.com
+spec:
+  group: upgrade.nvcre.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  type: integer
+                color:
+                  type: string

--- a/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/input_existing.yaml
+++ b/pkg/setup/testdata/apply-chart-crds/upgrade-updates-schema/input_existing.yaml
@@ -1,0 +1,27 @@
+# The CRD schema a previous chart version installed (field manager "helm"):
+# no "color" property yet.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.upgrade.nvcre.example.com
+spec:
+  group: upgrade.nvcre.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  type: integer


### PR DESCRIPTION
## Summary

Fixes #145

- `nvcrectl setup init` deploys via `helm upgrade --install`, and Helm applies a chart's `crds/` directory only on the first install — upgrading to a version with new or changed CRD schemas left the installed CRDs at the old schema, so the controller could write fields the stale schema silently drops and new validation rules were never enforced.
- The `[helm]` phase now reconciles the CRDs on every run before the Helm upgrade: it extracts the CRD manifests from the same OCI chart version it is about to install (`helm show crds`) and server-side-applies them with field manager `nvcrectl-setup` and force ownership. SSA is idempotent, so fresh installs and unchanged re-runs behave exactly as before; the reset/delete path is untouched.
- Only helm's stdout is parsed as the manifest stream (registry warnings on stderr can't corrupt the YAML), an empty CRD stream is an error rather than a silent skip, and blank or comment-only documents between the chart's `crds/` files are skipped. The GHCR 403 `read:packages` hint is now a shared helper used by both the CRD fetch and the other helm invocations.
- One SSA limitation is documented in code: a schema field a future chart version *removes* can linger while helm's first-install managedFields entry still co-owns it — strictly better than the pre-fix behavior of never updating CRDs. The Kubeflow Trainer/JobSet charts have the same drift class on version bumps; that's out of scope here and worth a follow-up issue.
- Docs: `docs/cli-reference/setup.md` and `docs/operations/deployment.md` now describe the CRD reconcile, and the manual Helm upgrade procedure gained an explicit `helm show crds ... | kubectl apply --server-side --force-conflicts -f -` step since plain `helm upgrade` never touches CRDs.
- Tests: new envtest golden suite `pkg/setup/testdata/apply-chart-crds` (testutil.TestCaseParser, real apiserver SSA) covering fresh install, upgrade with a changed CRD schema (generation bump, ownership taken from `helm`), idempotent re-run (no generation bump), and failure on empty or invalid CRD streams. All goldens are new files for the new tests, written by hand from intended behavior and passing on the first run — no existing goldens were regenerated.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [x] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [x] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
