### PR TITLE
test(integration): sort validation causes for deterministic goldens

### DIFF
--- a/cmd/integration/validation_test.go
+++ b/cmd/integration/validation_test.go
@@ -82,7 +82,10 @@ func TestCertificationValidation(t *testing.T) {
 				if result.Causes[i].Field != result.Causes[j].Field {
 					return result.Causes[i].Field < result.Causes[j].Field
 				}
-				return result.Causes[i].Message < result.Causes[j].Message
+				if result.Causes[i].Message != result.Causes[j].Message {
+					return result.Causes[i].Message < result.Causes[j].Message
+				}
+				return result.Causes[i].Type < result.Causes[j].Type
 			})
 		} else if delErr := suite.Client.Delete(ctx, objs[0]); delErr != nil {
 			// Accepted: remove the object so cases stay independent.

--- a/cmd/integration/validation_test.go
+++ b/cmd/integration/validation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -75,6 +76,14 @@ func TestCertificationValidation(t *testing.T) {
 					})
 				}
 			}
+			// The API server reports CEL violations for sibling fields in
+			// nondeterministic order; sort so goldens are stable.
+			sort.Slice(result.Causes, func(i, j int) bool {
+				if result.Causes[i].Field != result.Causes[j].Field {
+					return result.Causes[i].Field < result.Causes[j].Field
+				}
+				return result.Causes[i].Message < result.Causes[j].Message
+			})
 		} else if delErr := suite.Client.Delete(ctx, objs[0]); delErr != nil {
 			// Accepted: remove the object so cases stay independent.
 			return delErr


### PR DESCRIPTION
## Summary

- The `certification-resources-negative-pair` validation case pins two CEL causes on the same object, and the API server returns sibling-field violations in nondeterministic order, so the golden failed on roughly half of CI runs (seen on #239 and #250).
- Sort the collected causes by field, then message, in the validation harness before writing the result. The existing golden already matches sorted order, so no golden changes.
- Verified with three consecutive green runs of `TestCertificationValidation` locally.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [x] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [x] Ready for review
