### PR TITLE
docs: switch install and release instructions to public download URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,25 +203,17 @@ jobs:
 
             ## Install nvcrectl
 
-            While this repository is internal, GitHub serves release assets only through
-            authenticated API downloads — plain `curl` against `releases/download/...`
-            returns a 404 "Not Found" page instead of the script, even with a token.
-            Fetch the installer with the gh CLI (authenticate with `gh auth login`):
+            Install this release:
 
             ```bash
-            gh release download ${{ steps.tag.outputs.value }} \
-              --repo ${{ github.repository }} \
-              --pattern installer --output - | bash -s -- -v ${{ steps.tag.outputs.value }}
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
             ```
 
-            Once the repository is public, the plain curl form works. The version is
-            named explicitly because `releases/latest` resolves only to the newest
-            **stable** release, and every release so far is a pre-release. Once `v0.1.0`
-            is tagged, the shorter form installs the newest stable one:
+            Or install the newest stable release (`releases/latest` resolves only to
+            stable releases, never pre-releases):
 
             ```bash
-            curl -sSL https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
-            curl -sSL https://github.com/${{ github.repository }}/releases/latest/download/installer | bash
+            curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/installer | bash
             ```
 
             ## Helm Chart
@@ -278,22 +270,20 @@ jobs:
           generate_release_notes: true
 
       # Post-publish gate (issues #194, #195): download the just-published
-      # assets over the same authenticated channel the release notes tell
-      # users to use, and verify them. While the repository is internal, the
-      # unauthenticated browser URL (releases/download/<tag>/installer)
-      # serves a 404 "Not Found" page instead of the script — that page is
-      # what v0.1.0-rc.7 users piped into bash (issue #194) — so this check
-      # asserts the published asset really is a runnable shell script and the
-      # published binary really reports the released tag.
+      # assets over the same public unauthenticated URL the release notes
+      # tell users to use (releases/download/<tag>/<asset>), and verify
+      # them. v0.1.0-rc.7 users piped a "Not Found" page into bash (issue
+      # #194), so this check asserts the published asset really is a
+      # runnable shell script and the published binary really reports the
+      # released tag.
       - name: Verify published release assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.value }}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
           rm -rf verify-release && mkdir verify-release
-          gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
-            --pattern installer --pattern checksums.txt --pattern nvcrectl-linux-amd64 \
-            --dir verify-release
+          for asset in installer checksums.txt nvcrectl-linux-amd64; do
+            curl -fsSL -o "verify-release/${asset}" "${base}/${asset}"
+          done
           # The installer must be a shell script, not an HTML/text error page.
           [[ "$(head -c 2 verify-release/installer)" == '#!' ]]
           bash -n verify-release/installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,20 +270,35 @@ jobs:
           generate_release_notes: true
 
       # Post-publish gate (issues #194, #195): download the just-published
-      # assets over the same public unauthenticated URL the release notes
-      # tell users to use (releases/download/<tag>/<asset>), and verify
-      # them. v0.1.0-rc.7 users piped a "Not Found" page into bash (issue
-      # #194), so this check asserts the published asset really is a
-      # runnable shell script and the published binary really reports the
-      # released tag.
+      # assets over the same channel users take and verify them. On a public
+      # repository that is the unauthenticated browser URL
+      # (releases/download/<tag>/<asset>); v0.1.0-rc.7 users piped the 404
+      # "Not Found" page that URL serves on non-public repositories into
+      # bash (issue #194), and only an unauthenticated download can catch
+      # that. While the repository is not public the gate falls back to the
+      # authenticated channel so a release cut before a visibility flip
+      # still verifies instead of failing on the 404.
       - name: Verify published release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.value }}"
-          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
           rm -rf verify-release && mkdir verify-release
-          for asset in installer checksums.txt nvcrectl-linux-amd64; do
-            curl -fsSL -o "verify-release/${asset}" "${base}/${asset}"
-          done
+          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
+          echo "repository visibility: ${visibility}"
+          if [[ "${visibility}" == "public" ]]; then
+            base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
+            for asset in installer checksums.txt nvcrectl-linux-amd64; do
+              curl -fsSL -o "verify-release/${asset}" "${base}/${asset}"
+            done
+          else
+            echo "NOTICE: repository is not public; verifying over the" \
+              "authenticated channel. The public download URLs in the" \
+              "release notes will not work until the repository is public."
+            gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
+              --pattern installer --pattern checksums.txt --pattern nvcrectl-linux-amd64 \
+              --dir verify-release
+          fi
           # The installer must be a shell script, not an HTML/text error page.
           [[ "$(head -c 2 verify-release/installer)" == '#!' ]]
           bash -n verify-release/installer

--- a/README.md
+++ b/README.md
@@ -61,22 +61,15 @@ Run `kubectl nvcre setup status` at any time to see what is present.
 
 **1. Install the CLI**
 
-While this repository is internal, GitHub serves release assets only through
-authenticated API downloads — plain `curl` against `releases/download/...` returns a
-404 "Not Found" page instead of the script, even with a token. Fetch the installer
-with the gh CLI (authenticate with `gh auth login` first):
-
 ```bash
-NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
-gh release download "${NVCRE_VERSION}" --repo NVIDIA/cluster-readiness-engine \
-  --pattern installer --output - | bash -s -- -v "${NVCRE_VERSION}"
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 ```
 
-Once the repository is public and a stable release exists, this shorter form works
-and picks up the newest stable release:
+`releases/latest` resolves to the newest stable release. To pin a version, download
+the installer from that release and pass the tag:
 
 ```bash
-curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/<tag>/installer | bash -s -- -v <tag>
 ```
 
 The installer places `nvcrectl` on your `$PATH` and creates a `kubectl-nvcre` symlink so the CLI is also available as `kubectl nvcre`.
@@ -144,14 +137,6 @@ kubectl nvcre certification report <name> -n <namespace>
 `setup init` above is the quickest path. If you would rather manage NVCRE with
 Helm, or need to pin the controller image in your own manifests, both are
 published to the GitHub Container Registry on every release.
-
-While this repository is internal, Helm needs to authenticate to the registry
-before it can pull the chart:
-
-```bash
-gh auth token | helm registry login ghcr.io \
-  --username "$(gh api user --jq .login)" --password-stdin
-```
 
 ```bash
 NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,11 +68,8 @@ When an RC is good, tag the **same commit** with the stable version. Do not rebu
 re-merge between the RC and the stable tag; that would ship something nobody validated.
 
 Note that `curl .../releases/latest/download/installer` resolves to the newest
-**stable** release. While only pre-releases exist, that URL returns 404. Additionally,
-while this repository is internal, GitHub serves release assets only through
-authenticated API downloads: plain `curl` against any `releases/download/...` URL
-returns a 404 "Not Found" page even with a token, which is why the README installs
-through `gh release download`.
+**stable** release, never a pre-release. To install an RC, name its tag explicitly
+in the `releases/download/<tag>/installer` URL and pass `-v <tag>` to the installer.
 
 ## What a release publishes
 
@@ -103,14 +100,12 @@ tag exactly, and the Create GitHub Release job re-downloads the published `insta
 shell script (not an error page), verifies checksums, and re-checks the binary's
 self-reported version.
 
-To verify manually (via gh while the repository is internal; once public, plain
-`curl -sSLO "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/$VERSION/<asset>"`
-works too):
+To verify manually:
 
 ```bash
 VERSION=v0.1.0
-gh release download "$VERSION" --repo NVIDIA/cluster-readiness-engine \
-  --pattern checksums.txt --pattern nvcrectl-linux-amd64
+curl -fsSLO "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${VERSION}/checksums.txt"
+curl -fsSLO "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${VERSION}/nvcrectl-linux-amd64"
 sha256sum --check --ignore-missing checksums.txt
 ```
 

--- a/docs/cli-reference/overview.md
+++ b/docs/cli-reference/overview.md
@@ -10,15 +10,12 @@ description: The nvcrectl CLI manages the full lifecycle of cluster certificatio
 
 ## Install
 
-While this repository is internal, release assets require authenticated API
-downloads, so fetch the installer with the gh CLI (`gh auth login` first):
-
 ```bash
-export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
-gh release download "${NVCRECTL_VERSION}" --repo NVIDIA/cluster-readiness-engine \
-  --pattern installer --output - | bash -s -- -v "${NVCRECTL_VERSION}"
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 nvcrectl --version
 ```
+
+To pin a version: `curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/<tag>/installer | bash -s -- -v <tag>`.
 
 The installer also creates a `kubectl-nvcre` symlink so the CLI is available as a kubectl plugin (`kubectl nvcre ...`).
 

--- a/docs/getting-started/first-certification.md
+++ b/docs/getting-started/first-certification.md
@@ -26,17 +26,17 @@ Cordoned nodes are skipped. If a node is cordoned, NVCRE does not select it, and
 
 ## Step 1: install the CLI
 
-While this repository is internal, GitHub serves release assets only through authenticated API downloads — plain `curl` against `releases/download/...` returns a 404 "Not Found" page instead of the script, even with a token. Fetch the installer with the gh CLI (authenticate with `gh auth login` first); the snippet resolves the newest release:
-
 ```bash
-NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
-gh release download "${NVCRE_VERSION}" --repo NVIDIA/cluster-readiness-engine \
-  --pattern installer --output - | bash -s -- -v "${NVCRE_VERSION}"
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 ```
 
-Once the repository is public and `v0.1.0` is tagged, the shorter `curl -sSL .../releases/latest/download/installer | bash` form works and installs the newest stable release. (`releases/latest` resolves only to the newest **stable** release, and every release so far is a pre-release.)
+`releases/latest` resolves only to the newest **stable** release, never a pre-release. To install a specific version instead, download the installer from that release and pass the tag:
 
-The installer takes `-p` to accept pre-releases when it resolves a version itself. That flag is an argument to the script, so it cannot help you download the script — which is why the version is resolved with `gh release list` above.
+```bash
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/<tag>/installer | bash -s -- -v <tag>
+```
+
+The installer also takes `-p` to accept pre-releases when it resolves the version itself.
 
 The installer detects your OS and architecture, downloads the matching `nvcrectl` binary, installs it to `/usr/local/bin` (with sudo if needed), and adds a `kubectl-nvcre` symlink. After it finishes, both forms work and are the same binary:
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -15,16 +15,17 @@ description: Install the nvcrectl CLI and set up the NVIDIA Cluster Readiness En
 
 ## Install the CLI
 
-While this repository is internal, GitHub serves release assets only through
-authenticated API downloads — plain `curl` against `releases/download/...` returns a
-404 "Not Found" page instead of the script, even with a token. Fetch the installer
-with the gh CLI (authenticate with `gh auth login` first). Resolve the newest
-release, then run the installer:
+Download and run the installer. It detects your OS and architecture and resolves
+the newest stable release itself:
 
 ```bash
-export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
-gh release download "${NVCRECTL_VERSION}" --repo NVIDIA/cluster-readiness-engine \
-  --pattern installer --output - | bash -s -- -v "${NVCRECTL_VERSION}"
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
+```
+
+To pin a version, download the installer from that release and pass the tag:
+
+```bash
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/<tag>/installer | bash -s -- -v <tag>
 ```
 
 The installer automatically downloads and verifies a SHA-256 checksum before installing. On air-gapped systems, ensure `checksums.txt` from the same release is reachable alongside the binary.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -22,8 +22,7 @@ NVCRE supports two install paths. Both pull the same artifacts from the GitHub C
 Install the CLI first with the installer script (see [Install](../getting-started/install.md) for the full walkthrough):
 
 ```bash
-export NVCRECTL_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')
-curl -sSL "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${NVCRECTL_VERSION}/installer" | bash
+curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 ```
 
 Then set up the cluster:
@@ -53,13 +52,7 @@ nvcrectl setup status
 
 ### Helm chart
 
-For GitOps workflows, install the chart directly. **Log in to the GHCR Helm registry first** — the chart pull is authenticated:
-
-```bash
-echo $GITHUB_TOKEN | helm registry login ghcr.io --username <github-username> --password-stdin
-```
-
-Then inspect and install (the snippet resolves the newest release; set `NVCRE_VERSION` to an explicit tag for reproducible installs):
+For GitOps workflows, install the chart directly. The chart is public on GHCR, so no registry login is needed. Inspect and install (the snippet resolves the newest release; set `NVCRE_VERSION` to an explicit tag for reproducible installs):
 
 ```bash
 NVCRE_VERSION=$(gh release list --repo NVIDIA/cluster-readiness-engine --limit 1 --json tagName -q '.[0].tagName')

--- a/installer
+++ b/installer
@@ -11,16 +11,11 @@ set -euo pipefail
 # Installs nvcrectl if it is not present; upgrades it if it already is.
 #
 # Usage:
-#   While the repository is internal, GitHub serves release assets only
-#   through authenticated API downloads — plain curl against
-#   releases/download/... returns a 404 page, even with a token. Fetch the
-#   script with the gh CLI (gh auth login first):
-#     gh release download <tag> --repo NVIDIA/cluster-readiness-engine \
-#       --pattern installer --output - | bash -s -- -v <tag>
+#   curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
 #
-#   Once the repository is public:
-#     curl -sSL https://github.com/NVIDIA/cluster-readiness-engine/releases/latest/download/installer | bash
-#     curl -sSL <url> | bash -s -- -d /custom/path
+#   Pin an exact release, or change the install directory:
+#     curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/<tag>/installer | bash -s -- -v <tag>
+#     curl -fsSL <url> | bash -s -- -d /custom/path
 # ---------------------------------------------------------------------------
 
 # Configuration


### PR DESCRIPTION
## Summary

The install and release docs still route every download through the authenticated gh CLI because the repo used to be internal. Once the repo is public those instructions are pure friction, and the release pipeline's post-publish check exercises a path users no longer take.

- Install snippets in the README, install.md, first-certification.md, cli-reference/overview.md, and deployment.md become the plain curl one-liner (`releases/latest/download/installer | bash`), with a pinned variant for reproducible installs.
- Drop `helm registry login ghcr.io` from the README and deployment.md; the chart pulls anonymously once the GHCR package is public.
- RELEASE.md verifies assets with plain curl instead of gh.
- The installer header documents the curl form as primary. No logic changes: the GITHUB_TOKEN/gh fallbacks stay.
- release.yml embeds the curl instructions in generated release notes, and the post-publish gate downloads installer, checksums.txt, and nvcrectl-linux-amd64 from the unauthenticated URL with the same assertions as before (runnable script, checksums match, binary reports the tag).

Left alone: the read:packages and image-pull-secret guidance for the manager image. If the image package also goes public at launch, that can be simplified in a follow-up.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [x] Documentation / CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [x] Documentation updated (if needed)
- [x] Ready for review
