### PR TITLE
ci: fix Fern docs publish not triggering on release tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -70,6 +70,6 @@ body:
       placeholder: |
         - README.md
         - docs/designs/
-        - https://docs.nvidia.com/nvcre
+        - https://docs.nvidia.com/cluster-readiness-engine
     validations:
       required: false

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -37,6 +37,9 @@
 name: Publish Fern Docs
 
 on:
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Publishes the Fern documentation site on GitHub Release or manual dispatch.
+# Publishes the Fern documentation site on release tag push or manual dispatch.
 #
 # All versions serve frozen content extracted from their git tag — there is no
 # "live docs" entry. The newest version is stamped "Latest · vX.Y.Z" at publish
@@ -40,8 +40,6 @@ on:
   push:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -96,14 +94,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG: ${{ inputs.tag }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           set -eo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
-            TAG="${RELEASE_TAG}"
-            IS_PRERELEASE="${RELEASE_PRERELEASE}"
-          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             TAG="${GITHUB_REF#refs/tags/}"
           elif [ -n "${INPUT_TAG}" ]; then
             TAG="${INPUT_TAG}"
@@ -122,9 +115,7 @@ jobs:
             echo "::error::Tag '${TAG}' does not exist in this repository"
             exit 1
           fi
-          # Pre-release detection: use the Release event flag when available,
-          # fall back to hyphen check for tag-push and dispatch triggers.
-          if [ "${IS_PRERELEASE}" = "true" ] || [[ "$TAG" == *-* ]]; then
+          if [[ "$TAG" == *-* ]]; then
             IS_RELEASE=false
           else
             IS_RELEASE=true

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -235,7 +235,7 @@ readinessProbe:
    helm show crds oci://ghcr.io/nvidia/cluster-readiness-engine --version <new-version> \
      | kubectl apply --server-side --force-conflicts -f -
    ```
-3. Upgrade the Helm release (log in to `ghcr.io` first, as above):
+3. Upgrade the Helm release:
    ```bash
    helm upgrade nvcre \
      oci://ghcr.io/nvidia/cluster-readiness-engine \

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 instances:
-  - url: nvidia-nvcre.docs.buildwithfern.com/nvcre
-    custom-domain: docs.nvidia.com/nvcre
+  - url: nvidia-cluster-readiness-engine.docs.buildwithfern.com/cluster-readiness-engine
+    custom-domain: docs.nvidia.com/cluster-readiness-engine
     multi-source: true
 
 redirects:
-  - source: /nvcre/index.html
-    destination: /nvcre
+  - source: /cluster-readiness-engine/index.html
+    destination: /cluster-readiness-engine
 
 title: NVIDIA Cluster Readiness Engine
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -17,7 +17,7 @@ title: NVIDIA Cluster Readiness Engine
 global-theme: nvidia
 
 logo:
-  href: /nvcre
+  href: /cluster-readiness-engine
   right-text: NVIDIA Cluster Readiness Engine
 
 navbar-links:

--- a/installer
+++ b/installer
@@ -43,7 +43,7 @@ Usage: $0 [-d install_dir] [-p] [-v version]
 Options:
   -d DIR    Installation directory (default: /usr/local/bin)
   -p        Include pre-release versions
-  -v TAG    Install this exact release tag (e.g. v0.1.0-rc.8)
+  -v TAG    Install this exact release tag (e.g. v0.1.0)
 EOF
   exit 1
 }


### PR DESCRIPTION
## Summary

- Add `push: tags` trigger to `publish-fern-docs.yml` so it fires on tag push (matches established pattern in `aicr`, `nvsentinel`, `topograph`)
- Revert Fern URL from `nvidia-nvcre` back to `nvidia-cluster-readiness-engine` — the nvcre instance was never published to and `docs.nvidia.com/nvcre` is unrouted; the original URL is live at `docs.nvidia.com/cluster-readiness-engine`
- Fix stale `v0.1.0-rc.8` example in `installer` usage help
- Remove stale GHCR login note from `docs/operations/deployment.md`

## Related Issue

Fixes #259

## Type of Change
- [x] 🐛 Bug fix
- [x] 📚 Documentation
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation / CI

## Testing
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] Ready for review

## Notes

The `release: [published]` trigger is retained alongside `push: tags` for belt-and-suspenders.

For v0.1.0 (already tagged), a one-time `workflow_dispatch` pointing at `v0.1.0` is still needed to publish the docs.