### PR TITLE
test: exercise attest.yml's guards, and add a dispatch smoke test

### DIFF
--- a/.github/workflows/attest-selftest.yml
+++ b/.github/workflows/attest-selftest.yml
@@ -21,8 +21,14 @@
 #   * crane resolves a tag to a digest, and cosign reaches Fulcio and Rekor.
 #
 # Run it against an image tag that already exists in the registry, e.g. one of
-# the `main-<sha>` tags publish.yml pushes. A green run means the whole signing
-# path works end to end.
+# the `main-<sha>` tags publish.yml pushes.
+#
+# A green run proves the `image` path only. `subject_kind` is fixed to `image`
+# here, so the `oci-artifact` and `blob` branches and the optional
+# predicate-attestation branch are NOT exercised by this workflow; those arrive
+# with the chart and binary callers. The Go tests in test/releasepolicy cover
+# the input validation for every subject kind, but validation only -- no
+# signing branch.
 #
 # The run signs under a NON-RELEASE identity: the caller ref is a branch, so the
 # Fulcio SAN carries `@refs/heads/...` and attest.yml logs a loud non-production
@@ -38,7 +44,13 @@ on:
         required: true
         type: string
       expected_digest:
-        description: 'The digest that tag resolves to, as sha256:<64 hex>. A deliberate mismatch is a valid negative test: the run must fail at the digest comparison.'
+        description: >-
+          The digest that tag resolves to, as sha256:<64 hex>. Obtain it with
+          `crane digest ghcr.io/nvidia/cluster-readiness-engine/manager:<image_tag>`,
+          or read it from the GHCR package page. Supplying a deliberately
+          different (but well-formed) digest is a valid negative test: the run
+          must then fail at the digest comparison, and the report job will say
+          so rather than reporting a skip.
         required: true
         type: string
       platform:

--- a/.github/workflows/attest-selftest.yml
+++ b/.github/workflows/attest-selftest.yml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# On-demand smoke test for the reusable signing workflow.
+#
+# attest.yml is `workflow_call`-only, so it cannot be dispatched directly and
+# cannot be exercised from a pull request branch at all: GitHub only surfaces a
+# `workflow_dispatch` entry point that exists on the default branch. This
+# workflow is that entry point.
+#
+# The input validation is covered by Go tests (test/releasepolicy) which run on
+# every PR and need no network. What those cannot cover is the part that only
+# exists inside GitHub:
+#
+#   * the `github.repository` caller gate actually lets THIS repository through.
+#     This is the failure mode worth the most: a job whose `if` is false is
+#     SKIPPED, and a skipped job does not fail its caller. A subtly wrong gate
+#     would leave every future caller green while nothing was signed.
+#   * `runDetails.builder.id` is derived correctly from GITHUB_WORKFLOW_REF,
+#     which is only populated in a real run.
+#   * crane resolves a tag to a digest, and cosign reaches Fulcio and Rekor.
+#
+# Run it against an image tag that already exists in the registry, e.g. one of
+# the `main-<sha>` tags publish.yml pushes. A green run means the whole signing
+# path works end to end.
+#
+# The run signs under a NON-RELEASE identity: the caller ref is a branch, so the
+# Fulcio SAN carries `@refs/heads/...` and attest.yml logs a loud non-production
+# warning. It cannot be mistaken for, or verified as, a release attestation.
+
+name: Attest Self-Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'An existing tag of the manager image to sign, e.g. main-abc1234. Must already be in the registry.'
+        required: true
+        type: string
+      expected_digest:
+        description: 'The digest that tag resolves to, as sha256:<64 hex>. A deliberate mismatch is a valid negative test: the run must fail at the digest comparison.'
+        required: true
+        type: string
+      platform:
+        description: 'Optional os/arch to exercise per-platform resolution, e.g. linux/amd64.'
+        required: false
+        type: string
+        default: ''
+
+permissions: {}
+
+concurrency:
+  group: attest-selftest
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Sign a non-release image through attest.yml
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/attest.yml
+    with:
+      subject_kind: image
+      subject_name: ghcr.io/nvidia/cluster-readiness-engine/manager
+      subject_tag: ${{ inputs.image_tag }}
+      platform: ${{ inputs.platform }}
+      expected_digest: ${{ inputs.expected_digest }}
+      # Required: this runs from a branch, not a release tag. attest.yml refuses
+      # to run otherwise, and that refusal is itself one of the guards.
+      allow_untagged: true
+
+  # Reports what actually happened to the called workflow, because the three
+  # outcomes mean different things and only one of them is a pass.
+  report:
+    name: Report outcome
+    needs: [smoke]
+    if: always() && github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Interpret result
+        env:
+          RESULT: ${{ needs.smoke.result }}
+        run: |
+          set -euo pipefail
+          echo "attest.yml result: ${RESULT}"
+          case "${RESULT}" in
+            success)
+              echo "PASS: attest.yml ran and signed. The caller gate admits this repository, builder.id derived, crane and cosign reached their services."
+              ;;
+            skipped)
+              echo "::error::attest.yml was SKIPPED, not run. The github.repository caller gate is not matching this repository, so every future caller would go green while signing nothing."
+              exit 1
+              ;;
+            failure)
+              echo "::error::attest.yml ran but failed. If this run supplied a deliberately mismatched digest that is the expected negative result; otherwise read the job log."
+              exit 1
+              ;;
+            *)
+              echo "::error::unexpected result: ${RESULT}"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -86,7 +86,7 @@ on:
           upload-artifact name holding the blob and any predicate. Required when
           subject_kind is blob, AND required whenever predicate_name is set --
           including for image and oci-artifact subjects, since the predicate
-          file is read out of this artifact.'
+          file is read out of this artifact.
         required: false
         type: string
         default: ''
@@ -98,7 +98,7 @@ on:
       predicate_type:
         description: >-
           cosign --type value for predicate_name. One of cyclonedx, spdxjson, or
-          openvex. Required when predicate_name is set.'
+          openvex. Required when predicate_name is set.
         required: false
         type: string
         default: ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,12 @@ Integration tests use envtest with golden file comparison in `cmd/integration/te
 
 Unit tests in most packages use `testutil.TestCaseParser` (in `pkg/testutil/`) with testdata directories and golden files — the same pattern as integration tests but at the package level. See `/cre-test` skill for the full testing guide including which packages use which pattern, golden file rules, and the integration test input format.
 
+Release-path workflows are tested in `test/releasepolicy/`. `attest.yml`'s input validation is shell embedded in YAML — nothing type-checks it, and a weakened guard would not break a build, it would just stop rejecting things. The tests extract that step from the workflow and execute it against a table of accept and reject cases, so the test cannot drift from the validation it covers:
+
+```bash
+go test ./test/releasepolicy/ -run TestAttestValidationRejects -v
+```
+
 ## Critical Pitfalls
 
 - **After modifying `*_types.go`**: Must run `make manifests generate` before anything else compiles (stale deepcopy). `make manifests` writes CRDs directly to `helm/cluster-readiness-engine/crds/` and RBAC to `helm/cluster-readiness-engine/templates/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ Integration tests use envtest with golden file comparison in `cmd/integration/te
 
 Unit tests in most packages use `testutil.TestCaseParser` (in `pkg/testutil/`) with testdata directories and golden files — the same pattern as integration tests but at the package level. See `/cre-test` skill for the full testing guide including which packages use which pattern, golden file rules, and the integration test input format.
 
+Release-path workflows are tested in `test/releasepolicy/`. `attest.yml`'s input validation is shell embedded in YAML — nothing type-checks it, and a weakened guard would not break a build, it would just stop rejecting things. The tests extract that step from the workflow and execute it against a table of accept and reject cases, so the test cannot drift from the validation it covers:
+
+```bash
+go test ./test/releasepolicy/ -run TestAttestValidationRejects -v
+```
+
 ## Critical Pitfalls
 
 - **After modifying `*_types.go`**: Must run `make manifests generate` before anything else compiles (stale deepcopy). `make manifests` writes CRDs directly to `helm/cluster-readiness-engine/crds/` and RBAC to `helm/cluster-readiness-engine/templates/`.

--- a/test/releasepolicy/attest_guards_test.go
+++ b/test/releasepolicy/attest_guards_test.go
@@ -103,6 +103,13 @@ func (in inputs) with(overrides inputs) inputs {
 
 // runValidate executes the validation body and reports its exit status and
 // combined output.
+//
+// `bash` is resolved through PATH rather than pinned, so this runs against
+// whatever the developer or runner provides. The extracted script sticks to
+// constructs available since bash 2.0 -- indirect expansion, ANSI-C quoting,
+// and unquoted `[[ =~ ]]` patterns -- and the whole table has been confirmed to
+// pass under both macOS's bash 3.2 and bash 5.3, so a machine with either
+// exercises the same guards.
 func runValidate(t *testing.T, script string, in inputs) (bool, string) {
 	t.Helper()
 
@@ -226,13 +233,58 @@ func TestAttestValidationRejects(t *testing.T) {
 			inputs{"IN_SUBJECT_NAME": managerImage + ":v1.2.3"},
 			"without a tag or digest",
 		},
+		// artifact_name and predicate_name each had a traversal case; this one
+		// did not, and subject_name reaches `path="subject/${SUBJECT_NAME}"`
+		// in the job that holds the signing token.
+		"path traversal in blob subject_name": {
+			inputs{
+				"IN_SUBJECT_KIND":  "blob",
+				"IN_SUBJECT_NAME":  "../../etc/passwd",
+				"IN_SUBJECT_TAG":   "",
+				"IN_ARTIFACT_NAME": "cli-binaries",
+			},
+			"must be a plain file name for a blob subject",
+		},
+		"blob subject_name with a path separator": {
+			inputs{
+				"IN_SUBJECT_KIND":  "blob",
+				"IN_SUBJECT_NAME":  "nested/nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":   "",
+				"IN_ARTIFACT_NAME": "cli-binaries",
+			},
+			"must be a plain file name for a blob subject",
+		},
+		// Distinct from "subject_tag is required": an empty tag trips the
+		// emptiness guard and never reaches the format guard.
+		"malformed subject_tag": {
+			inputs{"IN_SUBJECT_TAG": "v1/2.3"},
+			"subject_tag is not a valid OCI tag",
+		},
+		"subject_tag starting with a dash": {
+			inputs{"IN_SUBJECT_TAG": "-v1.2.3"},
+			"subject_tag is not a valid OCI tag",
+		},
+		"over-long subject_tag": {
+			inputs{"IN_SUBJECT_TAG": strings.Repeat("v", 129)},
+			"subject_tag is not a valid OCI tag",
+		},
+		// artifact_name is required whenever predicate_name is set, including
+		// for image subjects where it is otherwise optional. Only the blob
+		// requirement was covered.
+		"image predicate without artifact_name": {
+			inputs{
+				"IN_PREDICATE_NAME": "sbom.cyclonedx.json",
+				"IN_PREDICATE_TYPE": "cyclonedx",
+			},
+			"artifact_name is required when predicate_name is set",
+		},
 		"blob without artifact_name": {
 			inputs{
 				"IN_SUBJECT_KIND": "blob",
 				"IN_SUBJECT_NAME": "nvcrectl-linux-amd64",
 				"IN_SUBJECT_TAG":  "",
 			},
-			"artifact_name is required",
+			"artifact_name is required when subject_kind is blob",
 		},
 		// An untyped predicate would be signed as cosign's `custom` default,
 		// which no documented verification command asks for.

--- a/test/releasepolicy/attest_guards_test.go
+++ b/test/releasepolicy/attest_guards_test.go
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package releasepolicy tests invariants of the release-path workflows.
+//
+// attest.yml holds the release signing identity, and its input validation is
+// the gate that stands between a caller and that identity. The validation is
+// shell embedded in YAML, which nothing else in the repository type-checks or
+// exercises: a weakened regex or a dropped guard would not break any build, it
+// would just stop rejecting things. These tests execute that shell directly so
+// that a regression fails `make test` rather than shipping.
+package releasepolicy
+
+import (
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+const attestWorkflow = "../../.github/workflows/attest.yml"
+
+// validDigest is a well-formed sha256 digest: the shape every guard below is
+// measured against, so a case fails for the reason it names and not because
+// the digest happened to be malformed too.
+const validDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+const managerImage = "ghcr.io/nvidia/cluster-readiness-engine/manager"
+
+// workflow is the subset of the workflow schema these tests read.
+type workflow struct {
+	Jobs map[string]struct {
+		Steps []struct {
+			ID  string `json:"id"`
+			Run string `json:"run"`
+		} `json:"steps"`
+	} `json:"jobs"`
+}
+
+// validateScript returns the body of attest.yml's input-validation step.
+//
+// Extracting it from the workflow rather than keeping a copy here is the point:
+// a copy would drift, and a drifted copy would keep passing while the real
+// validation rotted.
+func validateScript(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(attestWorkflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", attestWorkflow, err)
+	}
+
+	var wf workflow
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse %s: %v", attestWorkflow, err)
+	}
+
+	job, ok := wf.Jobs["validate"]
+	if !ok {
+		t.Fatalf("%s has no `validate` job; input validation must not be removed", attestWorkflow)
+	}
+	for _, step := range job.Steps {
+		if step.ID == "check" {
+			return step.Run
+		}
+	}
+	t.Fatalf("%s `validate` job has no step with id `check`", attestWorkflow)
+	return ""
+}
+
+// inputs are the workflow_call inputs as the validate step sees them, plus the
+// caller ref. Defaults mirror a well-formed tagged image call so each test case
+// changes only the field it is about.
+type inputs map[string]string
+
+func defaultInputs() inputs {
+	return inputs{
+		"IN_SUBJECT_KIND":    "image",
+		"IN_SUBJECT_NAME":    managerImage,
+		"IN_SUBJECT_TAG":     "v1.2.3",
+		"IN_PLATFORM":        "",
+		"IN_EXPECTED_DIGEST": validDigest,
+		"IN_ARTIFACT_NAME":   "",
+		"IN_PREDICATE_NAME":  "",
+		"IN_PREDICATE_TYPE":  "",
+		"IN_COSIGN_VERSION":  "v3.1.3",
+		"IN_CRANE_VERSION":   "v0.20.6",
+		"IN_ALLOW_UNTAGGED":  "false",
+		"CALLER_REF":         "refs/tags/v1.2.3",
+	}
+}
+
+func (in inputs) with(overrides inputs) inputs {
+	out := inputs{}
+	maps.Copy(out, in)
+	maps.Copy(out, overrides)
+	return out
+}
+
+// runValidate executes the validation body and reports its exit status and
+// combined output.
+func runValidate(t *testing.T, script string, in inputs) (bool, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "validate.sh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cmd := exec.Command("bash", path)
+	cmd.Env = append(os.Environ(), "GITHUB_OUTPUT="+filepath.Join(t.TempDir(), "out"))
+	for k, v := range in {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	out, err := cmd.CombinedOutput()
+	return err == nil, string(out)
+}
+
+// TestAttestValidationAccepts covers the shapes real callers will use. A guard
+// that rejects everything is not a working guard.
+func TestAttestValidationAccepts(t *testing.T) {
+	script := validateScript(t)
+
+	cases := map[string]inputs{
+		"tagged image": {},
+		"per-platform image": {
+			"IN_PLATFORM": "linux/amd64",
+		},
+		"oci artifact (helm chart)": {
+			"IN_SUBJECT_KIND": "oci-artifact",
+			"IN_SUBJECT_NAME": "ghcr.io/nvidia/cluster-readiness-engine",
+		},
+		"blob": {
+			"IN_SUBJECT_KIND":  "blob",
+			"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
+			"IN_SUBJECT_TAG":   "",
+			"IN_ARTIFACT_NAME": "cli-binaries",
+		},
+		"blob with sbom predicate": {
+			"IN_SUBJECT_KIND":   "blob",
+			"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
+			"IN_SUBJECT_TAG":    "",
+			"IN_ARTIFACT_NAME":  "cli-binaries",
+			"IN_PREDICATE_NAME": "sbom.cyclonedx.json",
+			"IN_PREDICATE_TYPE": "cyclonedx",
+		},
+		// The non-production escape hatch, which exists so the guards can be
+		// exercised by dispatch at all. It must still work.
+		"untagged ref with allow_untagged": {
+			"CALLER_REF":        "refs/heads/main",
+			"IN_SUBJECT_TAG":    "main-abc1234",
+			"IN_ALLOW_UNTAGGED": "true",
+		},
+	}
+
+	for name, overrides := range cases {
+		t.Run(name, func(t *testing.T) {
+			ok, out := runValidate(t, script, defaultInputs().with(overrides))
+			if !ok {
+				t.Errorf("validation rejected a legitimate call:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestAttestValidationRejects is the substance. Each case is a way a caller
+// could reach the signing identity with something it should not, and the
+// wantErr string pins the rejection to the guard that is supposed to catch it
+// — so a case cannot start passing for an unrelated reason.
+func TestAttestValidationRejects(t *testing.T) {
+	script := validateScript(t)
+
+	cases := map[string]struct {
+		overrides inputs
+		wantErr   string
+	}{
+		// Release attestations come from tags. Without this, a branch build
+		// signs under an identity users are told to trust.
+		"non-tag ref without allow_untagged": {
+			inputs{"CALLER_REF": "refs/heads/main"},
+			"refuses to run on refs/heads/main",
+		},
+		"digest with non-hex characters": {
+			inputs{"IN_EXPECTED_DIGEST": "sha256:zzzz"},
+			"expected_digest must match",
+		},
+		// Uppercase hex is a different string to cosign and to the registry, so
+		// accepting it would let two spellings of one digest diverge.
+		"digest with uppercase hex": {
+			inputs{"IN_EXPECTED_DIGEST": "sha256:AAAA111111111111111111111111111111111111111111111111111111111111"},
+			"expected_digest must match",
+		},
+		"digest missing the sha256 prefix": {
+			inputs{"IN_EXPECTED_DIGEST": strings.TrimPrefix(validDigest, "sha256:")},
+			"expected_digest must match",
+		},
+		// A newline lets a value forge extra lines in GITHUB_OUTPUT.
+		"newline in subject_name": {
+			inputs{"IN_SUBJECT_NAME": managerImage + "\nevil=1"},
+			"newline or carriage return",
+		},
+		"carriage return in subject_tag": {
+			inputs{"IN_SUBJECT_TAG": "v1.2.3\rx"},
+			"newline or carriage return",
+		},
+		"unknown subject_kind": {
+			inputs{"IN_SUBJECT_KIND": "sbom"},
+			"subject_kind must be",
+		},
+		// Without a tag there is nothing to resolve the digest from except the
+		// digest itself, which is the tautology this guard exists to prevent.
+		"image without subject_tag": {
+			inputs{"IN_SUBJECT_TAG": ""},
+			"subject_tag is required",
+		},
+		"subject_name carrying a digest": {
+			inputs{"IN_SUBJECT_NAME": managerImage + "@" + validDigest},
+			"without a tag or digest",
+		},
+		"subject_name carrying a tag": {
+			inputs{"IN_SUBJECT_NAME": managerImage + ":v1.2.3"},
+			"without a tag or digest",
+		},
+		"blob without artifact_name": {
+			inputs{
+				"IN_SUBJECT_KIND": "blob",
+				"IN_SUBJECT_NAME": "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":  "",
+			},
+			"artifact_name is required",
+		},
+		// An untyped predicate would be signed as cosign's `custom` default,
+		// which no documented verification command asks for.
+		"predicate without predicate_type": {
+			inputs{
+				"IN_SUBJECT_KIND":   "blob",
+				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":    "",
+				"IN_ARTIFACT_NAME":  "cli-binaries",
+				"IN_PREDICATE_NAME": "sbom.json",
+			},
+			"predicate_type is required",
+		},
+		"predicate_type outside the allowed set": {
+			inputs{
+				"IN_SUBJECT_KIND":   "blob",
+				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":    "",
+				"IN_ARTIFACT_NAME":  "cli-binaries",
+				"IN_PREDICATE_NAME": "sbom.json",
+				"IN_PREDICATE_TYPE": "custom",
+			},
+			"predicate_type must be one of",
+		},
+		"path traversal in predicate_name": {
+			inputs{
+				"IN_SUBJECT_KIND":   "blob",
+				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":    "",
+				"IN_ARTIFACT_NAME":  "cli-binaries",
+				"IN_PREDICATE_NAME": "../../etc/passwd",
+				"IN_PREDICATE_TYPE": "cyclonedx",
+			},
+			"predicate_name must match",
+		},
+		"path traversal in artifact_name": {
+			inputs{
+				"IN_SUBJECT_KIND":  "blob",
+				"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":   "",
+				"IN_ARTIFACT_NAME": "../secrets",
+			},
+			"artifact_name must match",
+		},
+		"platform on a blob subject": {
+			inputs{
+				"IN_SUBJECT_KIND":  "blob",
+				"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
+				"IN_SUBJECT_TAG":   "",
+				"IN_ARTIFACT_NAME": "cli-binaries",
+				"IN_PLATFORM":      "linux/amd64",
+			},
+			"platform is meaningless",
+		},
+		"platform without an os/arch pair": {
+			inputs{"IN_PLATFORM": "amd64"},
+			"platform must be os/arch",
+		},
+		// The version pin is what fixes the emitted bundle format, so a
+		// floating value would let the on-registry layout drift.
+		"floating cosign version": {
+			inputs{"IN_COSIGN_VERSION": "latest"},
+			"cosign_version must be",
+		},
+		"floating crane version": {
+			inputs{"IN_CRANE_VERSION": "main"},
+			"crane_version must be",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ok, out := runValidate(t, script, defaultInputs().with(tc.overrides))
+			if ok {
+				t.Fatalf("validation accepted a call it must reject; expected an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(out, tc.wantErr) {
+				t.Errorf("rejected, but not by the expected guard.\nwant error containing: %q\ngot:\n%s", tc.wantErr, out)
+			}
+		})
+	}
+}
+
+// TestAttestWorkflowIsGatedToThisRepository pins the guard that keeps outside
+// repositories away from the release signing identity.
+//
+// `workflow_call` on a public repository is callable by anyone, and in a called
+// reusable workflow `github.repository` is the *caller's* repository. Without
+// this condition on every job, an outside repository could invoke attest.yml at
+// one of our release tags and obtain a Fulcio certificate whose SAN is the
+// identity SECURITY.md tells users to pin.
+func TestAttestWorkflowIsGatedToThisRepository(t *testing.T) {
+	raw, err := os.ReadFile(attestWorkflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", attestWorkflow, err)
+	}
+
+	var wf struct {
+		Jobs map[string]struct {
+			If string `json:"if"`
+		} `json:"jobs"`
+	}
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse %s: %v", attestWorkflow, err)
+	}
+	if len(wf.Jobs) == 0 {
+		t.Fatal("attest.yml declares no jobs")
+	}
+
+	const want = "github.repository == 'NVIDIA/cluster-readiness-engine'"
+	for name, job := range wf.Jobs {
+		if !strings.Contains(job.If, want) {
+			t.Errorf("job %q is missing the caller gate %s; a public reusable workflow without it "+
+				"lets any repository sign under this repository's release identity", name, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two ways to exercise `attest.yml`, the reusable workflow that holds the release signing identity. Its input validation is shell embedded in YAML: nothing type-checks it, and a weakened guard would not break a build — it would just quietly stop rejecting things.

### `test/releasepolicy/attest_guards_test.go`

Extracts attest.yml's `validate` step **from the workflow YAML** and executes that shell against 31 input sets — 6 shapes real callers will use, 25 ways a caller could reach the signing identity with something it should not:

non-tag refs · uppercase-hex and unprefixed digests · newline and CR injection · `subject_name` smuggling its own tag or digest · path traversal in `subject_name`, `artifact_name` and `predicate_name` · malformed, dash-leading and over-long `subject_tag` · untyped and unknown predicate types · `platform` on a blob · floating tool versions.

Each rejection asserts the specific error string, so a case cannot start passing for an unrelated reason. Two guards both begin `"artifact_name is required"`, so those cases pin the full message rather than the shared prefix.

The script is **extracted, not copied**. A copy would drift, and a drifted copy would keep passing while the real validation rotted.

A separate test asserts every job in attest.yml carries `github.repository == 'NVIDIA/cluster-readiness-engine'` — the guard that stops any repository on GitHub from invoking this public reusable workflow at one of our release tags and obtaining a Fulcio certificate matching the identity `SECURITY.md` tells users to pin.

### `.github/workflows/attest-selftest.yml`

attest.yml is `workflow_call`-only, so it cannot be dispatched directly and cannot be exercised from a PR branch at all — GitHub only surfaces `workflow_dispatch` entry points that exist on the default branch. This is that entry point.

It targets one failure mode in particular: **a job whose `if` is false is skipped, and a skipped job does not fail its caller.** A subtly wrong caller gate would leave every future caller green while signing nothing. The `report` job treats `skipped` as a hard error rather than letting it read as success.

Scope is honest: `subject_kind` is fixed to `image`, so a green run proves the image path only — not `oci-artifact`, not `blob`, not predicate attestation. Those arrive with the chart and binary callers.

It signs under a branch ref, so the Fulcio SAN carries `@refs/heads/...` and cannot be verified as a release attestation.

## Related Issue

Part of #265, seeds #274. Deliberately **not** `Closes` — see below.

## Type of Change
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation / CI

## Testing

- `go test ./test/releasepolicy/` — 31 subtests pass. Also verified under **macOS bash 3.2** as well as bash 5.3, since the test shells out via `PATH`; the extracted script uses only bash 2.0-era constructs.
- **Mutation-tested, not just green.** Removing the caller gate, relaxing the digest regex to accept uppercase hex, and relaxing the `subject_name`/`subject_tag` regexes to `.+` each fail the suite with the message naming the guard. A test that never fails is not evidence.
- `actionlint` passes on both workflows; every input description round-trips through a YAML parse.
- `make verify`, `make check-agents-sync` pass.

`make lint` panics **locally** with `file requires newer Go version go1.27 (application built with go1.26)`. Verified pre-existing — it panics identically on clean `main`. Local Go is 1.27.1, go.mod pins 1.26.6, golangci-lint v2.11.4 was built with go1.26. CI lint is unaffected.

### Self-review findings

The five-persona review on this branch found three guards with **zero coverage in the very test whose purpose is coverage**: blob `subject_name` had no malformed case at all (while its two sibling fields each had a traversal case), `subject_tag` was only ever empty or valid so the format guard was never reached, and the `predicate_name`-requires-`artifact_name` rule was untested for image subjects. Six cases added.

It also caught the header claiming a green run proves "the whole signing path works end to end" — it does not, and the bullet list two lines above it already said so. Narrowed.

Also fixed: a stray trailing apostrophe left by converting three input descriptions from quoted scalars to `>-` blocks, two of them in already-merged `attest.yml`, where the character would have shown up in the rendered `workflow_call` input docs.

- [x] Tests pass locally
- [x] Manual testing completed — mutation testing described above
- [x] No breaking changes (or documented)

## Follow-ups recorded

- `CLAUDE.md` / `AGENTS.md` documented two test patterns; this is a third, structurally different one. Both updated together so `check-agents-sync` stays green.
- #273 and #275 now record that non-release-ref Rekor entries from the self-test are expected, so neither reads one as tampering.

## What is still not proven

#265 stays **open** after this merges. The dispatch run has not happened yet — it cannot, until this workflow is on the default branch. Once merged I will dispatch it against a current `main-<sha>` image to confirm the caller gate admits this repository, `builder.id` derives from `GITHUB_WORKFLOW_REF`, and crane and cosign reach their services. Only then does #265 close.

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated (if needed) — CLAUDE.md + AGENTS.md
- [x] Ready for review
