### PR TITLE
chore: go upgrade to 1.27

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `ci`,
 ## Development Setup
 
 **Prerequisites**:
-- Go 1.26+
+- Go 1.27+
 - Docker (for container builds)
 - Make (for build targets)
 

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.13.2
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -389,9 +389,15 @@ scan-vuln: govulncheck ## Scan Go dependencies for known vulnerabilities.
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+# Installed with `go install` like every other tool here rather than upstream's
+# install.sh. That script was fetched from `master` — an unpinned reference that
+# can change with no commit here — and its checksum check greps the tarball name
+# unanchored against checksums.txt. Since v2.13.x ships a
+# `<tarball>.tar.gz.sbom.json` asset, that grep matches two lines, so the
+# comparison sees two hashes and fails on a tarball that downloaded correctly.
+# `go install` pins the version and verifies it through the Go checksum database.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	@test -s $(GOLANGCI_LINT) || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA/cluster-readiness-engine/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
+[![Go](https://img.shields.io/badge/Go-1.27+-00ADD8.svg)](go.mod)
 
 New GPU clusters often contain faulty nodes, and those faults surface only under real distributed load. NVCRE is a Kubernetes controller that certifies GPU clusters before production workloads run on them. It runs real training and communication workloads across topology-aware node groups, measures performance, detects hardware failures, and reports every bad node with a reason. Quarantine is left to your platform: NVCRE never cordons, taints, or otherwise modifies a node.
 

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -195,10 +195,8 @@ func generateTestNodes(t *testing.T, c client.Client, spec *generateNodesSpec) {
 		labels["kubernetes.io/hostname"] = name
 		maps.Copy(labels, spec.Labels)
 		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-			},
+			Name:   name,
+			Labels: labels,
 			Spec: corev1.NodeSpec{
 				ProviderID: spec.ProviderID,
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/cluster-readiness-engine
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -36,7 +36,7 @@ type lookupInput struct {
 func TestLookup(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "lookup",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input lookupInput

--- a/pkg/catalog/gpu_defaults_test.go
+++ b/pkg/catalog/gpu_defaults_test.go
@@ -19,7 +19,7 @@ type gpuDefaultsInput struct {
 func TestGPUDefaults(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "gpu-defaults",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input gpuDefaultsInput

--- a/pkg/catalog/resources_test.go
+++ b/pkg/catalog/resources_test.go
@@ -30,7 +30,7 @@ type resourcesInput struct {
 func TestTrainingResources(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "resources",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input resourcesInput

--- a/pkg/catalog/test_scale_test.go
+++ b/pkg/catalog/test_scale_test.go
@@ -24,7 +24,7 @@ import (
 func TestTestScaleNodeCount(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "test-scale-node-count",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/certification/certification.go
+++ b/pkg/certification/certification.go
@@ -70,6 +70,10 @@ func newListCategoriesCommand() *cobra.Command {
 
 const outputJSON = "json"
 
+// nvcreAPIVersion is the apiVersion string used for rendered nvcre.nvidia.com
+// resources (Certification, etc.).
+const nvcreAPIVersion = "nvcre.nvidia.com/v1alpha1"
+
 func runListCategories(format string) error {
 	categories := catalog.List()
 
@@ -344,18 +348,14 @@ func renderCertification(cert *nvcrev1alpha1.Certification, platformName string)
 		)
 
 		workflow := nvcrev1alpha1.Workflow{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "nvcre.nvidia.com/v1alpha1",
-				Kind:       "Workflow",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: workflowName,
-				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":      "nvcre",
-					"nvcre.nvidia.com/certification":    cert.Name,
-					"nvcre.nvidia.com/category-domain":  cat.Domain,
-					"nvcre.nvidia.com/category-variant": cat.Variant,
-				},
+			APIVersion: nvcreAPIVersion,
+			Kind:       "Workflow",
+			Name:       workflowName,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":      "nvcre",
+				"nvcre.nvidia.com/certification":    cert.Name,
+				"nvcre.nvidia.com/category-domain":  cat.Domain,
+				"nvcre.nvidia.com/category-variant": cat.Variant,
 			},
 			Spec: workflowSpec,
 		}
@@ -424,7 +424,7 @@ func platformToProviderID(platformName string) string {
 // detection needs to map the node back to the requested platform.
 func syntheticRenderNode(platformName string, nodeSelector map[string]string) corev1.Node {
 	node := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Labels: nodeSelector},
+		Labels: nodeSelector,
 	}
 	if platformName == "" {
 		return node
@@ -730,17 +730,13 @@ func buildConfigFromFlags(
 	_, _ = fmt.Fprintf(out, "Discovered GPU nodes with product: %s\n", gpuProduct)
 
 	cert := &nvcrev1alpha1.Certification{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "nvcre.nvidia.com/v1alpha1",
-			Kind:       "Certification",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "nvcre",
-				"app.kubernetes.io/created-by": "nvcrectl",
-			},
+		APIVersion: nvcreAPIVersion,
+		Kind:       "Certification",
+		Name:       name,
+		Namespace:  namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by": "nvcre",
+			"app.kubernetes.io/created-by": "nvcrectl",
 		},
 		Spec: nvcrev1alpha1.CertificationSpec{
 			Target: nvcrev1alpha1.TargetSpec{
@@ -897,7 +893,7 @@ func executeCertificationRun(cfg *certRunConfig) (pipelineErr error) {
 			// terminated".
 			if createdNamespace != "" {
 				_, _ = fmt.Fprintf(out, "[cleanup] Deleting namespace %s...\n", createdNamespace)
-				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: createdNamespace}}
+				ns := &corev1.Namespace{Name: createdNamespace}
 				if err := wc.Delete(cleanupCtx, ns); err != nil && !apierrors.IsNotFound(err) {
 					_, _ = fmt.Fprintf(out, "[cleanup] Warning: failed to delete namespace %s: %v\n", createdNamespace, err)
 					warnings = true
@@ -968,9 +964,8 @@ func executeCertificationRun(cfg *certRunConfig) (pipelineErr error) {
 		// belonging to a concurrent run). Attempt delete unconditionally — if
 		// namespace deletion will cascade later, the delete will be a no-op NotFound.
 		if wasCreatedByUs {
-			pullSec := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name: setup.WorkloadPullSecretName(cfg.cert.Name), Namespace: cfg.namespace,
-			}}
+			pullSec := &corev1.Secret{
+				Name: setup.WorkloadPullSecretName(cfg.cert.Name), Namespace: cfg.namespace}
 			_ = wc.Delete(ctx, pullSec)
 		}
 		return fmt.Errorf("create certification: %w", err)
@@ -988,7 +983,7 @@ func executeCertificationRun(cfg *certRunConfig) (pipelineErr error) {
 				setup.WorkloadPullSecretName(cfg.cert.Name), getErr)
 		} else {
 			sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
-				APIVersion: "nvcre.nvidia.com/v1alpha1",
+				APIVersion: nvcreAPIVersion,
 				Kind:       "Certification",
 				Name:       cfg.cert.Name,
 				UID:        cfg.cert.UID,

--- a/pkg/certification/certification_test.go
+++ b/pkg/certification/certification_test.go
@@ -35,6 +35,15 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/kubeconfig"
 )
 
+const (
+	testDomainCommunication   = "communication"
+	testVariantNCCLAllReduce  = "nccl-all-reduce"
+	testCategoryNCCLAllReduce = testDomainCommunication + "/" + testVariantNCCLAllReduce
+	testCategoryFlag          = "--category"
+	testCertTimeoutCert       = "timeout-cert"
+	testCertNamespace         = "test-ns"
+)
+
 func newCertificationFakeClient(t testing.TB, objects ...client.Object) client.WithWatch {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -92,7 +101,7 @@ func normalizeCertificationReportOutput(output string) string {
 func TestCatalogListCategories(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "list-categories",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		categories := catalog.List()
@@ -109,7 +118,7 @@ func TestCatalogListCategories(t *testing.T) {
 func TestCertificationRender(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "certification-render",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		certPath := filepath.Join(t.TempDir(), "certification.yaml")
@@ -161,7 +170,7 @@ func TestCertificationRender(t *testing.T) {
 func TestCategoryWatchLabels(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "category-watch-labels",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cert nvcrev1alpha1.Certification
@@ -181,7 +190,7 @@ func TestCategoryWatchLabels(t *testing.T) {
 func TestCertificationRenderErrors(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "certification-render-errors",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -230,16 +239,16 @@ func TestCertificationRenderErrors(t *testing.T) {
 
 func TestParseCategories(t *testing.T) {
 	t.Run("valid single", func(t *testing.T) {
-		cats, err := parseCategories([]string{"communication/nccl-all-reduce"})
+		cats, err := parseCategories([]string{testCategoryNCCLAllReduce})
 		require.NoError(t, err)
 		require.Len(t, cats, 1)
-		assert.Equal(t, "communication", cats[0].Domain)
-		assert.Equal(t, "nccl-all-reduce", cats[0].Variant)
+		assert.Equal(t, testDomainCommunication, cats[0].Domain)
+		assert.Equal(t, testVariantNCCLAllReduce, cats[0].Variant)
 	})
 
 	t.Run("valid multiple", func(t *testing.T) {
 		cats, err := parseCategories([]string{
-			"communication/nccl-all-reduce",
+			testCategoryNCCLAllReduce,
 			"training/nemotron5-8b",
 		})
 		require.NoError(t, err)
@@ -247,7 +256,7 @@ func TestParseCategories(t *testing.T) {
 	})
 
 	t.Run("invalid format no slash", func(t *testing.T) {
-		_, err := parseCategories([]string{"nccl-all-reduce"})
+		_, err := parseCategories([]string{testVariantNCCLAllReduce})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected domain/variant")
 	})
@@ -277,7 +286,7 @@ func TestGenerateCertName(t *testing.T) {
 func TestCertificationNamespace(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "certification-namespace",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -350,7 +359,7 @@ func TestGenerateCertNameAndNamespaceAreIndependent(t *testing.T) {
 func TestPlatformToProviderID(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "platform-to-provider-id",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -391,7 +400,7 @@ func TestPlatformToProviderID(t *testing.T) {
 func TestRenderPlatformFlag(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "render-platform-flag",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -489,10 +498,10 @@ spec:
 		cert, err := readCertification(path)
 		require.NoError(t, err)
 		assert.Equal(t, "test-cert", cert.Name)
-		assert.Equal(t, "test-ns", cert.Namespace)
+		assert.Equal(t, testCertNamespace, cert.Namespace)
 		require.Len(t, cert.Spec.Categories, 1)
-		assert.Equal(t, "communication", cert.Spec.Categories[0].Domain)
-		assert.Equal(t, "nccl-all-reduce", cert.Spec.Categories[0].Variant)
+		assert.Equal(t, testDomainCommunication, cert.Spec.Categories[0].Domain)
+		assert.Equal(t, testVariantNCCLAllReduce, cert.Spec.Categories[0].Variant)
 	})
 
 	t.Run("nonexistent file", func(t *testing.T) {
@@ -515,7 +524,7 @@ func TestWatchCertificationImmediateTimeout(t *testing.T) {
 	wc := newCertificationFakeClient(t)
 	var out bytes.Buffer
 
-	cert, err := watchCertification(context.Background(), wc, "timeout-cert", "test-ns", 0, &out)
+	cert, err := watchCertification(context.Background(), wc, testCertTimeoutCert, testCertNamespace, 0, &out)
 
 	assert.Nil(t, cert)
 	require.Error(t, err)
@@ -554,7 +563,7 @@ func TestProcessWatchEventsContextDoneDuringActiveWatch(t *testing.T) {
 func TestFinishCertificationWaitTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "finish-certification-wait-timeout",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -567,19 +576,19 @@ func TestFinishCertificationWaitTimeout(t *testing.T) {
 			return err
 		}
 		if input.Name == "" {
-			input.Name = "timeout-cert"
+			input.Name = testCertTimeoutCert
 		}
 
 		cert := &nvcrev1alpha1.Certification{
-			ObjectMeta: metav1.ObjectMeta{Name: input.Name, Namespace: "test-ns"},
+			Name: input.Name, Namespace: testCertNamespace,
 			Spec: nvcrev1alpha1.CertificationSpec{
 				Categories: []nvcrev1alpha1.CertificateCategory{{
-					Domain: "communication", Variant: "nccl-all-reduce",
+					Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce,
 				}},
 			},
 			Status: nvcrev1alpha1.CertificationStatus{
 				CategoryStatuses: []nvcrev1alpha1.CertificationCategoryStatus{{
-					Domain: "communication", Variant: "nccl-all-reduce", Status: "InProgress",
+					Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce, Status: "InProgress",
 				}},
 			},
 		}
@@ -632,7 +641,7 @@ func TestFinishCertificationWaitTimeout(t *testing.T) {
 
 func TestFinishCertificationWaitBoundsPostTimeoutReads(t *testing.T) {
 	cert := &nvcrev1alpha1.Certification{
-		ObjectMeta: metav1.ObjectMeta{Name: "timeout-cert", Namespace: "test-ns"},
+		Name: testCertTimeoutCert, Namespace: testCertNamespace,
 	}
 	wc := &certificationDeadlineClient{WithWatch: newCertificationFakeClient(t, cert)}
 	var out bytes.Buffer
@@ -647,13 +656,13 @@ func TestFinishCertificationWaitBoundsPostTimeoutReads(t *testing.T) {
 }
 
 func TestExecuteCertificationRunReportsBeforeCleanup(t *testing.T) {
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+	namespace := &corev1.Namespace{Name: testCertNamespace}
 	wc := newCertificationFakeClient(t, namespace)
 	cert := &nvcrev1alpha1.Certification{
-		ObjectMeta: metav1.ObjectMeta{Name: "timeout-cert", Namespace: namespace.Name},
+		Name: testCertTimeoutCert, Namespace: namespace.Name,
 		Spec: nvcrev1alpha1.CertificationSpec{
 			Categories: []nvcrev1alpha1.CertificateCategory{{
-				Domain: "communication", Variant: "nccl-all-reduce",
+				Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce,
 			}},
 		},
 	}
@@ -685,7 +694,7 @@ func TestExecuteCertificationRunReportsBeforeCleanup(t *testing.T) {
 func TestFinishCertificationWaitTerminalAtTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "finish-certification-wait-terminal-at-timeout",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -696,7 +705,7 @@ func TestFinishCertificationWaitTerminalAtTimeout(t *testing.T) {
 		}
 
 		cert := &nvcrev1alpha1.Certification{
-			ObjectMeta: metav1.ObjectMeta{Name: "timeout-cert", Namespace: "test-ns"},
+			Name: testCertTimeoutCert, Namespace: testCertNamespace,
 			Status: nvcrev1alpha1.CertificationStatus{Conditions: []metav1.Condition{{
 				Type: input.ConditionType, Status: metav1.ConditionTrue,
 			}}},
@@ -716,7 +725,7 @@ func TestFinishCertificationWaitTerminalAtTimeout(t *testing.T) {
 
 func TestFinishCertificationWaitDoesNotMaskOtherWatchErrors(t *testing.T) {
 	cert := &nvcrev1alpha1.Certification{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-cert", Namespace: "test-ns"},
+		Name: "test-cert", Namespace: testCertNamespace,
 	}
 	wc := newCertificationFakeClient(t, cert)
 	resultsFile := filepath.Join(t.TempDir(), "results.json")
@@ -742,7 +751,7 @@ func TestParseCategoriesEdgeCases(t *testing.T) {
 	})
 
 	t.Run("triple slash", func(t *testing.T) {
-		// SplitN with n=2 means "communication" and "a/b"
+		// SplitN with n=2 means testDomainCommunication and "a/b"
 		_, err := parseCategories([]string{"communication/a/b"})
 		require.Error(t, err)
 		// "a/b" is not a valid variant in the catalog
@@ -763,7 +772,7 @@ func TestParseCategoriesEdgeCases(t *testing.T) {
 func TestNewRunCommandFlagDefaults(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "new-run-command-flag-defaults",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		cmd := newRunCommand("dev")
@@ -804,7 +813,7 @@ func TestNewRunCommandValidation(t *testing.T) {
 		cmd := newRunCommand("dev")
 		cmd.SetArgs([]string{
 			"--cert-file", "cert.yaml",
-			"--category", "communication/nccl-all-reduce",
+			testCategoryFlag, testCategoryNCCLAllReduce,
 		})
 		err := cmd.Execute()
 		require.Error(t, err)
@@ -854,7 +863,7 @@ func TestNewRunCommandCategoryRunOptsWiring(t *testing.T) {
 			}
 			return nil
 		}
-		cmd.SetArgs([]string{"--category", "communication/nccl-all-reduce"})
+		cmd.SetArgs([]string{testCategoryFlag, testCategoryNCCLAllReduce})
 		require.NoError(t, cmd.Execute())
 		assert.Nil(t, capturedOpts.enableCheckpoint, "omitted --enable-checkpoint should be nil")
 		assert.Nil(t, capturedOpts.enableMNNVL, "omitted --enable-mnnvl should be nil")
@@ -875,7 +884,7 @@ func TestNewRunCommandCategoryRunOptsWiring(t *testing.T) {
 			return nil
 		}
 		cmd.SetArgs([]string{
-			"--category", "communication/nccl-all-reduce",
+			testCategoryFlag, testCategoryNCCLAllReduce,
 			"--enable-checkpoint",
 			"--enable-mnnvl",
 		})
@@ -897,7 +906,7 @@ func TestNewRunCommandCategoryRunOptsWiring(t *testing.T) {
 			return nil
 		}
 		cmd.SetArgs([]string{
-			"--category", "communication/nccl-all-reduce",
+			testCategoryFlag, testCategoryNCCLAllReduce,
 			"--enable-mnnvl=false",
 		})
 		require.NoError(t, cmd.Execute())

--- a/pkg/certification/render_orchestration_test.go
+++ b/pkg/certification/render_orchestration_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -23,7 +22,7 @@ import (
 func TestRenderOrchestrationOptions(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "render-orchestration-options",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var opts nvcrev1alpha1.CategoryOptions
@@ -39,13 +38,13 @@ func TestRenderOrchestrationOptions(t *testing.T) {
 		if err := yaml.Unmarshal([]byte(tc.Inputs["input.yaml"]), &sel); err != nil {
 			return err
 		}
-		cat := nvcrev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+		cat := nvcrev1alpha1.CertificateCategory{Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce}
 		if sel.Category != nil {
 			cat = nvcrev1alpha1.CertificateCategory{Domain: sel.Category.Domain, Variant: sel.Category.Variant}
 		}
 
 		cert := &nvcrev1alpha1.Certification{
-			ObjectMeta: metav1.ObjectMeta{Name: "render-test"},
+			Name: "render-test",
 			Spec: nvcrev1alpha1.CertificationSpec{
 				Target: nvcrev1alpha1.TargetSpec{
 					NodeSelector: map[string]string{

--- a/pkg/certification/wait_timeout_test.go
+++ b/pkg/certification/wait_timeout_test.go
@@ -21,7 +21,7 @@ import (
 func TestResolveWaitTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "resolve-wait-timeout",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
@@ -21,7 +20,7 @@ import (
 // which is what a node shows before the device plugin advertises the resource.
 func gpuNode(name string, count int64) corev1.Node {
 	n := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Status: corev1.NodeStatus{
 			Allocatable: corev1.ResourceList{},
 			Conditions: []corev1.NodeCondition{
@@ -49,7 +48,7 @@ func TestNodeGPUCount(t *testing.T) {
 func TestBuildClusterInfoCountsRealGPUs(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-cluster-info-counts-real-gpus",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/controller/bandwidthmeasurement_controller.go
+++ b/pkg/controller/bandwidthmeasurement_controller.go
@@ -220,7 +220,7 @@ func (r *BandwidthMeasurementReconciler) handleRunning(ctx context.Context, meas
 	}
 
 	// Determine which pod to read logs from.
-	replicatedJobName := "node"
+	replicatedJobName := labelNode
 	if profile.Spec.WorkerStrategy != nil && profile.Spec.WorkerStrategy.ReplicatedJobName != "" {
 		replicatedJobName = profile.Spec.WorkerStrategy.ReplicatedJobName
 	}

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -15,6 +15,9 @@ import (
 // partitioned into a group — so it also defines the Node cache boundary.
 const GPUNodeLabel = "nvidia.com/gpu.present"
 
+// present is the label value indicating a node has the GPUNodeLabel set.
+const present = "true"
+
 // CacheOptions returns the informer cache configuration for the manager.
 //
 // Without it, controller-runtime caches every object of every watched kind,
@@ -44,7 +47,7 @@ func CacheOptions() cache.Options {
 		DefaultTransform: cache.TransformStripManagedFields(),
 		ByObject: map[client.Object]cache.ByObject{
 			&corev1.Node{}: {
-				Label: labels.SelectorFromSet(labels.Set{GPUNodeLabel: "true"}),
+				Label: labels.SelectorFromSet(labels.Set{GPUNodeLabel: present}),
 			},
 		},
 	}

--- a/pkg/controller/certification_archfilter_test.go
+++ b/pkg/controller/certification_archfilter_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -28,7 +27,7 @@ import (
 func TestResolveNodesPerJobAfterArchFilter(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "resolve-nodes-per-job-after-arch-filter",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -49,10 +48,9 @@ func TestResolveNodesPerJobAfterArchFilter(t *testing.T) {
 
 		nodes := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			nodes = append(nodes, corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			nodes = append(nodes, corev1.Node{
 				Name:   n.Name,
-				Labels: map[string]string{"nvidia.com/gpu.product": n.Product},
-			}})
+				Labels: map[string]string{testGPUProductLabel: n.Product}})
 		}
 
 		var entry *catalog.Entry
@@ -71,7 +69,7 @@ func TestResolveNodesPerJobAfterArchFilter(t *testing.T) {
 		}
 
 		opts := nvcrev1alpha1.CategoryOptions{NodesPerJob: input.NodesPerJob}
-		cat := nvcrev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+		cat := nvcrev1alpha1.CertificateCategory{Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce}
 
 		// The two steps the Certification controller performs, in order.
 		gpuArch, archNodes := detectGPUArchConsistent(nodes)

--- a/pkg/controller/certification_capacityfilter_test.go
+++ b/pkg/controller/certification_capacityfilter_test.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -29,7 +28,7 @@ import (
 func TestResolveNodesPerJobAfterCapacityFilter(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "resolve-nodes-per-job-after-capacity-filter",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -46,10 +45,9 @@ func TestResolveNodesPerJobAfterCapacityFilter(t *testing.T) {
 
 		nodes := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			node := corev1.Node{
 				Name:   n.Name,
-				Labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"},
-			}}
+				Labels: map[string]string{testGPUProductLabel: testGPUProductH100}}
 			if n.AllocatableGPUs != nil {
 				node.Status.Allocatable = corev1.ResourceList{
 					"nvidia.com/gpu": *resource.NewQuantity(*n.AllocatableGPUs, resource.DecimalSI),
@@ -59,7 +57,7 @@ func TestResolveNodesPerJobAfterCapacityFilter(t *testing.T) {
 		}
 
 		opts := nvcrev1alpha1.CategoryOptions{NodesPerJob: input.NodesPerJob}
-		cat := nvcrev1alpha1.CertificateCategory{Domain: "communication", Variant: "nccl-all-reduce"}
+		cat := nvcrev1alpha1.CertificateCategory{Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce}
 
 		// The steps the Certification controller performs, in order: arch
 		// detection first (gpusPerNode derives from it), then the capacity

--- a/pkg/controller/certification_controller.go
+++ b/pkg/controller/certification_controller.go
@@ -72,6 +72,7 @@ const (
 	annotationRequestedTestScale = "nvcre.nvidia.com/requested-test-scale"
 
 	labelManagedBy = "app.kubernetes.io/managed-by"
+	managedByValue = "nvcre"
 )
 
 // CertificationReconciler reconciles a Certification object
@@ -186,8 +187,7 @@ func (r *CertificationReconciler) initializeCategoryStatuses(ctx context.Context
 		}
 		// A foreign Workflow holds the generated name: terminal, no retry, and
 		// the collision is never recorded so cleanup cannot touch the object.
-		var collision *nameCollisionError
-		if errors.As(err, &collision) {
+		if collision, ok := errors.AsType[*nameCollisionError](err); ok {
 			log.Error(err, "Workflow name collision", "domain", firstCategory.Domain, "variant", firstCategory.Variant)
 			if statusErr := r.setCertificationFailed(ctx, certification, collision.Reason, err.Error()); statusErr != nil {
 				log.Error(statusErr, "Failed to update Certification status after Workflow name collision")
@@ -265,8 +265,7 @@ func (r *CertificationReconciler) processNextCategory(ctx context.Context, certi
 		}
 		// A foreign Workflow holds the generated name: terminal, no retry, and
 		// the collision is never recorded so cleanup cannot touch the object.
-		var collision *nameCollisionError
-		if errors.As(err, &collision) {
+		if collision, ok := errors.AsType[*nameCollisionError](err); ok {
 			log.Error(err, "Workflow name collision", "domain", category.Domain, "variant", category.Variant)
 			if statusErr := r.setCertificationFailed(ctx, certification, collision.Reason, err.Error()); statusErr != nil {
 				log.Error(statusErr, "Failed to update Certification status after Workflow name collision")
@@ -511,15 +510,13 @@ func (r *CertificationReconciler) createWorkflowForCategory(ctx context.Context,
 	// --- 5. Create Workflow ---
 	workflowName := r.getWorkflowName(certification, category)
 	workflow := &nvcrev1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      workflowName,
-			Namespace: certification.Namespace,
-			Labels: map[string]string{
-				labelManagedBy:       "nvcre",
-				labelCertification:   certification.Name,
-				labelCategoryDomain:  category.Domain,
-				labelCategoryVariant: category.Variant,
-			},
+		Name:      workflowName,
+		Namespace: certification.Namespace,
+		Labels: map[string]string{
+			labelManagedBy:       managedByValue,
+			labelCertification:   certification.Name,
+			labelCategoryDomain:  category.Domain,
+			labelCategoryVariant: category.Variant,
 		},
 		Spec: workflowSpec,
 	}

--- a/pkg/controller/collect_job_measured_values_test.go
+++ b/pkg/controller/collect_job_measured_values_test.go
@@ -26,7 +26,7 @@ import (
 func TestCollectJobMeasuredValues(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "collect-job-measured-values",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -48,8 +48,8 @@ func TestCollectJobMeasuredValues(t *testing.T) {
 
 		jobRef := corev1.TypedLocalObjectReference{Name: "j"}
 		gm := &nvcrev1alpha1.GoodputMeasurement{
-			ObjectMeta: metav1.ObjectMeta{Name: "j-goodput", Namespace: "ns"},
-			Spec:       nvcrev1alpha1.GoodputMeasurementSpec{JobRef: jobRef},
+			Name: "j-goodput", Namespace: "ns",
+			Spec: nvcrev1alpha1.GoodputMeasurementSpec{JobRef: jobRef},
 			Status: nvcrev1alpha1.GoodputMeasurementStatus{
 				Result:          in.Result,
 				AvgTFLOPSPerGPU: in.AvgTFLOPSPerGPU,
@@ -60,20 +60,20 @@ func TestCollectJobMeasuredValues(t *testing.T) {
 			gm.Status.Conditions = []metav1.Condition{{
 				Type:               nvcrev1alpha1.GoodputMeasurementComplete,
 				Status:             metav1.ConditionTrue,
-				Reason:             "JobSucceeded",
+				Reason:             reasonBandwidthJobSucceeded,
 				LastTransitionTime: metav1.Now(),
 			}}
 		}
 		bm := &nvcrev1alpha1.BandwidthMeasurement{
-			ObjectMeta: metav1.ObjectMeta{Name: "j-bandwidth", Namespace: "ns"},
-			Spec:       nvcrev1alpha1.BandwidthMeasurementSpec{JobRef: jobRef},
+			Name: "j-bandwidth", Namespace: "ns",
+			Spec: nvcrev1alpha1.BandwidthMeasurementSpec{JobRef: jobRef},
 			Status: nvcrev1alpha1.BandwidthMeasurementStatus{
 				Results: []nvcrev1alpha1.BandwidthResult{{
 					SizeBytes: 1 << 30, BusBW: in.BusBW, AlgBW: in.AlgBW, Samples: 1,
 				}},
 			},
 		}
-		job := &nvcrev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		job := &nvcrev1alpha1.Job{Name: "j", Namespace: "ns"}
 
 		gmIndex := func(obj client.Object) []string {
 			return []string{obj.(*nvcrev1alpha1.GoodputMeasurement).Spec.JobRef.Name}

--- a/pkg/controller/complete_terminal_group_test.go
+++ b/pkg/controller/complete_terminal_group_test.go
@@ -40,7 +40,7 @@ import (
 func TestCompleteTerminalGroup(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "complete-terminal-group",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -61,10 +61,10 @@ func TestCompleteTerminalGroup(t *testing.T) {
 		now := metav1.Now()
 
 		job := &nvcrev1alpha1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "wf-group-0-iter-1", Namespace: ns},
+			Name: "wf-group-0-iter-1", Namespace: ns,
 			Status: nvcrev1alpha1.JobStatus{
 				WorkloadRef: &nvcrev1alpha1.WorkloadReference{
-					APIVersion: "v1", Kind: "ConfigMap", Name: "workload-cm", Namespace: ns,
+					APIVersion: "v1", Kind: kindConfigMap, Name: "workload-cm", Namespace: ns,
 				},
 			},
 		}
@@ -86,7 +86,7 @@ func TestCompleteTerminalGroup(t *testing.T) {
 		}
 
 		workflow := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: ns},
+			Name: "wf", Namespace: ns,
 			Spec: nvcrev1alpha1.WorkflowSpec{
 				Orchestration: nvcrev1alpha1.OrchestrationSpec{
 					Execution: nvcrev1alpha1.ExecutionSpec{RetryFailedGroups: input.RetryFailedGroups},
@@ -94,18 +94,18 @@ func TestCompleteTerminalGroup(t *testing.T) {
 			},
 			Status: nvcrev1alpha1.WorkflowStatus{
 				DependencyRefs: []nvcrev1alpha1.DependencyResourceRef{{
-					APIVersion: "v1", Kind: "ConfigMap", Name: "dep-cm", Namespace: ns,
-					Scope: "job", GroupName: "group-0", Iteration: 1,
+					APIVersion: "v1", Kind: kindConfigMap, Name: "dep-cm", Namespace: ns,
+					Scope: labelJob, GroupName: "group-0", Iteration: 1,
 				}},
 				Orchestration: &nvcrev1alpha1.OrchestrationStatus{
 					TotalNodes: 1, NodesPerJob: 1, TotalGroups: 1, CurrentIteration: 1,
 					Groups: []nvcrev1alpha1.GroupStatus{{
 						Name:    "group-0",
-						Nodes:   []string{"node-a"},
+						Nodes:   []string{testNodeA},
 						Phase:   nvcrev1alpha1.GroupRunning,
 						Retries: input.GroupRetries,
 						JobRef: &nvcrev1alpha1.WorkloadReference{
-							APIVersion: nvcrev1alpha1.GroupVersion.String(), Kind: "Job",
+							APIVersion: nvcrev1alpha1.GroupVersion.String(), Kind: kindJob,
 							Name: job.Name, Namespace: ns,
 						},
 						StartTime: &now,
@@ -124,15 +124,13 @@ func TestCompleteTerminalGroup(t *testing.T) {
 
 		objs := []client.Object{
 			job.DeepCopy(),
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "dep-cm", Namespace: ns}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cm", Namespace: ns}},
+			&corev1.ConfigMap{Name: "dep-cm", Namespace: ns},
+			&corev1.ConfigMap{Name: "workload-cm", Namespace: ns},
 		}
 		for _, sp := range input.Pods {
 			objs = append(objs, &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sp.Name, Namespace: ns,
-					Labels: map[string]string{nodemonitor.NVCREJobLabel: job.Name},
-				},
+				Name: sp.Name, Namespace: ns,
+				Labels: map[string]string{nodemonitor.NVCREJobLabel: job.Name},
 				Status: corev1.PodStatus{Phase: corev1.PodPhase(sp.Phase)},
 			})
 		}

--- a/pkg/controller/discover_cordoned_test.go
+++ b/pkg/controller/discover_cordoned_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -27,7 +26,7 @@ import (
 func TestDiscoverCordonedNodes(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "discover-cordoned",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -46,10 +45,10 @@ func TestDiscoverCordonedNodes(t *testing.T) {
 
 		given := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			node := corev1.Node{Name: n.Name}
 			if !n.Unlabelled {
 				node.Labels = map[string]string{
-					"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
+					testGPUProductLabel: testGPUProductH100,
 				}
 				if !n.NoGPU {
 					node.Labels[GPUNodeLabel] = present

--- a/pkg/controller/discover_node_order_test.go
+++ b/pkg/controller/discover_node_order_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -40,7 +39,7 @@ func (u unorderedReader) Get(_ context.Context, _ client.ObjectKey, _ client.Obj
 func TestDiscoverNodeOrder(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "discover-node-order",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -52,19 +51,18 @@ func TestDiscoverNodeOrder(t *testing.T) {
 
 		given := make([]corev1.Node, 0, len(input.Nodes))
 		for _, name := range input.Nodes {
-			given = append(given, corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			given = append(given, corev1.Node{
 				Name: name,
 				Labels: map[string]string{
-					"nvidia.com/gpu.present": "true",
-					"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
-				},
-			}})
+					"nvidia.com/gpu.present": present,
+					testGPUProductLabel:      testGPUProductH100,
+				}})
 		}
 
 		nodes, _, err := discoverTargetNodes(context.Background(),
 			unorderedReader{nodes: given},
 			&nvcrev1alpha1.TargetSpec{
-				NodeSelector: map[string]string{"nvidia.com/gpu.present": "true"},
+				NodeSelector: map[string]string{"nvidia.com/gpu.present": present},
 			})
 		if err != nil {
 			return err

--- a/pkg/controller/event_helpers_test.go
+++ b/pkg/controller/event_helpers_test.go
@@ -6,8 +6,6 @@ package controller
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 )
 
@@ -24,7 +22,7 @@ func TestCertificationWarnfNilRecorder(t *testing.T) {
 
 	r := &CertificationReconciler{} // Recorder deliberately unset
 	cert := &nvcrev1alpha1.Certification{
-		ObjectMeta: metav1.ObjectMeta{Name: "cert", Namespace: "default"},
+		Name: "cert", Namespace: testNS,
 	}
 
 	r.warnf(cert, ReasonWorkflowCreationError,
@@ -38,7 +36,7 @@ func TestGoodputMeasurementWarnfNilRecorder(t *testing.T) {
 
 	r := &GoodputMeasurementReconciler{} // Recorder deliberately unset
 	gm := &nvcrev1alpha1.GoodputMeasurement{
-		ObjectMeta: metav1.ObjectMeta{Name: "gm", Namespace: "default"},
+		Name: "gm", Namespace: testNS,
 	}
 
 	r.warnf(gm, reasonGoodputLogProfileMissing,
@@ -52,7 +50,7 @@ func TestBandwidthMeasurementWarnfNilRecorder(t *testing.T) {
 
 	r := &BandwidthMeasurementReconciler{} // Recorder deliberately unset
 	bm := &nvcrev1alpha1.BandwidthMeasurement{
-		ObjectMeta: metav1.ObjectMeta{Name: "bm", Namespace: "default"},
+		Name: "bm", Namespace: testNS,
 	}
 
 	r.warnf(bm, reasonBandwidthLogProfileMissing,
@@ -66,7 +64,7 @@ func TestWorkloadRunWarnfNilRecorder(t *testing.T) {
 
 	r := &WorkloadRunReconciler{} // Recorder deliberately unset
 	run := &nvcrev1alpha1.WorkloadRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "default"},
+		Name: "run", Namespace: "default",
 	}
 
 	r.warnf(run, ReasonWorkflowCreationError,

--- a/pkg/controller/exclusion_summary_test.go
+++ b/pkg/controller/exclusion_summary_test.go
@@ -24,7 +24,7 @@ import (
 func TestExclusionSummary(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "exclusion-summary",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/failure_log_test.go
+++ b/pkg/controller/failure_log_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,7 +30,7 @@ import (
 func TestFailureLogTail(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "failure-log-tail",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -64,7 +63,7 @@ func TestFailureLogTail(t *testing.T) {
 func TestFailureLogCapture(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "failure-log-capture",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -88,10 +87,8 @@ func TestFailureLogCapture(t *testing.T) {
 		objs := make([]client.Object, 0, len(in.Pods))
 		for _, sp := range in.Pods {
 			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sp.Name, Namespace: "ns",
-					Labels: map[string]string{"nvcre.nvidia.com/job": "j"},
-				},
+				Name: sp.Name, Namespace: "ns",
+				Labels: map[string]string{"nvcre.nvidia.com/job": "j"},
 			}
 			if sp.Running {
 				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
@@ -102,7 +99,7 @@ func TestFailureLogCapture(t *testing.T) {
 			objs = append(objs, pod)
 		}
 
-		job := &nvcrev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		job := &nvcrev1alpha1.Job{Name: "j", Namespace: "ns"}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 			WithIndex(&corev1.Pod{}, nodemonitor.PodNVCREJobIndexField, func(obj client.Object) []string {
 				pod, ok := obj.(*corev1.Pod)

--- a/pkg/controller/goodput_final_sample_test.go
+++ b/pkg/controller/goodput_final_sample_test.go
@@ -47,7 +47,7 @@ func (s *stubLogFetcher) FetchLogs(_ context.Context, _, _ string, opts podlogs.
 func TestGoodputFinalSample(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "goodput-final-sample",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -79,7 +79,7 @@ func TestGoodputFinalSample(t *testing.T) {
 		anchor := time.Date(2026, 1, 22, 10, 5, 0, 0, time.UTC)
 
 		profile := &nvcrev1alpha1.LogProfile{
-			ObjectMeta: metav1.ObjectMeta{Name: "lp"},
+			Name: "lp",
 			Spec: nvcrev1alpha1.LogProfileSpec{
 				Timestamp: nvcrev1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05.999999999Z"},
 				Patterns: nvcrev1alpha1.LogPatternSet{
@@ -91,7 +91,7 @@ func TestGoodputFinalSample(t *testing.T) {
 			},
 		}
 		m := &nvcrev1alpha1.GoodputMeasurement{
-			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+			Name: "m", Namespace: "ns",
 			Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 				JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 				LogProfileRef: in.LogProfileRef,
@@ -110,7 +110,7 @@ func TestGoodputFinalSample(t *testing.T) {
 		}
 		initialStatus := m.Status.DeepCopy()
 		job := &nvcrev1alpha1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
+			Name: "j", Namespace: "ns",
 			Status: nvcrev1alpha1.JobStatus{
 				WorkloadRef: &nvcrev1alpha1.WorkloadReference{Kind: "TrainJob", Name: "w"},
 				Conditions: []metav1.Condition{{
@@ -122,13 +122,11 @@ func TestGoodputFinalSample(t *testing.T) {
 			},
 		}
 		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "w-node-0",
-				Namespace: "ns",
-				Labels: map[string]string{
-					"jobset.sigs.k8s.io/jobset-name":           "w",
-					"batch.kubernetes.io/job-completion-index": "0",
-				},
+			Name:      "w-node-0",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"jobset.sigs.k8s.io/jobset-name":           "w",
+				"batch.kubernetes.io/job-completion-index": "0",
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodRunning},
 		}

--- a/pkg/controller/goodput_set_complete_test.go
+++ b/pkg/controller/goodput_set_complete_test.go
@@ -30,7 +30,7 @@ import (
 func TestGoodputSetComplete(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "goodput-set-complete",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -63,7 +63,7 @@ func TestGoodputSetComplete(t *testing.T) {
 		frozenAt := metav1.NewTime(time.Date(2026, 1, 22, 10, 5, 0, 0, time.UTC))
 
 		m := &nvcrev1alpha1.GoodputMeasurement{
-			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+			Name: "m", Namespace: "ns",
 			Status: nvcrev1alpha1.GoodputMeasurementStatus{
 				Result:          "0.900000",
 				TrainingTimeSec: "295.000000",
@@ -74,7 +74,7 @@ func TestGoodputSetComplete(t *testing.T) {
 			meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
 				Type:    nvcrev1alpha1.GoodputMeasurementComplete,
 				Status:  metav1.ConditionTrue,
-				Reason:  "JobSucceeded",
+				Reason:  reasonBandwidthJobSucceeded,
 				Message: "Referenced Job completed successfully",
 			})
 		}
@@ -98,7 +98,7 @@ func TestGoodputSetComplete(t *testing.T) {
 			meta.SetStatusCondition(&live.Status.Conditions, metav1.Condition{
 				Type:    nvcrev1alpha1.GoodputMeasurementComplete,
 				Status:  metav1.ConditionTrue,
-				Reason:  "JobSucceeded",
+				Reason:  reasonBandwidthJobSucceeded,
 				Message: "Referenced Job completed successfully",
 			})
 			if err := c.Status().Update(ctx, live); err != nil {

--- a/pkg/controller/goodput_state_recovery_test.go
+++ b/pkg/controller/goodput_state_recovery_test.go
@@ -22,7 +22,7 @@ import (
 func TestGoodputStateRecovery(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "goodput-state-recovery",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/controller/goodput_terminal_anchor_test.go
+++ b/pkg/controller/goodput_terminal_anchor_test.go
@@ -22,7 +22,7 @@ import (
 func TestTerminalAnchor(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "goodput-terminal-anchor",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/controller/goodputmeasurement_controller_test.go
+++ b/pkg/controller/goodputmeasurement_controller_test.go
@@ -16,7 +16,7 @@ import (
 func TestComputeAvgTFLOPS(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "compute-avg-tflops",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -42,7 +42,7 @@ func TestComputeAvgTFLOPS(t *testing.T) {
 func TestComputeWarmupTime(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "compute-warmup-time",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -69,7 +69,7 @@ func TestComputeWarmupTime(t *testing.T) {
 func TestComputeNonWarmupTime(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "compute-non-warmup-time",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/gpu_arch_exclusion_test.go
+++ b/pkg/controller/gpu_arch_exclusion_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
@@ -20,7 +19,7 @@ import (
 func TestGPUArchExclusion(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "gpu-arch-exclusion",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -35,9 +34,9 @@ func TestGPUArchExclusion(t *testing.T) {
 
 		nodes := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			node := corev1.Node{Name: n.Name}
 			if n.Product != "" {
-				node.Labels = map[string]string{"nvidia.com/gpu.product": n.Product}
+				node.Labels = map[string]string{testGPUProductLabel: n.Product}
 			}
 			nodes = append(nodes, node)
 		}

--- a/pkg/controller/gpu_capacity_filter_test.go
+++ b/pkg/controller/gpu_capacity_filter_test.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
@@ -29,7 +28,7 @@ import (
 func TestFilterNodesByGPUCapacity(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "gpu-capacity-filter",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -48,7 +47,7 @@ func TestFilterNodesByGPUCapacity(t *testing.T) {
 
 		given := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			node := corev1.Node{Name: n.Name}
 			if n.AllocatableGPUs != nil {
 				node.Status.Allocatable = corev1.ResourceList{
 					"nvidia.com/gpu": *resource.NewQuantity(*n.AllocatableGPUs, resource.DecimalSI),

--- a/pkg/controller/group_completion_persist_test.go
+++ b/pkg/controller/group_completion_persist_test.go
@@ -28,7 +28,7 @@ import (
 func TestGroupCompletionPersists(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "group-completion-persist",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -50,7 +50,7 @@ func TestGroupCompletionPersists(t *testing.T) {
 		for i := 0; i < in.Groups; i++ {
 			name := []string{"g0", "g1", "g2"}[i]
 			job := &nvcrev1alpha1.Job{
-				ObjectMeta: metav1.ObjectMeta{Name: name + "-job", Namespace: "ns"},
+				Name: name + "-job", Namespace: "ns",
 				Status: nvcrev1alpha1.JobStatus{Conditions: []metav1.Condition{{
 					Type: in.JobCondition, Status: metav1.ConditionTrue,
 					Reason: "WorkloadCompleted", LastTransitionTime: metav1.Now(),
@@ -66,7 +66,7 @@ func TestGroupCompletionPersists(t *testing.T) {
 		}
 
 		wf := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "ns", Generation: 1},
+			Name: "wf", Namespace: "ns", Generation: 1,
 			Spec: nvcrev1alpha1.WorkflowSpec{
 				Orchestration: nvcrev1alpha1.OrchestrationSpec{Iterations: 1},
 			},

--- a/pkg/controller/job_controller.go
+++ b/pkg/controller/job_controller.go
@@ -43,8 +43,18 @@ import (
 )
 
 const (
+	// kindJob is the Kind value for Job object references.
+	kindJob = "Job"
+
+	// kindConfigMap is the Kind value for ConfigMap object references.
+	kindConfigMap = "ConfigMap"
+
 	// jobFinalizer is the finalizer added to Job resources to ensure cleanup
 	jobFinalizer = "nvcre.nvidia.com/finalizer"
+
+	// labelJobKey is the label key set on workload objects and pods to record
+	// the owning Job's name.
+	labelJobKey = "nvcre.nvidia.com/job"
 
 	// workloadRequeueInterval is the safety-net requeue interval for workload status polling.
 	// Primary status updates are event-driven via Owns(), but this ensures eventual consistency.
@@ -335,7 +345,7 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *nvcrev1
 
 	// Deep-copy the spec and inject the NVCRE pod label automatically
 	specCopy := job.Spec.Workload.DeepCopy()
-	adapter.InjectPodLabel(specCopy, "nvcre.nvidia.com/job", job.Name)
+	adapter.InjectPodLabel(specCopy, labelJobKey, job.Name)
 
 	workloadName := r.getWorkloadName(job)
 	obj, err := adapter.Build(workloadName, job.Namespace, specCopy)
@@ -352,8 +362,8 @@ func (r *JobReconciler) createWorkloadFromSpec(ctx context.Context, job *nvcrev1
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels["app.kubernetes.io/managed-by"] = "nvcre"
-	labels["nvcre.nvidia.com/job"] = job.Name
+	labels["app.kubernetes.io/managed-by"] = managedByValue
+	labels[labelJobKey] = job.Name
 	obj.SetLabels(labels)
 
 	// Set owner reference so the workload is garbage collected when the Job is deleted
@@ -1395,18 +1405,16 @@ func (r *JobReconciler) ensureGoodputMeasurement(ctx context.Context, job *nvcre
 
 	apiGroup := "nvcre.nvidia.com"
 	gm := &nvcrev1alpha1.GoodputMeasurement{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gmName,
-			Namespace: job.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "nvcre",
-				"nvcre.nvidia.com/job":         job.Name,
-			},
+		Name:      gmName,
+		Namespace: job.Namespace,
+		Labels: map[string]string{
+			labelManagedBy: managedByValue,
+			labelJobKey:    job.Name,
 		},
 		Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 			JobRef: corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
-				Kind:     "Job",
+				Kind:     kindJob,
 				Name:     job.Name,
 			},
 			LogProfileRef:  job.Spec.GoodputMeasurement.LogProfileRef,
@@ -1453,18 +1461,16 @@ func (r *JobReconciler) ensureBandwidthMeasurement(ctx context.Context, job *nvc
 
 	apiGroup := "nvcre.nvidia.com"
 	bm := &nvcrev1alpha1.BandwidthMeasurement{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      bmName,
-			Namespace: job.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "nvcre",
-				"nvcre.nvidia.com/job":         job.Name,
-			},
+		Name:      bmName,
+		Namespace: job.Namespace,
+		Labels: map[string]string{
+			labelManagedBy: managedByValue,
+			labelJobKey:    job.Name,
 		},
 		Spec: nvcrev1alpha1.BandwidthMeasurementSpec{
 			JobRef: corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
-				Kind:     "Job",
+				Kind:     kindJob,
 				Name:     job.Name,
 			},
 			LogProfileRef:  job.Spec.BandwidthMeasurement.LogProfileRef,
@@ -1560,13 +1566,11 @@ func (r *JobReconciler) nodeToJobRequests(ctx context.Context, obj client.Object
 			continue
 		}
 
-		if jobName, ok := pod.Labels["nvcre.nvidia.com/job"]; ok {
+		if jobName, ok := pod.Labels[labelJobKey]; ok {
 			key := pod.Namespace + "/" + jobName
 			requests[key] = reconcile.Request{
-				NamespacedName: client.ObjectKey{
-					Namespace: pod.Namespace,
-					Name:      jobName,
-				},
+				Namespace: pod.Namespace,
+				Name:      jobName,
 			}
 		}
 	}

--- a/pkg/controller/job_event_test.go
+++ b/pkg/controller/job_event_test.go
@@ -6,8 +6,6 @@ package controller
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 )
 
@@ -20,7 +18,7 @@ func TestJobWarnfNilRecorder(t *testing.T) {
 
 	r := &JobReconciler{} // Recorder deliberately unset
 	job := &nvcrev1alpha1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"},
+		Name: "job", Namespace: testNS,
 	}
 
 	r.warnf(job, ReasonMeasurementCreationError,

--- a/pkg/controller/job_stall_anchor_test.go
+++ b/pkg/controller/job_stall_anchor_test.go
@@ -22,7 +22,7 @@ import (
 func TestStartupStallAnchor(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "startup-stall-anchor",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/job_threshold_helpers_test.go
+++ b/pkg/controller/job_threshold_helpers_test.go
@@ -11,14 +11,18 @@ import (
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 )
 
+// testMetricBusBandwidth is the bus bandwidth metric/threshold key used
+// throughout this file's fixtures.
+const testMetricBusBandwidth = "busBandwidthGBps"
+
 func TestMissingJobThresholdKeys(t *testing.T) {
 	t.Parallel()
 
 	missing := missingJobThresholdKeys(
-		map[string]string{"busBandwidthGBps": "value >= 900", "goodputRatio": "value >= 0.9"},
-		map[string]float64{"busBandwidthGBps": 1000},
+		map[string]string{testMetricBusBandwidth: "value >= 900", testMetricGoodputRatio: "value >= 0.9"},
+		map[string]float64{testMetricBusBandwidth: 1000},
 	)
-	if len(missing) != 1 || missing[0] != "goodputRatio" {
+	if len(missing) != 1 || missing[0] != testMetricGoodputRatio {
 		t.Fatalf("missing = %v, want [goodputRatio]", missing)
 	}
 }
@@ -27,9 +31,9 @@ func TestIsJobAwaitingThresholdEvaluation(t *testing.T) {
 	t.Parallel()
 
 	job := &nvcrev1alpha1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"},
+		Name: "job", Namespace: testNS,
 		Spec: nvcrev1alpha1.JobSpec{
-			Thresholds: map[string]string{"busBandwidthGBps": "value >= 900"},
+			Thresholds: map[string]string{testMetricBusBandwidth: "value >= 900"},
 		},
 		Status: nvcrev1alpha1.JobStatus{
 			Conditions: []metav1.Condition{{

--- a/pkg/controller/job_timeout_test.go
+++ b/pkg/controller/job_timeout_test.go
@@ -24,7 +24,7 @@ import (
 func TestIsJobTimedOut(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "job-timed-out",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/merge_test.go
+++ b/pkg/controller/merge_test.go
@@ -16,7 +16,7 @@ import (
 func TestMergeFailedNodes(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "merge-failed-nodes",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -186,7 +186,7 @@ var (
 		goodputLabels,
 	)
 
-	topologyNodeLabels = []string{labelNamespace, labelWorkflow, "topology_key", "domain", "node"}
+	topologyNodeLabels = []string{labelNamespace, labelWorkflow, "topology_key", "domain", labelNode}
 
 	// topologyValidatedNodesGauge tracks nodes that passed burn-in validation,
 	// one time series per node with value 1.

--- a/pkg/controller/metrics_cleanup_test.go
+++ b/pkg/controller/metrics_cleanup_test.go
@@ -25,7 +25,7 @@ import (
 func TestCleanupJobMetricsRemovesEveryJobScopedSeries(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "cleanup-job-metrics-cardinality",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -50,8 +50,8 @@ func TestCleanupJobMetricsRemovesEveryJobScopedSeries(t *testing.T) {
 			record  func()
 		}{
 			{"nvcre_job_status", jobStatusGauge, func() { recordJobStatus(ns, job, wf, "in_progress") }},
-			{"nvcre_job_failed_nodes", failedNodesGauge, func() { recordHardwareFailure(ns, job, wf, []string{"node-a"}) }},
-			{"nvcre_hardware_failures_detected_total", hardwareFailuresDetectedTotal, func() { recordHardwareFailure(ns, job, wf, []string{"node-a"}) }},
+			{"nvcre_job_failed_nodes", failedNodesGauge, func() { recordHardwareFailure(ns, job, wf, []string{testNodeA}) }},
+			{"nvcre_hardware_failures_detected_total", hardwareFailuresDetectedTotal, func() { recordHardwareFailure(ns, job, wf, []string{testNodeA}) }},
 			{"nvcre_hardware_failed_jobs_total", hardwareFailedJobsTotal, func() { recordFirstHardwareFailure(ns, job, wf) }},
 			{"nvcre_nodes_evaluated_total", nodesEvaluatedTotal, func() { recordNodesEvaluated(ns, job, wf, 8) }},
 			{"nvcre_workload_created_total", workloadCreatedTotal, func() { recordWorkloadCreated(ns, job, wf) }},

--- a/pkg/controller/metrics_test.go
+++ b/pkg/controller/metrics_test.go
@@ -16,7 +16,7 @@ import (
 func TestRecordGoodputMetrics(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "record-goodput-metrics",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input goodputMetricValues
@@ -33,16 +33,16 @@ func TestRecordGoodputMetrics(t *testing.T) {
 		defer cleanupGoodputMetrics(ns, meas, job, wf)
 
 		result := map[string]float64{
-			"avgStepTime":        promtest.ToFloat64(goodputAvgStepTimeGauge.WithLabelValues(labels...)),
-			"avgTFLOPS":          promtest.ToFloat64(goodputAvgTFLOPSGauge.WithLabelValues(labels...)),
-			"checkpointSaveTime": promtest.ToFloat64(goodputCheckpointSaveTimeGauge.WithLabelValues(labels...)),
-			"goodputRatio":       promtest.ToFloat64(goodputRatioGauge.WithLabelValues(labels...)),
-			"lostWorkTime":       promtest.ToFloat64(goodputLostWorkTimeGauge.WithLabelValues(labels...)),
-			"nonWarmupTime":      promtest.ToFloat64(goodputNonWarmupTimeGauge.WithLabelValues(labels...)),
-			"rescheduleTime":     promtest.ToFloat64(goodputRescheduleTimeGauge.WithLabelValues(labels...)),
-			"resumeTime":         promtest.ToFloat64(goodputResumeTimeGauge.WithLabelValues(labels...)),
-			"trainingTime":       promtest.ToFloat64(goodputTrainingTimeGauge.WithLabelValues(labels...)),
-			"warmupTime":         promtest.ToFloat64(goodputWarmupTimeGauge.WithLabelValues(labels...)),
+			"avgStepTime":          promtest.ToFloat64(goodputAvgStepTimeGauge.WithLabelValues(labels...)),
+			"avgTFLOPS":            promtest.ToFloat64(goodputAvgTFLOPSGauge.WithLabelValues(labels...)),
+			"checkpointSaveTime":   promtest.ToFloat64(goodputCheckpointSaveTimeGauge.WithLabelValues(labels...)),
+			testMetricGoodputRatio: promtest.ToFloat64(goodputRatioGauge.WithLabelValues(labels...)),
+			"lostWorkTime":         promtest.ToFloat64(goodputLostWorkTimeGauge.WithLabelValues(labels...)),
+			"nonWarmupTime":        promtest.ToFloat64(goodputNonWarmupTimeGauge.WithLabelValues(labels...)),
+			"rescheduleTime":       promtest.ToFloat64(goodputRescheduleTimeGauge.WithLabelValues(labels...)),
+			"resumeTime":           promtest.ToFloat64(goodputResumeTimeGauge.WithLabelValues(labels...)),
+			"trainingTime":         promtest.ToFloat64(goodputTrainingTimeGauge.WithLabelValues(labels...)),
+			"warmupTime":           promtest.ToFloat64(goodputWarmupTimeGauge.WithLabelValues(labels...)),
 		}
 
 		data, err := json.MarshalIndent(result, "", "  ")
@@ -57,7 +57,7 @@ func TestRecordGoodputMetrics(t *testing.T) {
 func TestRecordGoodputMetricsSetsAllGauges(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "record-goodput-all-gauges",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input goodputMetricValues
@@ -73,16 +73,16 @@ func TestRecordGoodputMetricsSetsAllGauges(t *testing.T) {
 		defer cleanupGoodputMetrics(ns, meas, job, wf)
 
 		gaugeValues := map[string]float64{
-			"avgStepTime":        promtest.ToFloat64(goodputAvgStepTimeGauge.WithLabelValues(labels...)),
-			"avgTFLOPS":          promtest.ToFloat64(goodputAvgTFLOPSGauge.WithLabelValues(labels...)),
-			"checkpointSaveTime": promtest.ToFloat64(goodputCheckpointSaveTimeGauge.WithLabelValues(labels...)),
-			"goodputRatio":       promtest.ToFloat64(goodputRatioGauge.WithLabelValues(labels...)),
-			"lostWorkTime":       promtest.ToFloat64(goodputLostWorkTimeGauge.WithLabelValues(labels...)),
-			"nonWarmupTime":      promtest.ToFloat64(goodputNonWarmupTimeGauge.WithLabelValues(labels...)),
-			"rescheduleTime":     promtest.ToFloat64(goodputRescheduleTimeGauge.WithLabelValues(labels...)),
-			"resumeTime":         promtest.ToFloat64(goodputResumeTimeGauge.WithLabelValues(labels...)),
-			"trainingTime":       promtest.ToFloat64(goodputTrainingTimeGauge.WithLabelValues(labels...)),
-			"warmupTime":         promtest.ToFloat64(goodputWarmupTimeGauge.WithLabelValues(labels...)),
+			"avgStepTime":          promtest.ToFloat64(goodputAvgStepTimeGauge.WithLabelValues(labels...)),
+			"avgTFLOPS":            promtest.ToFloat64(goodputAvgTFLOPSGauge.WithLabelValues(labels...)),
+			"checkpointSaveTime":   promtest.ToFloat64(goodputCheckpointSaveTimeGauge.WithLabelValues(labels...)),
+			testMetricGoodputRatio: promtest.ToFloat64(goodputRatioGauge.WithLabelValues(labels...)),
+			"lostWorkTime":         promtest.ToFloat64(goodputLostWorkTimeGauge.WithLabelValues(labels...)),
+			"nonWarmupTime":        promtest.ToFloat64(goodputNonWarmupTimeGauge.WithLabelValues(labels...)),
+			"rescheduleTime":       promtest.ToFloat64(goodputRescheduleTimeGauge.WithLabelValues(labels...)),
+			"resumeTime":           promtest.ToFloat64(goodputResumeTimeGauge.WithLabelValues(labels...)),
+			"trainingTime":         promtest.ToFloat64(goodputTrainingTimeGauge.WithLabelValues(labels...)),
+			"warmupTime":           promtest.ToFloat64(goodputWarmupTimeGauge.WithLabelValues(labels...)),
 		}
 
 		// Check that all gauges are non-zero; build sorted result
@@ -111,7 +111,7 @@ func TestRecordGoodputMetricsSetsAllGauges(t *testing.T) {
 func TestCleanupGoodputMetrics(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "cleanup-goodput-metrics",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input goodputMetricValues
@@ -141,7 +141,7 @@ func TestCleanupGoodputMetrics(t *testing.T) {
 func TestRecordJobStatus(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "record-job-status",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -177,7 +177,7 @@ func TestRecordJobStatus(t *testing.T) {
 func TestCleanupJobMetrics(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "cleanup-job-metrics",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -209,7 +209,7 @@ func TestCleanupJobMetrics(t *testing.T) {
 func TestRecordTopologyValidatedNodes(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "record-topology-validated-nodes",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -257,7 +257,7 @@ func TestRecordTopologyValidatedNodes(t *testing.T) {
 func TestCleanupTopologyMetrics(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "cleanup-topology-metrics",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/node_health_predicate_test.go
+++ b/pkg/controller/node_health_predicate_test.go
@@ -21,7 +21,7 @@ import (
 func TestNodeHealthChangePredicate(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "node-health-predicate",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var oldNode, newNode corev1.Node

--- a/pkg/controller/node_results.go
+++ b/pkg/controller/node_results.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -140,10 +139,8 @@ func recordNodeResults[T any](
 
 	cmName := nodeResultsCMName(target.namePrefix, string(workflow.UID))
 	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: workflow.Namespace,
-		},
+		Name:      cmName,
+		Namespace: workflow.Namespace,
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
 		if err := controllerutil.SetControllerReference(workflow, cm, r.Scheme); err != nil {
@@ -163,7 +160,7 @@ func recordNodeResults[T any](
 		return fmt.Errorf("failed to write node-results ConfigMap %s: %w", cmName, err)
 	}
 
-	target.setRef(workflow, &corev1.TypedLocalObjectReference{Kind: "ConfigMap", Name: cmName})
+	target.setRef(workflow, &corev1.TypedLocalObjectReference{Kind: kindConfigMap, Name: cmName})
 	return nil
 }
 

--- a/pkg/controller/node_results_test.go
+++ b/pkg/controller/node_results_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,6 +17,14 @@ import (
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 	gzip "github.com/NVIDIA/cluster-readiness-engine/pkg/controller/compress"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/noderesults"
+)
+
+// Node names and a failure message reused across this file's fixtures.
+const (
+	testGPU01      = "gpu-01"
+	testGPU02      = "gpu-02"
+	testGPU03      = "gpu-03"
+	testReasonBoom = "boom"
 )
 
 func decodeOrFail(t *testing.T, b []byte) []string {
@@ -46,7 +53,7 @@ func newNodeResultsScheme(t *testing.T) *runtime.Scheme {
 
 func testWorkflow(name string) *nvcrev1alpha1.Workflow {
 	return &nvcrev1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid")},
+		Name: name, Namespace: testNS, UID: types.UID(name + "-uid"),
 	}
 }
 
@@ -56,7 +63,7 @@ func getCMByRef(t *testing.T, c client.Client, ref *corev1.TypedLocalObjectRefer
 		t.Fatalf("expected a non-nil node-results ref")
 	}
 	cm := &corev1.ConfigMap{}
-	if err := c.Get(context.Background(), types.NamespacedName{Name: ref.Name, Namespace: "default"}, cm); err != nil {
+	if err := c.Get(context.Background(), types.NamespacedName{Name: ref.Name, Namespace: testNS}, cm); err != nil {
 		t.Fatalf("get ConfigMap %s: %v", ref.Name, err)
 	}
 	return cm
@@ -93,18 +100,18 @@ func TestMergeSucceededNodesCSV(t *testing.T) {
 	}{
 		"empty existing": {
 			existingNodes: nil,
-			newNodes:      []string{"gpu-02", "gpu-01"},
-			want:          []string{"gpu-01", "gpu-02"},
+			newNodes:      []string{testGPU02, testGPU01},
+			want:          []string{testGPU01, testGPU02},
 		},
 		"union and sort": {
-			existingNodes: []string{"gpu-03", "gpu-01"},
-			newNodes:      []string{"gpu-02", "gpu-04"},
-			want:          []string{"gpu-01", "gpu-02", "gpu-03", "gpu-04"},
+			existingNodes: []string{testGPU03, testGPU01},
+			newNodes:      []string{testGPU02, "gpu-04"},
+			want:          []string{testGPU01, testGPU02, testGPU03, "gpu-04"},
 		},
 		"dedupe across existing and new": {
-			existingNodes: []string{"gpu-01", "gpu-02"},
-			newNodes:      []string{"gpu-02", "gpu-03"},
-			want:          []string{"gpu-01", "gpu-02", "gpu-03"},
+			existingNodes: []string{testGPU01, testGPU02},
+			newNodes:      []string{testGPU02, testGPU03},
+			want:          []string{testGPU01, testGPU02, testGPU03},
 		},
 	}
 
@@ -150,28 +157,28 @@ func TestMergeFailedNodesJSON(t *testing.T) {
 		want     []nvcrev1alpha1.FailedNode
 	}{
 		"empty existing": {
-			incoming: []nvcrev1alpha1.FailedNode{{Name: "gpu-02", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
-			want:     []nvcrev1alpha1.FailedNode{{Name: "gpu-02", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: "boom"}},
+			incoming: []nvcrev1alpha1.FailedNode{{Name: testGPU02, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: testReasonBoom}},
+			want:     []nvcrev1alpha1.FailedNode{{Name: testGPU02, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: testReasonBoom}},
 		},
 		"union sort and dedupe by name+reason": {
-			existing: []nvcrev1alpha1.FailedNode{{Name: "gpu-03", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed}},
+			existing: []nvcrev1alpha1.FailedNode{{Name: testGPU03, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed}},
 			incoming: []nvcrev1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-03", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
+				{Name: testGPU03, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed},
 			},
 			want: []nvcrev1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-03", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
+				{Name: testGPU03, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed},
 			},
 		},
 		"same node two reasons kept": {
 			incoming: []nvcrev1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureThresholdViolation},
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureThresholdViolation},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
 			},
 			want: []nvcrev1alpha1.FailedNode{
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
-				{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureThresholdViolation},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
+				{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureThresholdViolation},
 			},
 		},
 		"message with comma and quote preserved": {
@@ -221,7 +228,7 @@ func TestRecordSucceededNodes(t *testing.T) {
 	wf := testWorkflow("test-cert-training-hello")
 	ctx := context.Background()
 
-	if err := r.recordSucceededNodes(ctx, wf, []string{"gpu-02", "gpu-01"}); err != nil {
+	if err := r.recordSucceededNodes(ctx, wf, []string{testGPU02, testGPU01}); err != nil {
 		t.Fatalf("recordSucceededNodes (1): %v", err)
 	}
 	wantName := nodeResultsCMName(succeededNodesPrefix, string(wf.UID))
@@ -231,7 +238,7 @@ func TestRecordSucceededNodes(t *testing.T) {
 	if got := strings.Join(readSucceededNodes(t, c, wf), ","); got != "gpu-01,gpu-02" {
 		t.Fatalf("after first write got %q", got)
 	}
-	if err := r.recordSucceededNodes(ctx, wf, []string{"gpu-02", "gpu-03"}); err != nil {
+	if err := r.recordSucceededNodes(ctx, wf, []string{testGPU02, testGPU03}); err != nil {
 		t.Fatalf("recordSucceededNodes (2): %v", err)
 	}
 	if wf.Status.SucceededNodesRef.Name != wantName {
@@ -250,7 +257,7 @@ func TestRecordFailedNodes(t *testing.T) {
 	ctx := context.Background()
 
 	if err := r.recordFailedNodes(ctx, wf, []nvcrev1alpha1.FailedNode{
-		{Name: "gpu-02", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
+		{Name: testGPU02, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: testReasonBoom},
 	}); err != nil {
 		t.Fatalf("recordFailedNodes (1): %v", err)
 	}
@@ -259,13 +266,13 @@ func TestRecordFailedNodes(t *testing.T) {
 		t.Fatalf("FailedNodesRef = %+v, want name %q", wf.Status.FailedNodesRef, wantFailedName)
 	}
 	got := readFailedNodes(t, c, wf)
-	if len(got) != 1 || got[0].Name != "gpu-02" || got[0].Message != "boom" {
+	if len(got) != 1 || got[0].Name != testGPU02 || got[0].Message != testReasonBoom {
 		t.Fatalf("after first write got %+v", got)
 	}
 
 	if err := r.recordFailedNodes(ctx, wf, []nvcrev1alpha1.FailedNode{
-		{Name: "gpu-02", Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: "boom"},
-		{Name: "gpu-01", Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
+		{Name: testGPU02, Reason: nvcrev1alpha1.NodeFailureWorkloadFailed, Message: testReasonBoom},
+		{Name: testGPU01, Reason: nvcrev1alpha1.NodeFailureHardwareDetected},
 	}); err != nil {
 		t.Fatalf("recordFailedNodes (2): %v", err)
 	}
@@ -273,7 +280,7 @@ func TestRecordFailedNodes(t *testing.T) {
 		t.Fatalf("second write changed ConfigMap name to %q (want %q)", wf.Status.FailedNodesRef.Name, wantFailedName)
 	}
 	got = readFailedNodes(t, c, wf)
-	if len(got) != 2 || got[0].Name != "gpu-01" || got[1].Name != "gpu-02" {
+	if len(got) != 2 || got[0].Name != testGPU01 || got[1].Name != testGPU02 {
 		t.Fatalf("after second write got %+v", got)
 	}
 }

--- a/pkg/controller/parser_cache_test.go
+++ b/pkg/controller/parser_cache_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -20,10 +19,8 @@ import (
 // trainingStep regex.
 func logProfile(name, resourceVersion, regex string) *nvcrev1alpha1.LogProfile {
 	return &nvcrev1alpha1.LogProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			ResourceVersion: resourceVersion,
-		},
+		Name:            name,
+		ResourceVersion: resourceVersion,
 		Spec: nvcrev1alpha1.LogProfileSpec{
 			Timestamp: nvcrev1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05"},
 			Patterns: nvcrev1alpha1.LogPatternSet{

--- a/pkg/controller/pod_drain_test.go
+++ b/pkg/controller/pod_drain_test.go
@@ -43,7 +43,7 @@ func (f failingPodLister) List(_ context.Context, _ client.ObjectList, _ ...clie
 func TestShouldWaitForPodDrain(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "pod-drain",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -67,7 +67,7 @@ func TestShouldWaitForPodDrain(t *testing.T) {
 
 		now := time.Now()
 		anchors := map[string]metav1.Time{}
-		job := &nvcrev1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"}}
+		job := &nvcrev1alpha1.Job{Name: "j", Namespace: "ns"}
 		addCondition := func(condType string, ageSeconds int) {
 			if ageSeconds == 0 {
 				return
@@ -105,10 +105,8 @@ func TestShouldWaitForPodDrain(t *testing.T) {
 				jobLabel = "some-other-job"
 			}
 			objs = append(objs, &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sp.Name, Namespace: job.Namespace,
-					Labels: map[string]string{nodemonitor.NVCREJobLabel: jobLabel},
-				},
+				Name: sp.Name, Namespace: job.Namespace,
+				Labels: map[string]string{nodemonitor.NVCREJobLabel: jobLabel},
 				Status: corev1.PodStatus{Phase: corev1.PodPhase(sp.Phase)},
 			})
 		}

--- a/pkg/controller/status_test.go
+++ b/pkg/controller/status_test.go
@@ -49,7 +49,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 			ctx := context.Background()
 
 			wf := &nvcrev1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "default"},
+				Name: "wf", Namespace: testNS,
 			}
 
 			remaining := tt.conflicts
@@ -77,7 +77,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 				Build()
 
 			obj := &nvcrev1alpha1.Workflow{}
-			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, obj))
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: testNS}, obj))
 
 			mutations := 0
 			err := updateStatusWithRetry(ctx, c, obj, func(w *nvcrev1alpha1.Workflow) bool {
@@ -101,7 +101,7 @@ func TestUpdateStatusWithRetryRecoversFromConflict(t *testing.T) {
 
 			// The condition must actually be persisted, not merely applied in memory.
 			stored := &nvcrev1alpha1.Workflow{}
-			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, stored))
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: testNS}, stored))
 			require.True(t, CondIsTrue(stored.Status.Conditions, nvcrev1alpha1.WorkflowInProgress))
 		})
 	}
@@ -114,7 +114,7 @@ func TestUpdateStatusWithRetrySkipsWriteWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
 
 	wf := &nvcrev1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "default"},
+		Name: "wf", Namespace: testNS,
 	}
 
 	writes := 0
@@ -134,7 +134,7 @@ func TestUpdateStatusWithRetrySkipsWriteWhenUnchanged(t *testing.T) {
 		Build()
 
 	obj := &nvcrev1alpha1.Workflow{}
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: "default"}, obj))
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "wf", Namespace: testNS}, obj))
 
 	require.NoError(t, updateStatusWithRetry(ctx, c, obj, func(*nvcrev1alpha1.Workflow) bool {
 		return false

--- a/pkg/controller/testconsts_test.go
+++ b/pkg/controller/testconsts_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+// Shared string literals reused across multiple test files in this package.
+// goconst flags literals repeated three or more times package-wide; these
+// constants collect the ones that span file boundaries so every call site
+// can share a single definition instead of duplicating the literal.
+const (
+	// testGPUProductLabel is the node label key advertising GPU product.
+	testGPUProductLabel = "nvidia.com/gpu.product"
+	// testGPUProductH100 is a GPU product label value used by fixtures.
+	testGPUProductH100 = "NVIDIA-H100-80GB-HBM3"
+	// testDomainCommunication is a CertificateCategory domain used by fixtures.
+	testDomainCommunication = "communication"
+	// testNodeA is a node name used by fixtures.
+	testNodeA = "node-a"
+	// testMetricGoodputRatio is the goodput ratio metric/result key.
+	testMetricGoodputRatio = "goodputRatio"
+	// testVariantNCCLAllReduce is a CertificateCategory variant used by fixtures.
+	testVariantNCCLAllReduce = "nccl-all-reduce"
+	// testNS is the namespace used by fixtures.
+	testNS = "default"
+)

--- a/pkg/controller/unresolved_log_profile_test.go
+++ b/pkg/controller/unresolved_log_profile_test.go
@@ -35,7 +35,7 @@ type conditionOut struct {
 func TestUnresolvedLogProfile(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "unresolved-log-profile",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -59,7 +59,7 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		// missing, and reaches a different branch now that the final sample runs
 		// before the terminal handling.
 		profile := &nvcrev1alpha1.LogProfile{
-			ObjectMeta: metav1.ObjectMeta{Name: "megatron-training"},
+			Name: "megatron-training",
 			Spec: nvcrev1alpha1.LogProfileSpec{
 				Timestamp: nvcrev1alpha1.TimestampSpec{Layout: "2006-01-02 15:04:05.999999"},
 				Patterns: nvcrev1alpha1.LogPatternSet{
@@ -71,7 +71,7 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		}
 
 		job := &nvcrev1alpha1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
+			Name: "j", Namespace: "ns",
 			Status: nvcrev1alpha1.JobStatus{Conditions: []metav1.Condition{{
 				Type: in.JobCondition, Status: metav1.ConditionTrue,
 				Reason: "Test", LastTransitionTime: metav1.Now(),
@@ -86,10 +86,8 @@ func TestUnresolvedLogProfile(t *testing.T) {
 		switch in.Measurement {
 		case "bandwidth":
 			m := &nvcrev1alpha1.BandwidthMeasurement{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "m", Namespace: "ns",
-					Finalizers: []string{bandwidthMeasurementFinalizer},
-				},
+				Name: "m", Namespace: "ns",
+				Finalizers: []string{bandwidthMeasurementFinalizer},
 				Spec: nvcrev1alpha1.BandwidthMeasurementSpec{
 					JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 					LogProfileRef: in.LogProfileRef,
@@ -112,10 +110,8 @@ func TestUnresolvedLogProfile(t *testing.T) {
 			conds, results = got.Status.Conditions, len(got.Status.Results)
 		default:
 			m := &nvcrev1alpha1.GoodputMeasurement{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "m", Namespace: "ns",
-					Finalizers: []string{goodputMeasurementFinalizer},
-				},
+				Name: "m", Namespace: "ns",
+				Finalizers: []string{goodputMeasurementFinalizer},
 				Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 					JobRef:        corev1.TypedLocalObjectReference{Name: "j"},
 					LogProfileRef: in.LogProfileRef,

--- a/pkg/controller/waiting_for_nodes_test.go
+++ b/pkg/controller/waiting_for_nodes_test.go
@@ -29,7 +29,7 @@ import (
 func TestWaitingForNodes(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "waiting-for-nodes",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -49,15 +49,13 @@ func TestWaitingForNodes(t *testing.T) {
 		}
 
 		cert := &nvcrev1alpha1.Certification{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "c", Namespace: "ns",
-				CreationTimestamp: metav1.Now(),
-				Finalizers:        []string{certificationFinalizer},
-			},
+			Name: "c", Namespace: "ns",
+			CreationTimestamp: metav1.Now(),
+			Finalizers:        []string{certificationFinalizer},
 			Spec: nvcrev1alpha1.CertificationSpec{
 				Target: nvcrev1alpha1.TargetSpec{NodeSelector: in.NodeSelector},
 				Categories: []nvcrev1alpha1.CertificateCategory{
-					{Domain: "communication", Variant: "nccl-all-reduce"},
+					{Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce},
 				},
 			},
 		}
@@ -65,12 +63,12 @@ func TestWaitingForNodes(t *testing.T) {
 		builder := fake.NewClientBuilder().WithScheme(scheme).
 			WithObjects(cert).WithStatusSubresource(cert)
 		for _, n := range in.Nodes {
-			builder = builder.WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n}})
+			builder = builder.WithObjects(&corev1.Node{Name: n})
 		}
 		c := builder.Build()
 
 		r := &CertificationReconciler{Client: c, Scheme: scheme}
-		_, _ = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c", Namespace: "ns"}})
+		_, _ = r.Reconcile(context.Background(), ctrl.Request{Name: "c", Namespace: "ns"})
 
 		got := &nvcrev1alpha1.Certification{}
 		if err := c.Get(context.Background(), types.NamespacedName{Name: "c", Namespace: "ns"}, got); err != nil {

--- a/pkg/controller/workflow_controller.go
+++ b/pkg/controller/workflow_controller.go
@@ -43,6 +43,9 @@ const (
 	workflowFinalizer              = "nvcre.nvidia.com/workflow-finalizer"
 	defaultWorkflowRequeueInterval = 15 * time.Second
 
+	// mnnvlEnableEnvVar is the env var name used to toggle multi-node NVLink.
+	mnnvlEnableEnvVar = "NCCL_MNNVL_ENABLE"
+
 	// Workflow tier reason constants are in helpers.go.
 )
 
@@ -660,7 +663,7 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *nvcr
 	var cordoned []string
 	for _, n := range nodes {
 		if n.Spec.Unschedulable {
-			if n.Labels["nvidia.com/gpu.present"] == "true" {
+			if n.Labels[GPUNodeLabel] == present {
 				cordoned = append(cordoned, n.Name)
 			}
 			continue
@@ -672,7 +675,7 @@ func discoverTargetNodes(ctx context.Context, reader client.Reader, target *nvcr
 	// Filter to GPU-equipped nodes only
 	var gpuFiltered []corev1.Node
 	for _, n := range nodes {
-		if n.Labels["nvidia.com/gpu.present"] == "true" {
+		if n.Labels[GPUNodeLabel] == present {
 			gpuFiltered = append(gpuFiltered, n)
 		}
 	}
@@ -935,8 +938,7 @@ func (r *WorkflowReconciler) launchPendingGroups(ctx context.Context, workflow *
 			// A name collision with a foreign Job or dependency is terminal:
 			// retrying cannot succeed while the foreign object holds the name,
 			// and adopting or deleting it is never safe.
-			var collision *nameCollisionError
-			if errors.As(err, &collision) {
+			if collision, ok := errors.AsType[*nameCollisionError](err); ok {
 				logf.FromContext(ctx).Error(err, "Name collision while launching group", "group", g.Name)
 				// Persist refs for dependency copies created before the collision
 				// so the finalizer can clean them up (conflict-safe via the extra
@@ -1007,11 +1009,9 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *nv
 	}
 
 	job := &nvcrev1alpha1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobName,
-			Namespace: workflow.Namespace,
-		},
-		Spec: *patchedSpec,
+		Name:      jobName,
+		Namespace: workflow.Namespace,
+		Spec:      *patchedSpec,
 	}
 
 	// Pin to this group's specific nodes via NodeAffinity
@@ -1069,7 +1069,7 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *nv
 	// Merge labels from template metadata
 	labels := make(map[string]string)
 	maps.Copy(labels, workflow.Spec.JobTemplate.Labels)
-	labels["app.kubernetes.io/managed-by"] = "nvcre"
+	labels["app.kubernetes.io/managed-by"] = managedByValue
 	labels["nvcre.nvidia.com/workflow"] = workflow.Name
 	labels["nvcre.nvidia.com/group"] = group.Name
 	job.SetLabels(labels)
@@ -1150,7 +1150,7 @@ func (r *WorkflowReconciler) createJobForGroup(ctx context.Context, workflow *nv
 	group.Phase = nvcrev1alpha1.GroupRunning
 	group.JobRef = &nvcrev1alpha1.WorkloadReference{
 		APIVersion: "nvcre.nvidia.com/v1alpha1",
-		Kind:       "Job",
+		Kind:       kindJob,
 		Name:       jobName,
 		Namespace:  workflow.Namespace,
 	}
@@ -2507,7 +2507,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *nvcrev1
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList,
 		client.InNamespace(job.Namespace),
-		client.MatchingLabels{"nvcre.nvidia.com/job": job.Name},
+		client.MatchingLabels{labelJobKey: job.Name},
 	); err != nil {
 		log.V(1).Info("Failed to list pods for timeout log capture", "error", err)
 		return
@@ -2538,7 +2538,7 @@ func (r *WorkflowReconciler) captureTimeoutLog(ctx context.Context, job *nvcrev1
 	// Find the main container name (prefer "node", fall back to first)
 	containerName := ""
 	for _, c := range targetPod.Spec.Containers {
-		if containerName == "" || c.Name == "node" {
+		if containerName == "" || c.Name == labelNode {
 			containerName = c.Name
 		}
 	}
@@ -2947,7 +2947,7 @@ func overrideMNNVL(spec *nvcrev1alpha1.WorkloadSpec, value string) {
 
 	// Check Env vars.
 	for i, e := range trainer.Env {
-		if e.Name == "NCCL_MNNVL_ENABLE" {
+		if e.Name == mnnvlEnableEnvVar {
 			trainer.Env[i].Value = value
 			return
 		}
@@ -2955,7 +2955,7 @@ func overrideMNNVL(spec *nvcrev1alpha1.WorkloadSpec, value string) {
 
 	// Not found — add as env var.
 	trainer.Env = append(trainer.Env, corev1.EnvVar{
-		Name: "NCCL_MNNVL_ENABLE", Value: value,
+		Name: mnnvlEnableEnvVar, Value: value,
 	})
 }
 
@@ -2976,7 +2976,7 @@ func isMNNVLEnabledInJobTemplate(tmpl *nvcrev1alpha1.JobTemplateSpec) bool {
 		}
 	}
 	for _, e := range trainer.Env {
-		if e.Name == "NCCL_MNNVL_ENABLE" {
+		if e.Name == mnnvlEnableEnvVar {
 			return e.Value != "0"
 		}
 	}

--- a/pkg/controller/workflow_controller_test.go
+++ b/pkg/controller/workflow_controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
@@ -18,7 +17,7 @@ import (
 func TestBuildTolerations(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-tolerations",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -42,7 +41,7 @@ func TestBuildTolerations(t *testing.T) {
 func TestNodeMatchesTaints(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "node-match-taints",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -69,7 +68,7 @@ func TestNodeMatchesTaints(t *testing.T) {
 func TestCanLaunchOverflow(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "can-launch-overflow",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -96,7 +95,7 @@ func TestCanLaunchOverflow(t *testing.T) {
 func TestHasNodeOverlap(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "has-node-overlap",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -123,7 +122,7 @@ func TestHasNodeOverlap(t *testing.T) {
 func TestCountRunningGroups(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "count-running-groups",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -150,7 +149,7 @@ func TestCountRunningGroups(t *testing.T) {
 func TestAllGroupsTerminal(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "all-groups-terminal",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -178,7 +177,7 @@ func TestAllGroupsTerminal(t *testing.T) {
 func TestHasRunningGroups(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "has-running-groups",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -206,7 +205,7 @@ func TestHasRunningGroups(t *testing.T) {
 func TestGetGroupJobName(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "get-group-job-name",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -221,7 +220,7 @@ func TestGetGroupJobName(t *testing.T) {
 		}
 
 		workflow := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: input.WorkflowName},
+			Name: input.WorkflowName,
 			Spec: nvcrev1alpha1.WorkflowSpec{
 				Orchestration: nvcrev1alpha1.OrchestrationSpec{
 					Iterations: input.Iterations,
@@ -251,7 +250,7 @@ func TestGetGroupJobName(t *testing.T) {
 func TestEffectiveIterations(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "effective-iterations",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -278,7 +277,7 @@ func TestEffectiveIterations(t *testing.T) {
 func TestHasMultipleIterations(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "has-multiple-iterations",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/workflow_deps_test.go
+++ b/pkg/controller/workflow_deps_test.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -21,7 +19,7 @@ import (
 func TestClassifyDependencies(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "classify-dependencies",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -37,7 +35,7 @@ func TestClassifyDependencies(t *testing.T) {
 		var deps []nvcrev1alpha1.DependencySpec
 		for _, d := range input.Deps {
 			deps = append(deps, nvcrev1alpha1.DependencySpec{
-				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
+				Raw: []byte(d.Raw),
 			})
 		}
 
@@ -72,7 +70,7 @@ func TestClassifyDependencies(t *testing.T) {
 func TestOrderDependencies(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "order-dependencies",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -87,7 +85,7 @@ func TestOrderDependencies(t *testing.T) {
 		var deps []nvcrev1alpha1.DependencySpec
 		for _, d := range input.Deps {
 			deps = append(deps, nvcrev1alpha1.DependencySpec{
-				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
+				Raw: []byte(d.Raw),
 			})
 		}
 
@@ -114,7 +112,7 @@ func TestOrderDependencies(t *testing.T) {
 func TestDetectCrossRefs(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-cross-refs",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -129,7 +127,7 @@ func TestDetectCrossRefs(t *testing.T) {
 		var deps []nvcrev1alpha1.DependencySpec
 		for _, d := range input.Deps {
 			deps = append(deps, nvcrev1alpha1.DependencySpec{
-				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
+				Raw: []byte(d.Raw),
 			})
 		}
 
@@ -157,7 +155,7 @@ func TestDetectCrossRefs(t *testing.T) {
 func TestDepJobSuffix(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "dep-job-suffix",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -190,7 +188,7 @@ func TestDepJobSuffix(t *testing.T) {
 func TestBuildReplacementMap(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-replacement-map",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -207,7 +205,7 @@ func TestBuildReplacementMap(t *testing.T) {
 		var deps []nvcrev1alpha1.DependencySpec
 		for _, d := range input.Deps {
 			dep := nvcrev1alpha1.DependencySpec{
-				RawExtension: runtime.RawExtension{Raw: []byte(d.Raw)},
+				Raw: []byte(d.Raw),
 			}
 			deps = append(deps, dep)
 		}
@@ -241,7 +239,7 @@ func TestBuildReplacementMap(t *testing.T) {
 func TestSuffixDependencyObject(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "suffix-dependency-object",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -269,7 +267,7 @@ func TestSuffixDependencyObject(t *testing.T) {
 func TestSuffixJobSpec(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "suffix-job-spec",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -302,7 +300,7 @@ func TestSuffixJobSpec(t *testing.T) {
 func TestIsResourceName(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "is-resource-name",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -328,7 +326,7 @@ func TestIsResourceName(t *testing.T) {
 func TestExtractMetadataName(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "extract-metadata-name",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -354,7 +352,7 @@ func TestExtractMetadataName(t *testing.T) {
 func TestReverseDependencyRefs(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "reverse-dependency-refs",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -384,7 +382,7 @@ func TestReverseDependencyRefs(t *testing.T) {
 func TestDependencyOwnership(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "dependency-ownership",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -399,10 +397,8 @@ func TestDependencyOwnership(t *testing.T) {
 		}
 
 		workflow := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: input.Workflow.Name,
-				UID:  types.UID(input.Workflow.UID),
-			},
+			Name: input.Workflow.Name,
+			UID:  types.UID(input.Workflow.UID),
 		}
 		obj := &unstructured.Unstructured{Object: input.Object}
 
@@ -424,7 +420,7 @@ func TestDependencyOwnership(t *testing.T) {
 func TestCollectAllStrings(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "collect-all-strings",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/workflow_detect_aws_gb300_test.go
+++ b/pkg/controller/workflow_detect_aws_gb300_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/catalog"
 )
 
+// testGPUArchGB300 is the gpuArchitecture value used throughout this file's
+// AWS GB300 override-matching fixtures.
+const testGPUArchGB300 = "gb300"
+
 // TestAWSGB300EFAStripInvariant asserts that every NCCL-using catalog entry,
 // after applying its overrides for the (platform=aws, gpuArchitecture=gb300)
 // context, produces a trainer container that does NOT leave the AWS EFA stack
@@ -35,22 +39,22 @@ import (
 func TestAWSGB300EFAStripInvariant(t *testing.T) {
 	// Sweep configurations large enough to satisfy each entry's MinGPUs.
 	configs := []catalog.BuildConfig{
-		{NodesPerJob: 1, GpusPerNode: 4, GPUArchitecture: "gb300"},
-		{NodesPerJob: 4, GpusPerNode: 4, GPUArchitecture: "gb300"},
-		{NodesPerJob: 8, GpusPerNode: 4, GPUArchitecture: "gb300"},
-		{NodesPerJob: 32, GpusPerNode: 4, GPUArchitecture: "gb300"},
-		{NodesPerJob: 128, GpusPerNode: 4, GPUArchitecture: "gb300"},
+		{NodesPerJob: 1, GpusPerNode: 4, GPUArchitecture: testGPUArchGB300},
+		{NodesPerJob: 4, GpusPerNode: 4, GPUArchitecture: testGPUArchGB300},
+		{NodesPerJob: 8, GpusPerNode: 4, GPUArchitecture: testGPUArchGB300},
+		{NodesPerJob: 32, GpusPerNode: 4, GPUArchitecture: testGPUArchGB300},
+		{NodesPerJob: 128, GpusPerNode: 4, GPUArchitecture: testGPUArchGB300},
 	}
 
 	target := nvcrev1alpha1.TargetSpec{
 		NodeSelector: map[string]string{
-			"nvidia.com/gpu.product": "NVIDIA-GB300",
+			testGPUProductLabel: "NVIDIA-GB300",
 		},
 	}
 
 	octx := OverrideContext{
 		Platform:        "aws",
-		GPUArchitecture: "gb300",
+		GPUArchitecture: testGPUArchGB300,
 		WorkloadKind:    "trainJob",
 	}
 
@@ -166,7 +170,7 @@ func entryUsesNCCL(spec nvcrev1alpha1.WorkflowSpec) bool {
 		if err := json.Unmarshal(dep.Raw, &obj); err != nil {
 			continue
 		}
-		if obj["kind"] != "ConfigMap" {
+		if obj["kind"] != kindConfigMap {
 			continue
 		}
 		data, _ := obj["data"].(map[string]any)
@@ -192,8 +196,8 @@ func hasAWSGB300When(w nvcrev1alpha1.WhenSpec) bool {
 		return false
 	}
 	platformMatches := w.Platform.Equals == "aws" || containsString(w.Platform.In, "aws")
-	archMatches := w.GPUArchitecture.Equals == "gb300" ||
-		containsString(w.GPUArchitecture.In, "gb300")
+	archMatches := w.GPUArchitecture.Equals == testGPUArchGB300 ||
+		containsString(w.GPUArchitecture.In, testGPUArchGB300)
 	return platformMatches && archMatches
 }
 

--- a/pkg/controller/workflow_detect_test.go
+++ b/pkg/controller/workflow_detect_test.go
@@ -18,7 +18,7 @@ import (
 func TestDetectPlatform(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-platform",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -44,7 +44,7 @@ func TestDetectPlatform(t *testing.T) {
 func TestDetectPlatformConsistent(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-platform-consistent",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -76,7 +76,7 @@ func TestDetectPlatformConsistent(t *testing.T) {
 func TestDetectGPUArchConsistent(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-gpu-arch-consistent",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -108,7 +108,7 @@ func TestDetectGPUArchConsistent(t *testing.T) {
 func TestDetectGPUArchitecture(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-gpu-architecture",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -134,7 +134,7 @@ func TestDetectGPUArchitecture(t *testing.T) {
 func TestMatchesWhen(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "matches-when",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -177,7 +177,7 @@ func TestMatchesWhen(t *testing.T) {
 func TestApplyOverrides(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-overrides",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -217,7 +217,7 @@ func TestApplyOverrides(t *testing.T) {
 func TestDetectWorkloadKind(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-workload-kind",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -243,7 +243,7 @@ func TestDetectWorkloadKind(t *testing.T) {
 func TestMatchesIntSpec(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "matches-int-spec",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -270,7 +270,7 @@ func TestMatchesIntSpec(t *testing.T) {
 func TestSummarizeWhen(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "summarize-when",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -296,7 +296,7 @@ func TestSummarizeWhen(t *testing.T) {
 func TestApplyOverridesWithTracking(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-overrides-tracking",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -331,7 +331,7 @@ func TestApplyOverridesWithTracking(t *testing.T) {
 func TestCountDomains(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "count-domains",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/workflow_nodes_ref_test.go
+++ b/pkg/controller/workflow_nodes_ref_test.go
@@ -17,7 +17,7 @@ import (
 func TestApplySucceededNodesRef(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-succeeded-nodes-ref",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *nvcrev1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {
@@ -31,7 +31,7 @@ func TestApplySucceededNodesRef(t *testing.T) {
 func TestApplyFailedNodesRef(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-failed-nodes-ref",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		return runApplyNodesRefCase(tc, func(ref *corev1.TypedLocalObjectReference, w *nvcrev1alpha1.Workflow) (bool, *corev1.TypedLocalObjectReference) {

--- a/pkg/controller/workflow_nodeshortfall_test.go
+++ b/pkg/controller/workflow_nodeshortfall_test.go
@@ -19,7 +19,7 @@ import (
 func TestNotEnoughNodesMessage(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "not-enough-nodes-message",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/workflow_orchestration_conflict_test.go
+++ b/pkg/controller/workflow_orchestration_conflict_test.go
@@ -159,7 +159,7 @@ func persistedOrchestrationOutput(c client.Client, writes int) (string, error) {
 func TestHandleIterationCompleteSurvivesConflict(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "iteration-complete-conflict",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -192,7 +192,7 @@ func TestHandleIterationCompleteSurvivesConflict(t *testing.T) {
 		}
 
 		wf := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "ns", Generation: 1, UID: "01234567-89ab"},
+			Name: "wf", Namespace: "ns", Generation: 1, UID: "01234567-89ab",
 			Spec: nvcrev1alpha1.WorkflowSpec{
 				Orchestration: nvcrev1alpha1.OrchestrationSpec{Iterations: in.Iterations},
 			},
@@ -233,7 +233,7 @@ func TestHandleIterationCompleteSurvivesConflict(t *testing.T) {
 func TestDiagnoseSetGroupsSurvivesConflict(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "diagnose-set-groups-conflict",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -256,7 +256,7 @@ func TestDiagnoseSetGroupsSurvivesConflict(t *testing.T) {
 		}
 
 		wf := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "ns", Generation: 1, UID: "01234567-89ab"},
+			Name: "wf", Namespace: "ns", Generation: 1, UID: "01234567-89ab",
 			Spec: nvcrev1alpha1.WorkflowSpec{
 				Orchestration: nvcrev1alpha1.OrchestrationSpec{
 					Diagnose: &nvcrev1alpha1.DiagnoseSpec{},
@@ -269,7 +269,7 @@ func TestDiagnoseSetGroupsSurvivesConflict(t *testing.T) {
 					CurrentIteration:    in.CompletedIterations,
 					CompletedIterations: in.CompletedIterations,
 					Groups: []nvcrev1alpha1.GroupStatus{{
-						Name: "previous-round", Nodes: []string{"node-a", "node-b"},
+						Name: "previous-round", Nodes: []string{testNodeA, "node-b"},
 						Phase: nvcrev1alpha1.GroupSucceeded,
 					}},
 					Diagnose: &nvcrev1alpha1.DiagnoseStatus{Stage: in.Stage, Round: in.Round},

--- a/pkg/controller/workflow_validation_failed_test.go
+++ b/pkg/controller/workflow_validation_failed_test.go
@@ -17,7 +17,7 @@ import (
 func TestApplyWorkflowValidationFailed(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-workflow-validation-failed",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/controller/workload_gpus_test.go
+++ b/pkg/controller/workload_gpus_test.go
@@ -25,7 +25,7 @@ import (
 func TestWorkloadGPUsPerNode(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "workload-gpus-per-node",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var spec nvcrev1alpha1.WorkflowSpec

--- a/pkg/controller/workloadrun_controller.go
+++ b/pkg/controller/workloadrun_controller.go
@@ -88,13 +88,11 @@ func (r *WorkloadRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	workflowSpec := r.buildWorkflowSpec(ctx, &run)
 
 	workflow := &nvcrev1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      run.Name,
-			Namespace: run.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":  "nvcre",
-				"nvcre.nvidia.com/workload-run": run.Name,
-			},
+		Name:      run.Name,
+		Namespace: run.Namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by":  managedByValue,
+			"nvcre.nvidia.com/workload-run": run.Name,
 		},
 		Spec: *workflowSpec,
 	}
@@ -288,11 +286,9 @@ func (r *WorkloadRunReconciler) buildWorkflowSpec(ctx context.Context, run *nvcr
 		}
 		volumes = append(volumes, corev1.Volume{
 			Name: "config-volume",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-					DefaultMode:          func() *int32 { m := int32(0755); return &m }(),
-				},
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				Name:        configMapName,
+				DefaultMode: func() *int32 { m := int32(0755); return &m }(),
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -523,7 +519,7 @@ func (r *WorkloadRunReconciler) buildJobTemplate(run *nvcrev1alpha1.WorkloadRun,
 func buildWRConfigMapDep(name string, data map[string]string) nvcrev1alpha1.DependencySpec {
 	cm := map[string]any{
 		"apiVersion": "v1",
-		"kind":       "ConfigMap",
+		"kind":       kindConfigMap,
 		"metadata": map[string]any{
 			"name":   fmt.Sprintf("%s-config", name),
 			"labels": map[string]any{"app": name},
@@ -531,7 +527,7 @@ func buildWRConfigMapDep(name string, data map[string]string) nvcrev1alpha1.Depe
 		"data": data,
 	}
 	raw, _ := json.Marshal(cm)
-	return nvcrev1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
+	return nvcrev1alpha1.DependencySpec{Raw: raw}
 }
 
 // buildWRPVCDep creates a PVC dependency for checkpoint storage.
@@ -552,7 +548,7 @@ func buildWRPVCDep(name string, checkpoint *nvcrev1alpha1.WorkloadRunCheckpoint)
 		pvc["spec"].(map[string]any)["storageClassName"] = *checkpoint.StorageClassName
 	}
 	raw, _ := json.Marshal(pvc)
-	return nvcrev1alpha1.DependencySpec{RawExtension: kruntime.RawExtension{Raw: raw}}
+	return nvcrev1alpha1.DependencySpec{Raw: raw}
 }
 
 // resolveWRTimeout turns a user-supplied timeoutPerJob into a duration, falling

--- a/pkg/controller/workloadrun_mnnvl_test.go
+++ b/pkg/controller/workloadrun_mnnvl_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -31,7 +30,7 @@ import (
 func TestWorkloadRunMPILauncherMNNVL(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "workloadrun-mpi-launcher-mnnvl",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -51,18 +50,16 @@ func TestWorkloadRunMPILauncherMNNVL(t *testing.T) {
 		}
 
 		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-0",
-				Labels: map[string]string{
-					GPUNodeLabel:             "true",
-					"nvidia.com/gpu.product": in.GPUProduct,
-				},
+			Name: "node-0",
+			Labels: map[string]string{
+				GPUNodeLabel:        present,
+				testGPUProductLabel: in.GPUProduct,
 			},
 		}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
 
 		run := &nvcrev1alpha1.WorkloadRun{
-			ObjectMeta: metav1.ObjectMeta{Name: "mnnvl-run", Namespace: "default"},
+			Name: "mnnvl-run", Namespace: testNS,
 			Spec: nvcrev1alpha1.WorkloadRunSpec{
 				Image:       "nvcr.io/nvidia/pytorch:24.01-py3",
 				NumNodes:    2,

--- a/pkg/controller/workloadrun_scale_test.go
+++ b/pkg/controller/workloadrun_scale_test.go
@@ -20,7 +20,7 @@ import (
 func TestNodesPerJobForScale(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "workloadrun-scale",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var spec nvcrev1alpha1.WorkloadRunSpec

--- a/pkg/controller/workloadrun_timeout_test.go
+++ b/pkg/controller/workloadrun_timeout_test.go
@@ -22,7 +22,7 @@ import (
 func TestWorkloadRunTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "workloadrun-timeout",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var spec nvcrev1alpha1.WorkloadRunSpec

--- a/pkg/goodput/calculator_test.go
+++ b/pkg/goodput/calculator_test.go
@@ -27,7 +27,7 @@ type calculatorInput struct {
 func TestCalculateGoodput(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "calculate-goodput",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input calculatorInput
@@ -55,7 +55,7 @@ type progressInput struct {
 func TestCumulativeMetricsUpdateProgress(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "cumulative-update-progress",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input progressInput

--- a/pkg/goodput/parser_test.go
+++ b/pkg/goodput/parser_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 )
 
+// testFieldStep is the "step" key shared by the checkpoint/restore map
+// builders below.
+const testFieldStep = "step"
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Golden-file tests using testutil
 // ──────────────────────────────────────────────────────────────────────────────
@@ -23,7 +27,7 @@ import (
 func TestParseLogs(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "parse-logs",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var profile v1alpha1.LogProfile
@@ -54,7 +58,7 @@ func TestParseLogs(t *testing.T) {
 func TestExtractK8sTimestamp(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "extract-k8s-timestamp",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		line := strings.TrimSpace(tc.Inputs["input.txt"])
@@ -75,7 +79,7 @@ func TestExtractK8sTimestamp(t *testing.T) {
 func TestNormalizeUnit(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "normalize-unit",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -137,7 +141,7 @@ func toTestOutput(r *ParseResult) map[string]any {
 	}
 	if r.CheckpointRestore != nil {
 		m := map[string]any{
-			"step": r.CheckpointRestore.Step,
+			testFieldStep: r.CheckpointRestore.Step,
 		}
 		if r.CheckpointRestore.Path != "" {
 			m["path"] = r.CheckpointRestore.Path
@@ -152,7 +156,7 @@ func toTestOutput(r *ParseResult) map[string]any {
 	}
 	if r.PendingSave != nil {
 		ps := map[string]any{
-			"step": r.PendingSave.Step,
+			testFieldStep: r.PendingSave.Step,
 		}
 		if !r.PendingSave.Timestamp.IsZero() {
 			ps["timestamp"] = r.PendingSave.Timestamp.UTC().Format(time.RFC3339Nano)
@@ -194,7 +198,7 @@ func stepToMap(s *TrainingStepInfo) map[string]any {
 
 func checkpointToMap(c *CheckpointInfo) map[string]any {
 	m := map[string]any{
-		"step": c.Step,
+		testFieldStep: c.Step,
 	}
 	if !c.Timestamp.IsZero() {
 		m["timestamp"] = c.Timestamp.UTC().Format(time.RFC3339Nano)

--- a/pkg/goodput/reader_test.go
+++ b/pkg/goodput/reader_test.go
@@ -28,7 +28,7 @@ func (f *fakeLogFetcher) FetchLogs(_ context.Context, _, podName string, _ podlo
 func TestReadMultiWorkerLogs(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "read-multi-worker-logs",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var profile v1alpha1.LogProfile

--- a/pkg/gpu/majority_test.go
+++ b/pkg/gpu/majority_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
@@ -21,7 +20,7 @@ import (
 func TestMajorityArchitecture(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "majority-architecture",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -36,7 +35,7 @@ func TestMajorityArchitecture(t *testing.T) {
 
 		nodes := make([]corev1.Node, 0, len(input.Nodes))
 		for _, n := range input.Nodes {
-			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: n.Name}}
+			node := corev1.Node{Name: n.Name}
 			if n.Product != "" {
 				node.Labels = map[string]string{"nvidia.com/gpu.product": n.Product}
 			}

--- a/pkg/gpu/product_test.go
+++ b/pkg/gpu/product_test.go
@@ -15,7 +15,7 @@ import (
 func TestParseProduct(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse-product",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -16,7 +16,7 @@ import (
 func TestTruncate(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "truncate",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -86,7 +86,7 @@ func TestTruncateTrailingHyphen(t *testing.T) {
 func TestTruncateEndToEndChain(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "truncate-end-to-end-chain",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/nccl/parser_test.go
+++ b/pkg/nccl/parser_test.go
@@ -11,12 +11,19 @@ import (
 	"strings"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	v1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
+
+// testTimestampLayout is the Kubernetes log timestamp layout shared by the
+// fixtures below.
+const testTimestampLayout = "2006-01-02T15:04:05.999999999Z"
+
+// testBusBWRegex is the NCCL bandwidth table row regex shared by the
+// fixtures below.
+const testBusBWRegex = `^\s*(?P<size>\d+)\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+(?P<algBW>[\d.]+)\s+(?P<busBW>[\d.]+)`
 
 // The lines below cover an NCCL INFO line, a two-line table header, data
 // lines with a K8s timestamp prefix (both "Z" and offset-free variants), and
@@ -25,7 +32,7 @@ import (
 func TestParseBandwidthLogs(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse-bandwidth-logs",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -37,7 +44,7 @@ func TestParseBandwidthLogs(t *testing.T) {
 		}
 
 		profile := &v1alpha1.LogProfile{
-			ObjectMeta: metav1.ObjectMeta{Name: "nccl-all-reduce"},
+			Name: "nccl-all-reduce",
 			Spec: v1alpha1.LogProfileSpec{
 				Timestamp: v1alpha1.TimestampSpec{Layout: in.TimestampLayout},
 				Patterns: v1alpha1.LogPatternSet{
@@ -84,12 +91,12 @@ func TestParseBandwidthLogs(t *testing.T) {
 // A100 run on a node in PDT.
 func TestParseBandwidthLogsNonUTCNode(t *testing.T) {
 	profile := &v1alpha1.LogProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "nccl-loopback"},
+		Name: "nccl-loopback",
 		Spec: v1alpha1.LogProfileSpec{
-			Timestamp: v1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05.999999999Z"},
+			Timestamp: v1alpha1.TimestampSpec{Layout: testTimestampLayout},
 			Patterns: v1alpha1.LogPatternSet{
 				BandwidthResult: &v1alpha1.EventPattern{
-					Regex: `^\s*(?P<size>\d+)\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+(?P<algBW>[\d.]+)\s+(?P<busBW>[\d.]+)`,
+					Regex: testBusBWRegex,
 				},
 			},
 		},
@@ -131,12 +138,12 @@ func TestParseRealA100LoopbackLog(t *testing.T) {
 	}
 
 	profile := &v1alpha1.LogProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "nccl-loopback"},
+		Name: "nccl-loopback",
 		Spec: v1alpha1.LogProfileSpec{
-			Timestamp: v1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05.999999999Z"},
+			Timestamp: v1alpha1.TimestampSpec{Layout: testTimestampLayout},
 			Patterns: v1alpha1.LogPatternSet{
 				BandwidthResult: &v1alpha1.EventPattern{
-					Regex: `^\s*(?P<size>\d+)\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+(?P<algBW>[\d.]+)\s+(?P<busBW>[\d.]+)`,
+					Regex: testBusBWRegex,
 				},
 			},
 		},
@@ -183,12 +190,12 @@ func TestParseRealA100AllReduce2NodeLog(t *testing.T) {
 	}
 
 	profile := &v1alpha1.LogProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "nccl-bandwidth"},
+		Name: "nccl-bandwidth",
 		Spec: v1alpha1.LogProfileSpec{
-			Timestamp: v1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05.999999999Z"},
+			Timestamp: v1alpha1.TimestampSpec{Layout: testTimestampLayout},
 			Patterns: v1alpha1.LogPatternSet{
 				BandwidthResult: &v1alpha1.EventPattern{
-					Regex: `^\s*(?P<size>\d+)\s+\d+\s+\w+\s+\w+\s+-?\d+\s+[\d.]+\s+(?P<algBW>[\d.]+)\s+(?P<busBW>[\d.]+)`,
+					Regex: testBusBWRegex,
 				},
 			},
 		},
@@ -222,7 +229,7 @@ func TestParseRealA100AllReduce2NodeLog(t *testing.T) {
 
 func TestNewParserMissingPattern(t *testing.T) {
 	profile := &v1alpha1.LogProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "empty"},
+		Name: "empty",
 		Spec: v1alpha1.LogProfileSpec{
 			Timestamp: v1alpha1.TimestampSpec{Layout: "2006-01-02T15:04:05Z"},
 			Patterns:  v1alpha1.LogPatternSet{},
@@ -238,7 +245,7 @@ func TestNewParserMissingPattern(t *testing.T) {
 func TestStripK8sTimestamp(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "strip-k8s-timestamp",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/nodemonitor/cel/detector_test.go
+++ b/pkg/nodemonitor/cel/detector_test.go
@@ -21,7 +21,7 @@ import (
 func TestDetect(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "detect",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		expression := strings.TrimSpace(tc.Inputs["input_expression.txt"])
@@ -52,7 +52,7 @@ func TestDetect(t *testing.T) {
 func TestDetectorName(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "detector-name",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		expression := strings.TrimSpace(tc.Inputs["input_expression.txt"])

--- a/pkg/numstr/numstr_test.go
+++ b/pkg/numstr/numstr_test.go
@@ -21,7 +21,7 @@ import (
 func TestParse(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -51,7 +51,7 @@ func TestParse(t *testing.T) {
 func TestFormatParseRoundTrip(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "format-parse-round-trip",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/orchestration/bisect_test.go
+++ b/pkg/orchestration/bisect_test.go
@@ -14,7 +14,7 @@ import (
 func TestBisect(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "bisect",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input BisectInput

--- a/pkg/orchestration/diagnose_test.go
+++ b/pkg/orchestration/diagnose_test.go
@@ -14,7 +14,7 @@ import (
 func TestScreenGroups(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "screen-groups",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -56,7 +56,7 @@ func TestScreenGroups(t *testing.T) {
 func TestBuildConfirmationGroups(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "confirmation-groups",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/orchestration/partition_test.go
+++ b/pkg/orchestration/partition_test.go
@@ -14,7 +14,7 @@ import (
 func TestPartitionNodes(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "partition",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input PartitionInput
@@ -39,7 +39,7 @@ func TestPartitionNodes(t *testing.T) {
 func TestPartitionNodesErrors(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "partition-errors",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input PartitionInput

--- a/pkg/platform/overrides_test.go
+++ b/pkg/platform/overrides_test.go
@@ -69,7 +69,7 @@ func TestEveryLibFragmentParsesThroughPlatform(t *testing.T) {
 func TestBuildOverridesRendersForEveryPlatform(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "build-overrides",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg OverrideConfig
@@ -107,7 +107,7 @@ func TestBuildOverridesRendersForEveryPlatform(t *testing.T) {
 func TestBuildOverridesMPIArgs(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "override-mpi-args",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg OverrideConfig

--- a/pkg/platform/resources_test.go
+++ b/pkg/platform/resources_test.go
@@ -29,7 +29,7 @@ type workerResourcesInput struct {
 func TestWorkerResources(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "worker-resources",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in workerResourcesInput

--- a/pkg/platform/runtime.go
+++ b/pkg/platform/runtime.go
@@ -11,13 +11,37 @@ import (
 	nvcrev1alpha1 "github.com/NVIDIA/cluster-readiness-engine/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // gpuResourceName is the extended resource a container must request to be given
 // a GPU. A container that does not name it is scheduled without one, however
 // many GPUs the node has.
 const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
+
+// Repeated map keys and literal values used when building the unstructured
+// TrainingRuntime manifests below.
+const (
+	keyName         = "name"
+	keyImage        = "image"
+	keyEnv          = "env"
+	keyEmptyDir     = "emptyDir"
+	keyContainers   = "containers"
+	keyVolumes      = "volumes"
+	keyMetadata     = "metadata"
+	keyLabels       = "labels"
+	keySpec         = "spec"
+	keyTemplate     = "template"
+	keyVolumeMounts = "volumeMounts"
+	keyMountPath    = "mountPath"
+
+	volumeNameDSHM    = "dshm"
+	volumeNameSSHKeys = "ssh-keys"
+	labelKeyApp       = "app"
+	mpiSSHMountPath   = "/tmp/mpi-ssh-raw"
+	nodeJobName       = "node"
+	mpiSSHAuthName    = "mpi-ssh-auth"
+	keyReadOnly       = "readOnly"
+)
 
 // defaultWorkerResources returns the worker resources block when the user did
 // not provide spec.resources.
@@ -126,9 +150,9 @@ func applyGangScheduler(cfg RuntimeConfig, podSpec, podLabels map[string]any) {
 func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 	// Build container spec
 	container := map[string]any{
-		"name":  "node",
-		"image": cfg.Image,
-		"env":   cfg.Env,
+		keyName:  nodeJobName,
+		keyImage: cfg.Image,
+		keyEnv:   cfg.Env,
 	}
 
 	if cfg.Resources != nil {
@@ -139,15 +163,15 @@ func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 
 	// Volume mounts: shared memory + user-provided.
 	mounts := make([]corev1.VolumeMount, 0, 1+len(cfg.VolumeMounts))
-	mounts = append(mounts, corev1.VolumeMount{Name: "dshm", MountPath: "/dev/shm"})
+	mounts = append(mounts, corev1.VolumeMount{Name: volumeNameDSHM, MountPath: "/dev/shm"})
 	mounts = append(mounts, cfg.VolumeMounts...)
-	container["volumeMounts"] = mounts
+	container[keyVolumeMounts] = mounts
 
 	// Volumes: shared memory + user-provided.
 	volumes := make([]any, 0, 1+len(cfg.Volumes))
 	volumes = append(volumes, map[string]any{
-		"name":     "dshm",
-		"emptyDir": map[string]any{"medium": "Memory"},
+		keyName:     volumeNameDSHM,
+		keyEmptyDir: map[string]any{"medium": "Memory"},
 	})
 	for _, v := range cfg.Volumes {
 		volumes = append(volumes, v)
@@ -161,8 +185,8 @@ func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 				"type": "RuntimeDefault",
 			},
 		},
-		"containers": []any{container},
-		"volumes":    volumes,
+		keyContainers: []any{container},
+		keyVolumes:    volumes,
 	}
 
 	// Add init containers if provided
@@ -172,39 +196,39 @@ func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 
 	podLabels := map[string]any{
 		"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
-		"app": cfg.EntryName,
+		labelKeyApp: cfg.EntryName,
 	}
 	applyGangScheduler(cfg, podSpec, podLabels)
 
 	rt := map[string]any{
 		"apiVersion": "trainer.kubeflow.org/v1alpha1",
 		"kind":       "TrainingRuntime",
-		"metadata": map[string]any{
-			"name": fmt.Sprintf("%s-runtime", cfg.EntryName),
-			"labels": map[string]any{
+		keyMetadata: map[string]any{
+			keyName: fmt.Sprintf("%s-runtime", cfg.EntryName),
+			keyLabels: map[string]any{
 				"trainer.kubeflow.org/framework": "torch",
-				"app":                            cfg.EntryName,
+				labelKeyApp:                      cfg.EntryName,
 			},
 		},
-		"spec": map[string]any{
+		keySpec: map[string]any{
 			"mlPolicy": map[string]any{
 				"numNodes": cfg.NodesPerJob,
 				"torch": map[string]any{
 					"numProcPerNode": cfg.GpusPerNode,
 				},
 			},
-			"template": map[string]any{
-				"spec": map[string]any{
+			keyTemplate: map[string]any{
+				keySpec: map[string]any{
 					"replicatedJobs": []any{
 						map[string]any{
-							"name": "node",
-							"template": map[string]any{
-								"metadata": map[string]any{
-									"labels": podLabels,
+							keyName: nodeJobName,
+							keyTemplate: map[string]any{
+								keyMetadata: map[string]any{
+									keyLabels: podLabels,
 								},
-								"spec": map[string]any{
-									"template": map[string]any{
-										"spec": podSpec,
+								keySpec: map[string]any{
+									keyTemplate: map[string]any{
+										keySpec: podSpec,
 									},
 								},
 							},
@@ -217,7 +241,7 @@ func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 
 	data, _ := json.Marshal(rt)
 	return nvcrev1alpha1.DependencySpec{
-		RawExtension: runtime.RawExtension{Raw: data},
+		Raw: data,
 	}
 }
 
@@ -238,9 +262,9 @@ func BuildTorchRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 	// Worker (node) container: runs sshd
 	workerContainer := map[string]any{
-		"name":    "node",
-		"image":   cfg.Image,
-		"env":     cfg.Env,
+		keyName:   nodeJobName,
+		keyImage:  cfg.Image,
+		keyEnv:    cfg.Env,
 		"command": []string{"sh", "-c"},
 		"args": []string{
 			"set -x && " +
@@ -266,9 +290,9 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 				"add": []string{"IPC_LOCK"},
 			},
 		},
-		"volumeMounts": []map[string]any{
-			{"name": "mpi-ssh-auth", "mountPath": "/tmp/mpi-ssh-raw", "readOnly": true},
-			{"name": "dshm", "mountPath": "/dev/shm"},
+		keyVolumeMounts: []map[string]any{
+			{keyName: mpiSSHAuthName, keyMountPath: mpiSSHMountPath, keyReadOnly: true},
+			{keyName: volumeNameDSHM, keyMountPath: "/dev/shm"},
 		},
 	}
 
@@ -280,8 +304,8 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 
 	// Launcher init container: fix SSH permissions
 	launcherInitContainer := map[string]any{
-		"name":    "fix-ssh-permissions",
-		"image":   cfg.Image,
+		keyName:   "fix-ssh-permissions",
+		keyImage:  cfg.Image,
 		"command": []string{"sh", "-c"},
 		"args": []string{
 			"set -x && " +
@@ -289,36 +313,36 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 				"chmod 600 /root/.ssh/id_rsa && " +
 				"chmod 644 /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys",
 		},
-		"volumeMounts": []map[string]any{
-			{"name": "mpi-ssh-auth", "mountPath": "/tmp/mpi-ssh-raw", "readOnly": true},
-			{"name": "ssh-keys", "mountPath": "/root/.ssh"},
+		keyVolumeMounts: []map[string]any{
+			{keyName: mpiSSHAuthName, keyMountPath: mpiSSHMountPath, keyReadOnly: true},
+			{keyName: volumeNameSSHKeys, keyMountPath: "/root/.ssh"},
 		},
 	}
 
 	// Launcher container
 	launcherContainer := map[string]any{
-		"name":  "node",
-		"image": cfg.Image,
-		"env":   cfg.Env,
+		keyName:  nodeJobName,
+		keyImage: cfg.Image,
+		keyEnv:   cfg.Env,
 		"resources": map[string]any{
 			"limits": map[string]any{
 				"cpu":    "2",
 				"memory": "1Gi",
 			},
 		},
-		"volumeMounts": []map[string]any{
-			{"name": "mpi-ssh-auth", "mountPath": "/tmp/mpi-ssh-raw", "readOnly": true},
-			{"name": "ssh-keys", "mountPath": "/root/.ssh"},
+		keyVolumeMounts: []map[string]any{
+			{keyName: mpiSSHAuthName, keyMountPath: mpiSSHMountPath, keyReadOnly: true},
+			{keyName: volumeNameSSHKeys, keyMountPath: "/root/.ssh"},
 		},
 	}
 
 	workerPodSpec := map[string]any{
-		"containers":    []any{workerContainer},
+		keyContainers:   []any{workerContainer},
 		"restartPolicy": "OnFailure",
-		"volumes": []any{
+		keyVolumes: []any{
 			map[string]any{
-				"name": "dshm",
-				"emptyDir": map[string]any{
+				keyName: volumeNameDSHM,
+				keyEmptyDir: map[string]any{
 					"medium": "Memory",
 				},
 			},
@@ -328,27 +352,27 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 	applyGangScheduler(cfg, workerPodSpec, workerPodLabels)
 
 	workerReplicatedJob := map[string]any{
-		"name": "node",
-		"template": map[string]any{
-			"spec": map[string]any{
-				"template": map[string]any{
-					"spec": workerPodSpec,
+		keyName: nodeJobName,
+		keyTemplate: map[string]any{
+			keySpec: map[string]any{
+				keyTemplate: map[string]any{
+					keySpec: workerPodSpec,
 				},
 			},
 		},
 	}
 	if len(workerPodLabels) > 0 {
-		workerReplicatedJob["template"].(map[string]any)["metadata"] = map[string]any{
-			"labels": workerPodLabels,
+		workerReplicatedJob[keyTemplate].(map[string]any)[keyMetadata] = map[string]any{
+			keyLabels: workerPodLabels,
 		}
 	}
 
 	launcherPodSpec := map[string]any{
 		"initContainers": []any{launcherInitContainer},
-		"containers":     []any{launcherContainer},
+		keyContainers:    []any{launcherContainer},
 		"restartPolicy":  "OnFailure",
-		"volumes": []any{
-			map[string]any{"name": "ssh-keys", "emptyDir": map[string]any{}},
+		keyVolumes: []any{
+			map[string]any{keyName: volumeNameSSHKeys, keyEmptyDir: map[string]any{}},
 		},
 	}
 	launcherPodLabels := map[string]any{
@@ -359,24 +383,24 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 	rt := map[string]any{
 		"apiVersion": "trainer.kubeflow.org/v1alpha1",
 		"kind":       "TrainingRuntime",
-		"metadata": map[string]any{
-			"name": fmt.Sprintf("%s-runtime", cfg.EntryName),
-			"labels": map[string]any{
+		keyMetadata: map[string]any{
+			keyName: fmt.Sprintf("%s-runtime", cfg.EntryName),
+			keyLabels: map[string]any{
 				"trainer.kubeflow.org/framework": "mpi",
-				"app":                            cfg.EntryName,
+				labelKeyApp:                      cfg.EntryName,
 			},
 		},
-		"spec": map[string]any{
+		keySpec: map[string]any{
 			"mlPolicy": map[string]any{
 				"numNodes": 1, // MPI launcher runs on 1 node; workers scale via replicatedJobs
 				"mpi": map[string]any{
 					"mpiImplementation": "OpenMPI",
 					"numProcPerNode":    cfg.GpusPerNode,
-					"sshAuthMountPath":  "/tmp/mpi-ssh-raw",
+					"sshAuthMountPath":  mpiSSHMountPath,
 				},
 			},
-			"template": map[string]any{
-				"spec": map[string]any{
+			keyTemplate: map[string]any{
+				keySpec: map[string]any{
 					"network": map[string]any{
 						"publishNotReadyAddresses": true,
 					},
@@ -384,20 +408,20 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 						workerReplicatedJob,
 						// Launcher replicatedJob
 						map[string]any{
-							"name": "launcher",
+							keyName: "launcher",
 							"dependsOn": []any{
 								map[string]any{
-									"name":   "node",
+									keyName:  nodeJobName,
 									"status": "Ready",
 								},
 							},
-							"template": map[string]any{
-								"metadata": map[string]any{
-									"labels": launcherPodLabels,
+							keyTemplate: map[string]any{
+								keyMetadata: map[string]any{
+									keyLabels: launcherPodLabels,
 								},
-								"spec": map[string]any{
-									"template": map[string]any{
-										"spec": launcherPodSpec,
+								keySpec: map[string]any{
+									keyTemplate: map[string]any{
+										keySpec: launcherPodSpec,
 									},
 								},
 							},
@@ -414,7 +438,7 @@ func BuildMPIRuntime(cfg RuntimeConfig) nvcrev1alpha1.DependencySpec {
 
 	data, _ := json.Marshal(rt)
 	return nvcrev1alpha1.DependencySpec{
-		RawExtension: runtime.RawExtension{Raw: data},
+		Raw: data,
 	}
 }
 

--- a/pkg/podlogs/fetcher_test.go
+++ b/pkg/podlogs/fetcher_test.go
@@ -42,7 +42,7 @@ type openStreamResult struct {
 func TestOpenStream(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "open-stream",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in openStreamInput

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -33,6 +33,10 @@ import (
 //go:embed nodes/*.yaml
 var embeddedNodes embed.FS
 
+// nvcreAPIVersion is the apiVersion string used for rendered nvcre.nvidia.com
+// resources (Certification, Workflow, Job).
+const nvcreAPIVersion = "nvcre.nvidia.com/v1alpha1"
+
 // NewWorkflowCommand returns the "workflow" parent cobra command with
 // the "render" subcommand attached. This was previously newWorkflowCommand
 // in root.go.
@@ -168,7 +172,7 @@ func render(workflowFile, platform, gpuArch, nodesFile string) (*nvcrev1alpha1.W
 	}
 
 	workflow.TypeMeta = metav1.TypeMeta{
-		APIVersion: "nvcre.nvidia.com/v1alpha1",
+		APIVersion: nvcreAPIVersion,
 		Kind:       "Workflow",
 	}
 
@@ -271,7 +275,7 @@ func renderDryRun(workflowFile string, configFlags *kubeconfig.ConfigFlags) (
 	}
 
 	workflow.TypeMeta = metav1.TypeMeta{
-		APIVersion: "nvcre.nvidia.com/v1alpha1",
+		APIVersion: nvcreAPIVersion,
 		Kind:       "Workflow",
 	}
 
@@ -410,15 +414,11 @@ func DryRunCreate(ctx context.Context, c client.Client, namespace string,
 
 	// --- 2. Validate Job ---
 	job := &nvcrev1alpha1.Job{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "nvcre.nvidia.com/v1alpha1",
-			Kind:       "Job",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dry-run-job",
-			Namespace: namespace,
-		},
-		Spec: *specCopy,
+		APIVersion: nvcreAPIVersion,
+		Kind:       "Job",
+		Name:       "dry-run-job",
+		Namespace:  namespace,
+		Spec:       *specCopy,
 	}
 
 	jobResult := DryRunResult{Resource: "Job/dry-run-job", Valid: true}

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -16,7 +16,7 @@ import (
 func TestRender(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "render",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -60,7 +60,7 @@ func TestRender(t *testing.T) {
 func TestRenderErrors(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "render-errors",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -102,7 +102,7 @@ func TestRenderErrors(t *testing.T) {
 func TestValidateFlags(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "validate-flags",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {
@@ -137,7 +137,7 @@ func TestValidateFlags(t *testing.T) {
 func TestListAvailable(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "list-available",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		avail := listAvailable()

--- a/pkg/report/build_excluded_test.go
+++ b/pkg/report/build_excluded_test.go
@@ -24,7 +24,7 @@ import (
 func TestBuildExcludedReport(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-excluded-report",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		scheme := runtime.NewScheme()

--- a/pkg/report/build_failed_groups_test.go
+++ b/pkg/report/build_failed_groups_test.go
@@ -27,7 +27,7 @@ import (
 func TestBuildFailedGroups(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-failed-groups",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		scheme := runtime.NewScheme()

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -34,6 +34,15 @@ const (
 	statusInProgress = "InProgress"
 )
 
+// Diagnose stage names, as returned by inferDiagnoseStage.
+const (
+	diagnoseStageScreening      = "screening"
+	diagnoseStageScreeningNoNVL = "screening-no-nvl"
+	diagnoseStageBisection      = "bisection"
+	diagnoseStageConfirmation   = "confirmation"
+	diagnoseStageInterScreening = "inter-screening"
+)
+
 // ---------------------------------------------------------------------------
 // Report data model
 // ---------------------------------------------------------------------------
@@ -1410,7 +1419,7 @@ func buildDiagnoseTests(
 
 		// Only set domain for screening tests — other stages list individual nodes.
 		var domain string
-		if stage == "screening" {
+		if stage == diagnoseStageScreening {
 			domain = lookupScreeningDomain(wf, nodes)
 		}
 
@@ -1432,19 +1441,19 @@ func buildDiagnoseTests(
 // inferDiagnoseStage infers the stage from the group name.
 func inferDiagnoseStage(groupName string) string {
 	if strings.Contains(groupName, "screen-no-nvl") {
-		return "screening-no-nvl"
+		return diagnoseStageScreeningNoNVL
 	}
 	if strings.Contains(groupName, "screen") {
-		return "screening"
+		return diagnoseStageScreening
 	}
 	if strings.Contains(groupName, "bisect") {
-		return "bisection"
+		return diagnoseStageBisection
 	}
 	if strings.Contains(groupName, "confirm") {
-		return "confirmation"
+		return diagnoseStageConfirmation
 	}
 	if strings.Contains(groupName, "inter-domain") {
-		return "inter-screening"
+		return diagnoseStageInterScreening
 	}
 	return "unknown"
 }
@@ -1518,13 +1527,13 @@ func groupFaultyByDomain(faulty []string, screening map[string]nvcrev1alpha1.Dom
 func printDiagnoseResults(w io.Writer, d *DiagnoseReport) {
 	_, _ = fmt.Fprintf(w, "│%s│\n", pad(boxWidth-2))
 	stageNames := map[string]string{
-		"intra-screening":        "intra-rack screening",
-		"intra-screening-no-nvl": "intra-rack screening (no NVL)",
-		"inter-screening":        "inter-rack screening",
-		"bisection":              "bisection",
-		"confirmation":           "confirmation",
-		"cross-boundary":         "cross-boundary probing",
-		"complete":               "complete",
+		"intra-screening":           "intra-rack screening",
+		"intra-screening-no-nvl":    "intra-rack screening (no NVL)",
+		diagnoseStageInterScreening: "inter-rack screening",
+		diagnoseStageBisection:      diagnoseStageBisection,
+		diagnoseStageConfirmation:   diagnoseStageConfirmation,
+		"cross-boundary":            "cross-boundary probing",
+		"complete":                  "complete",
 	}
 	stage := d.Stage
 	if name, ok := stageNames[stage]; ok {
@@ -1590,13 +1599,16 @@ func printDiagnoseResults(w io.Writer, d *DiagnoseReport) {
 		printBoxLine(w, "Test Results:")
 
 		stageDisplay := map[string]string{
-			"screening":        "intra-rack screening",
-			"screening-no-nvl": "intra-rack screening (no NVL)",
-			"inter-screening":  "inter-rack screening",
-			"bisection":        "bisection",
-			"confirmation":     "confirmation",
+			diagnoseStageScreening:      "intra-rack screening",
+			diagnoseStageScreeningNoNVL: "intra-rack screening (no NVL)",
+			diagnoseStageInterScreening: "inter-rack screening",
+			diagnoseStageBisection:      diagnoseStageBisection,
+			diagnoseStageConfirmation:   diagnoseStageConfirmation,
 		}
-		stages := []string{"screening", "screening-no-nvl", "inter-screening", "bisection", "confirmation"}
+		stages := []string{
+			diagnoseStageScreening, diagnoseStageScreeningNoNVL, diagnoseStageInterScreening,
+			diagnoseStageBisection, diagnoseStageConfirmation,
+		}
 		for _, stage := range stages {
 
 			var stageTests []DiagnoseTestRow

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -24,10 +24,37 @@ import (
 
 const testAPIGroup = "nvcre.nvidia.com"
 
+// testBusBW1_0 is the "1.0" BusBW value shared by several bandwidth
+// measurement fixtures below.
+const testBusBW1_0 = "1.0"
+
+// testBusBW350_0 is the "350.0" BusBW value shared by several bandwidth
+// measurement fixtures below.
+const testBusBW350_0 = "350.0"
+
+// Fixture names shared by several test cases below.
+const (
+	testGroup0  = "group-0"
+	testNode0   = "node-0"
+	testNode1   = "node-1"
+	testClique0 = "clique-0"
+	testJob0    = "job-0"
+	testNode2   = "node-2"
+	testJob1    = "job-1"
+	testKindJob = "Job"
+
+	testDomainTraining       = "training"
+	testVariantNemotron      = "nemotron"
+	testDomainCommunication  = "communication"
+	testVariantNCCLAllReduce = "nccl-all-reduce"
+
+	testTFLOPs800_5 = "800.5"
+)
+
 func TestHumanSize(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "human-size",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -54,7 +81,7 @@ func TestHumanSize(t *testing.T) {
 func TestParseFloat(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse-float",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -81,7 +108,7 @@ func TestParseFloat(t *testing.T) {
 func TestAvg(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "avg",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -114,7 +141,7 @@ func TestFmtPercent(t *testing.T) {
 func TestFmtDuration(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "fmt-duration",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -155,16 +182,16 @@ func TestFmtAvg(t *testing.T) {
 
 func TestHasCondition(t *testing.T) {
 	conditions := []metav1.Condition{
-		{Type: "Succeeded", Status: metav1.ConditionTrue},
-		{Type: "Failed", Status: metav1.ConditionFalse},
+		{Type: statusSucceeded, Status: metav1.ConditionTrue},
+		{Type: statusFailed, Status: metav1.ConditionFalse},
 	}
 
 	t.Run("match true", func(t *testing.T) {
-		assert.True(t, controller.CondIsTrue(conditions, "Succeeded"))
+		assert.True(t, controller.CondIsTrue(conditions, statusSucceeded))
 	})
 
 	t.Run("exists but false", func(t *testing.T) {
-		assert.False(t, controller.CondIsTrue(conditions, "Failed"))
+		assert.False(t, controller.CondIsTrue(conditions, statusFailed))
 	})
 
 	t.Run("no match", func(t *testing.T) {
@@ -172,7 +199,7 @@ func TestHasCondition(t *testing.T) {
 	})
 
 	t.Run("empty list", func(t *testing.T) {
-		assert.False(t, controller.CondIsTrue(nil, "Succeeded"))
+		assert.False(t, controller.CondIsTrue(nil, statusSucceeded))
 	})
 }
 
@@ -183,16 +210,16 @@ func TestBuildDomainReports(t *testing.T) {
 		orch := &nvcrev1alpha1.OrchestrationStatus{
 			Groups: []nvcrev1alpha1.GroupStatus{
 				{
-					Name:    "group-0",
-					Nodes:   []string{"node-0", "node-1"},
-					Domains: []string{"clique-0"},
-					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-0"},
+					Name:    testGroup0,
+					Nodes:   []string{testNode0, testNode1},
+					Domains: []string{testClique0},
+					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob0},
 				},
 				{
 					Name:    "group-1",
-					Nodes:   []string{"node-2", "node-3"},
+					Nodes:   []string{testNode2, "node-3"},
 					Domains: []string{"clique-1"},
-					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-1"},
+					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob1},
 				},
 			},
 		}
@@ -202,13 +229,13 @@ func TestBuildDomainReports(t *testing.T) {
 				Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     "Job",
-						Name:     "job-0",
+						Kind:     testKindJob,
+						Name:     testJob0,
 					},
 				},
 				Status: nvcrev1alpha1.GoodputMeasurementStatus{
 					Result:          "0.95",
-					AvgTFLOPSPerGPU: "800.5",
+					AvgTFLOPSPerGPU: testTFLOPs800_5,
 					TrainingTimeSec: "120",
 					AvgStepTimeSec:  "1.25",
 				},
@@ -217,8 +244,8 @@ func TestBuildDomainReports(t *testing.T) {
 				Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     "Job",
-						Name:     "job-1",
+						Kind:     testKindJob,
+						Name:     testJob1,
 					},
 				},
 				Status: nvcrev1alpha1.GoodputMeasurementStatus{
@@ -238,10 +265,10 @@ func TestBuildDomainReports(t *testing.T) {
 			byDomain[r.Name] = r
 		}
 
-		clique0 := byDomain["clique-0"]
+		clique0 := byDomain[testClique0]
 		assert.Equal(t, 2, clique0.NodeCount)
 		assert.Contains(t, clique0.Goodput, "0.95")
-		assert.Contains(t, clique0.TFLOPs, "800.5")
+		assert.Contains(t, clique0.TFLOPs, testTFLOPs800_5)
 
 		clique1 := byDomain["clique-1"]
 		assert.Equal(t, 2, clique1.NodeCount)
@@ -254,7 +281,7 @@ func TestBuildDomainReports(t *testing.T) {
 				Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 					JobRef: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     "Job",
+						Kind:     testKindJob,
 						Name:     "job-x",
 					},
 				},
@@ -275,9 +302,9 @@ func TestBuildDomainReports(t *testing.T) {
 		orch := &nvcrev1alpha1.OrchestrationStatus{
 			Groups: []nvcrev1alpha1.GroupStatus{
 				{
-					Name:    "group-0",
-					Domains: []string{"clique-0"},
-					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-0"},
+					Name:    testGroup0,
+					Domains: []string{testClique0},
+					JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob0},
 				},
 			},
 		}
@@ -294,25 +321,25 @@ func TestPrintReport(t *testing.T) {
 		TotalNodes: 8,
 		Categories: []CategoryReport{
 			{
-				Domain:  "training",
-				Variant: "nemotron",
-				Status:  "Succeeded",
+				Domain:  testDomainTraining,
+				Variant: testVariantNemotron,
+				Status:  statusSucceeded,
 				Runtime: "2m 30s",
 				Domains: []DomainReport{
 					{
-						Name:      "clique-0",
+						Name:      testClique0,
 						NodeCount: 4,
 						Goodput:   "0.95 (95%)",
-						TFLOPs:    "800.5",
+						TFLOPs:    testTFLOPs800_5,
 
 						StepTime: "1.25s",
 					},
 				},
 			},
 			{
-				Domain:  "communication",
-				Variant: "nccl-all-reduce",
-				Status:  "Succeeded",
+				Domain:  testDomainCommunication,
+				Variant: testVariantNCCLAllReduce,
+				Status:  statusSucceeded,
 				Bandwidth: []BandwidthRow{
 					{Size: "1 MB", AlgBW: "10.5 GB/s", BusBW: "9.8 GB/s", Samples: 100},
 				},
@@ -339,12 +366,12 @@ func TestPrintReport(t *testing.T) {
 	// Check category cards.
 	assert.Contains(t, output, "training/nemotron")
 	assert.Contains(t, output, "communication/nccl-all-reduce")
-	assert.Contains(t, output, "Succeeded")
+	assert.Contains(t, output, statusSucceeded)
 
 	// Check training metrics.
 	assert.Contains(t, output, "Avg Runtime Goodput")
 	assert.Contains(t, output, "0.95 (95%)")
-	assert.Contains(t, output, "clique-0")
+	assert.Contains(t, output, testClique0)
 
 	// Check bandwidth table.
 	assert.Contains(t, output, "Bandwidth:")
@@ -361,9 +388,9 @@ func TestPrintReportFailed(t *testing.T) {
 	report := &CertReport{
 		Name: "fail-cert",
 		Categories: []CategoryReport{
-			{Domain: "training", Variant: "v1", Status: "Failed"},
+			{Domain: testDomainTraining, Variant: "v1", Status: statusFailed},
 		},
-		FailedNodes: []string{"node-1", "node-2"},
+		FailedNodes: []string{testNode1, testNode2},
 		Result:      "FAILED",
 	}
 
@@ -379,13 +406,13 @@ func TestPrintReportFailed(t *testing.T) {
 
 func TestPrintCategoryCardTraining(t *testing.T) {
 	cat := &CategoryReport{
-		Domain:  "training",
-		Variant: "nemotron",
-		Status:  "Succeeded",
+		Domain:  testDomainTraining,
+		Variant: testVariantNemotron,
+		Status:  statusSucceeded,
 		Runtime: "5m 0s",
 		Domains: []DomainReport{
 			{
-				Name:      "clique-0",
+				Name:      testClique0,
 				NodeCount: 4,
 				Goodput:   "0.92 (92%)",
 				TFLOPs:    "750.0",
@@ -423,9 +450,9 @@ func TestPrintCategoryCardTraining(t *testing.T) {
 
 func TestPrintCategoryCardCommunication(t *testing.T) {
 	cat := &CategoryReport{
-		Domain:  "communication",
-		Variant: "nccl-all-reduce",
-		Status:  "Succeeded",
+		Domain:  testDomainCommunication,
+		Variant: testVariantNCCLAllReduce,
+		Status:  statusSucceeded,
 		Bandwidth: []BandwidthRow{
 			{Size: "1 KB", AlgBW: "0.5 GB/s", BusBW: "0.4 GB/s", Samples: 50},
 			{Size: "1 MB", AlgBW: "10.5 GB/s", BusBW: "9.8 GB/s", Samples: 100},
@@ -448,9 +475,9 @@ func TestPrintCategoryCardCommunication(t *testing.T) {
 
 func TestPrintCategoryCardNoTopology(t *testing.T) {
 	cat := &CategoryReport{
-		Domain:  "training",
+		Domain:  testDomainTraining,
 		Variant: "v1",
-		Status:  "Succeeded",
+		Status:  statusSucceeded,
 		Domains: []DomainReport{
 			{
 				Name:    "", // no topology
@@ -490,7 +517,7 @@ func TestFmtFloat2(t *testing.T) {
 func TestCountDigits(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "count-digits",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -525,21 +552,21 @@ func TestFailureReason(t *testing.T) {
 	t.Run("has failed condition", func(t *testing.T) {
 		conditions := []metav1.Condition{
 			{Type: "InProgress", Status: metav1.ConditionFalse},
-			{Type: "Failed", Status: metav1.ConditionTrue, Message: "workload timeout"},
+			{Type: statusFailed, Status: metav1.ConditionTrue, Message: "workload timeout"},
 		}
 		assert.Equal(t, "workload timeout", failureReasonFromConditions(conditions))
 	})
 
 	t.Run("no failed condition", func(t *testing.T) {
 		conditions := []metav1.Condition{
-			{Type: "Succeeded", Status: metav1.ConditionTrue},
+			{Type: statusSucceeded, Status: metav1.ConditionTrue},
 		}
 		assert.Equal(t, "", failureReasonFromConditions(conditions))
 	})
 
 	t.Run("failed condition false", func(t *testing.T) {
 		conditions := []metav1.Condition{
-			{Type: "Failed", Status: metav1.ConditionFalse, Message: "old error"},
+			{Type: statusFailed, Status: metav1.ConditionFalse, Message: "old error"},
 		}
 		assert.Equal(t, "", failureReasonFromConditions(conditions))
 	})
@@ -555,10 +582,10 @@ func TestFailureReason(t *testing.T) {
 
 func TestPrintDomainBox(t *testing.T) {
 	d := &DomainReport{
-		Name:      "clique-0",
+		Name:      testClique0,
 		NodeCount: 4,
 		Goodput:   "0.95 (95%)",
-		TFLOPs:    "800.5",
+		TFLOPs:    testTFLOPs800_5,
 		StepTime:  "1.25s",
 	}
 
@@ -570,7 +597,7 @@ func TestPrintDomainBox(t *testing.T) {
 	assert.Contains(t, output, "Avg Runtime Goodput")
 	assert.Contains(t, output, "0.95 (95%)")
 	assert.Contains(t, output, "Avg TFLOPs/GPU")
-	assert.Contains(t, output, "800.5")
+	assert.Contains(t, output, testTFLOPs800_5)
 	assert.NotContains(t, output, "Avg Train Time")
 	assert.Contains(t, output, "Avg Step Time")
 	assert.Contains(t, output, "1.25s")
@@ -581,15 +608,15 @@ func TestPrintDomainBox(t *testing.T) {
 
 func TestPrintDomainBoxEmptyMetrics(t *testing.T) {
 	d := &DomainReport{
-		Name: "clique-0",
+		Name: testClique0,
 		// All metrics empty — lines should be omitted.
 	}
 
 	var buf bytes.Buffer
-	printDomainBox(&buf, "clique-0", d)
+	printDomainBox(&buf, testClique0, d)
 	output := buf.String()
 
-	assert.Contains(t, output, "clique-0")
+	assert.Contains(t, output, testClique0)
 	assert.NotContains(t, output, "Avg Runtime Goodput")
 	assert.NotContains(t, output, "Avg TFLOPs/GPU")
 }
@@ -632,9 +659,9 @@ func TestPrintMetricLine(t *testing.T) {
 
 func TestPrintCategoryCardWithFailureReason(t *testing.T) {
 	cat := &CategoryReport{
-		Domain:        "training",
-		Variant:       "nemotron",
-		Status:        "Failed",
+		Domain:        testDomainTraining,
+		Variant:       testVariantNemotron,
+		Status:        statusFailed,
 		FailureReason: "workload timed out after 30m",
 		Runtime:       "30m 0s",
 	}
@@ -652,9 +679,9 @@ func TestPrintCategoryCardWithFailureReason(t *testing.T) {
 func TestPrintCategoryCardLongReasonTruncated(t *testing.T) {
 	longReason := strings.Repeat("x", 100)
 	cat := &CategoryReport{
-		Domain:        "training",
+		Domain:        testDomainTraining,
 		Variant:       "v1",
-		Status:        "Failed",
+		Status:        statusFailed,
 		FailureReason: longReason,
 	}
 
@@ -673,7 +700,7 @@ func TestPrintReportMinimal(t *testing.T) {
 	report := &CertReport{
 		Name: "minimal-cert",
 		Categories: []CategoryReport{
-			{Domain: "communication", Variant: "nccl-loopback", Status: "Succeeded"},
+			{Domain: testDomainCommunication, Variant: "nccl-loopback", Status: statusSucceeded},
 		},
 		Result: "PASSED",
 	}
@@ -701,10 +728,10 @@ func TestPrintReportMultipleCategoriesMixed(t *testing.T) {
 		GPU:        "gb200",
 		TotalNodes: 16,
 		Categories: []CategoryReport{
-			{Domain: "communication", Variant: "nccl-all-reduce", Status: "Succeeded"},
-			{Domain: "training", Variant: "nemotron5-8b", Status: "Failed",
+			{Domain: testDomainCommunication, Variant: testVariantNCCLAllReduce, Status: statusSucceeded},
+			{Domain: testDomainTraining, Variant: "nemotron5-8b", Status: statusFailed,
 				FailureReason: "hardware failure detected"},
-			{Domain: "communication", Variant: "nccl-loopback", Status: "Succeeded"},
+			{Domain: testDomainCommunication, Variant: "nccl-loopback", Status: statusSucceeded},
 		},
 		FailedNodes: []string{"node-5"},
 		Result:      "FAILED",
@@ -793,8 +820,8 @@ func TestBuildDomainReportsPartialMetrics(t *testing.T) {
 			Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
 					APIGroup: &apiGroup,
-					Kind:     "Job",
-					Name:     "job-0",
+					Kind:     testKindJob,
+					Name:     testJob0,
 				},
 			},
 			Status: nvcrev1alpha1.GoodputMeasurementStatus{
@@ -814,7 +841,7 @@ func TestBuildDomainReportsPartialMetrics(t *testing.T) {
 func TestBuildCliqueReport(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-clique-report",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -867,7 +894,7 @@ func TestBuildCliqueReport(t *testing.T) {
 func TestDetectTestScale(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "detect-test-scale",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -919,16 +946,16 @@ func TestBuildDomainReportsMultipleMeasurementsSameDomain(t *testing.T) {
 	orch := &nvcrev1alpha1.OrchestrationStatus{
 		Groups: []nvcrev1alpha1.GroupStatus{
 			{
-				Name:    "group-0",
-				Nodes:   []string{"node-0", "node-1"},
+				Name:    testGroup0,
+				Nodes:   []string{testNode0, testNode1},
 				Domains: []string{"rack-a"},
-				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-0"},
+				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob0},
 			},
 			{
 				Name:    "group-1",
-				Nodes:   []string{"node-2", "node-3"},
+				Nodes:   []string{testNode2, "node-3"},
 				Domains: []string{"rack-a"}, // Same domain.
-				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-1"},
+				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob1},
 			},
 		},
 	}
@@ -937,7 +964,7 @@ func TestBuildDomainReportsMultipleMeasurementsSameDomain(t *testing.T) {
 		{
 			Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
-					APIGroup: &apiGroup, Kind: "Job", Name: "job-0",
+					APIGroup: &apiGroup, Kind: testKindJob, Name: testJob0,
 				},
 			},
 			Status: nvcrev1alpha1.GoodputMeasurementStatus{
@@ -947,7 +974,7 @@ func TestBuildDomainReportsMultipleMeasurementsSameDomain(t *testing.T) {
 		{
 			Spec: nvcrev1alpha1.GoodputMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
-					APIGroup: &apiGroup, Kind: "Job", Name: "job-1",
+					APIGroup: &apiGroup, Kind: testKindJob, Name: testJob1,
 				},
 			},
 			Status: nvcrev1alpha1.GoodputMeasurementStatus{
@@ -974,26 +1001,26 @@ func TestPeakBandwidthResult(t *testing.T) {
 
 	t.Run("ascending — last is peak", func(t *testing.T) {
 		results := []nvcrev1alpha1.BandwidthResult{
-			{SizeBytes: 1024, BusBW: "1.0"},
+			{SizeBytes: 1024, BusBW: testBusBW1_0},
 			{SizeBytes: 1048576, BusBW: "100.0"},
-			{SizeBytes: 17179869184, BusBW: "350.0"},
+			{SizeBytes: 17179869184, BusBW: testBusBW350_0},
 		}
 		peak := peakBandwidthResult(results)
 		require.NotNil(t, peak)
 		assert.Equal(t, int64(17179869184), peak.SizeBytes)
-		assert.Equal(t, "350.0", peak.BusBW)
+		assert.Equal(t, testBusBW350_0, peak.BusBW)
 	})
 
 	t.Run("unsorted — picks largest size, not last", func(t *testing.T) {
 		results := []nvcrev1alpha1.BandwidthResult{
-			{SizeBytes: 17179869184, BusBW: "350.0"},
-			{SizeBytes: 1024, BusBW: "1.0"},
+			{SizeBytes: 17179869184, BusBW: testBusBW350_0},
+			{SizeBytes: 1024, BusBW: testBusBW1_0},
 			{SizeBytes: 1048576, BusBW: "100.0"},
 		}
 		peak := peakBandwidthResult(results)
 		require.NotNil(t, peak)
 		assert.Equal(t, int64(17179869184), peak.SizeBytes)
-		assert.Equal(t, "350.0", peak.BusBW)
+		assert.Equal(t, testBusBW350_0, peak.BusBW)
 	})
 
 	t.Run("single entry", func(t *testing.T) {
@@ -1009,10 +1036,10 @@ func TestBuildGroupBandwidthRowsUnsorted(t *testing.T) {
 	orch := &nvcrev1alpha1.OrchestrationStatus{
 		Groups: []nvcrev1alpha1.GroupStatus{
 			{
-				Name:    "group-0",
-				Nodes:   []string{"node-0", "node-1"},
-				Domains: []string{"clique-0"},
-				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: "job-0"},
+				Name:    testGroup0,
+				Nodes:   []string{testNode0, testNode1},
+				Domains: []string{testClique0},
+				JobRef:  &nvcrev1alpha1.WorkloadReference{Name: testJob0},
 			},
 		},
 	}
@@ -1020,14 +1047,14 @@ func TestBuildGroupBandwidthRowsUnsorted(t *testing.T) {
 		{
 			Spec: nvcrev1alpha1.BandwidthMeasurementSpec{
 				JobRef: corev1.TypedLocalObjectReference{
-					APIGroup: &apiGroup, Kind: "Job", Name: "job-0",
+					APIGroup: &apiGroup, Kind: testKindJob, Name: testJob0,
 				},
 			},
 			Status: nvcrev1alpha1.BandwidthMeasurementStatus{
 				Results: []nvcrev1alpha1.BandwidthResult{
 					// Largest size first — last entry is NOT the peak.
-					{SizeBytes: 17179869184, BusBW: "350.0"},
-					{SizeBytes: 1024, BusBW: "1.0"},
+					{SizeBytes: 17179869184, BusBW: testBusBW350_0},
+					{SizeBytes: 1024, BusBW: testBusBW1_0},
 				},
 			},
 		},

--- a/pkg/setup/crds.go
+++ b/pkg/setup/crds.go
@@ -28,7 +28,7 @@ const crdFieldManager = "nvcrectl-setup"
 // stderr (registry warnings and errors) is surfaced separately on failure so
 // it can never corrupt the YAML stream.
 func fetchChartCRDs(helmPath, chartVersion string, out io.Writer) ([]byte, error) {
-	args := []string{"show", "crds", helmChartOCI, "--version", chartVersion}
+	args := []string{"show", "crds", helmChartOCI, helmFlagVersion, chartVersion}
 
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command(helmPath, args...) // #nosec G204 -- helmPath and args come from this CLI, not from untrusted input

--- a/pkg/setup/crds_test.go
+++ b/pkg/setup/crds_test.go
@@ -52,7 +52,7 @@ func TestApplyChartCRDs(t *testing.T) {
 
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-chart-crds",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {

--- a/pkg/setup/helm.go
+++ b/pkg/setup/helm.go
@@ -26,6 +26,12 @@ const (
 	trainerReleaseName  = "kubeflow-trainer"
 	trainerHelmChartOCI = "oci://ghcr.io/kubeflow/charts/kubeflow-trainer"
 	trainerNamespace    = "kubeflow-system"
+
+	helmFlagNamespace = "--namespace"
+	helmFlagVersion   = "--version"
+	helmFlagSet       = "--set"
+	helmFlagWait      = "--wait"
+	helmFlagTimeout   = "--timeout"
 )
 
 // gitDescribeSuffix matches the trailing commit count and hash that git
@@ -149,16 +155,16 @@ func installHelmRelease(p helmInstallParams) (string, error) {
 	imageName, imageTag := parseImage(p.image)
 	args := []string{
 		"upgrade", "--install", helmReleaseName, helmChartOCI,
-		"--namespace", nvcreNamespace,
+		helmFlagNamespace, nvcreNamespace,
 		"--create-namespace",
-		"--version", chartVersion,
-		"--set", "manager.image.repository=" + imageName,
-		"--set", "manager.image.tag=" + imageTag,
-		"--wait",
-		"--timeout", helmInstallTimeout.String(),
+		helmFlagVersion, chartVersion,
+		helmFlagSet, "manager.image.repository=" + imageName,
+		helmFlagSet, "manager.image.tag=" + imageTag,
+		helmFlagWait,
+		helmFlagTimeout, helmInstallTimeout.String(),
 	}
 	if p.pullSecretName != "" {
-		args = append(args, "--set", "manager.imagePullSecrets[0].name="+p.pullSecretName)
+		args = append(args, helmFlagSet, "manager.imagePullSecrets[0].name="+p.pullSecretName)
 	}
 	args = appendKubeconfigArgs(args, p.kubeconfig, p.kubeContext)
 
@@ -183,10 +189,10 @@ func uninstallHelmRelease(p helmUninstallParams) error {
 
 	args := []string{
 		"uninstall", helmReleaseName,
-		"--namespace", nvcreNamespace,
+		helmFlagNamespace, nvcreNamespace,
 		"--ignore-not-found",
-		"--wait",
-		"--timeout", helmInstallTimeout.String(),
+		helmFlagWait,
+		helmFlagTimeout, helmInstallTimeout.String(),
 	}
 	args = appendKubeconfigArgs(args, p.kubeconfig, p.kubeContext)
 
@@ -210,13 +216,13 @@ func installTrainerHelmRelease(kubeconfig, kubeContext string, out io.Writer) (s
 		trainerReleaseName, trainerNamespace)
 	args := []string{
 		"upgrade", "--install", trainerReleaseName, trainerHelmChartOCI,
-		"--namespace", trainerNamespace,
+		helmFlagNamespace, trainerNamespace,
 		"--create-namespace",
-		"--version", strings.TrimPrefix(kubeflowTrainerVersion, "v"),
-		"--set", "manager.tolerations[0].operator=Exists",
-		"--set", "jobset.controller.tolerations[0].operator=Exists",
-		"--wait",
-		"--timeout", helmInstallTimeout.String(),
+		helmFlagVersion, strings.TrimPrefix(kubeflowTrainerVersion, "v"),
+		helmFlagSet, "manager.tolerations[0].operator=Exists",
+		helmFlagSet, "jobset.controller.tolerations[0].operator=Exists",
+		helmFlagWait,
+		helmFlagTimeout, helmInstallTimeout.String(),
 	}
 	args = appendKubeconfigArgs(args, kubeconfig, kubeContext)
 	return runHelmCapture(helmPath, args, out)
@@ -231,10 +237,10 @@ func uninstallTrainerHelmRelease(kubeconfig, kubeContext string, out io.Writer) 
 
 	args := []string{
 		"uninstall", trainerReleaseName,
-		"--namespace", trainerNamespace,
+		helmFlagNamespace, trainerNamespace,
 		"--ignore-not-found",
-		"--wait",
-		"--timeout", helmInstallTimeout.String(),
+		helmFlagWait,
+		helmFlagTimeout, helmInstallTimeout.String(),
 	}
 	args = appendKubeconfigArgs(args, kubeconfig, kubeContext)
 	_, _ = fmt.Fprintf(out, "[deps] Removing Helm release %q from namespace %s...\n", trainerReleaseName, trainerNamespace)
@@ -288,7 +294,7 @@ func helmReleaseState(helmPath, release, namespace, kubeconfig, kubeContext stri
 // report an empty version; callers that need it fall back to
 // helmReleaseMetadataVersion.
 func helmReleaseStateAndVersion(helmPath, release, namespace, kubeconfig, kubeContext string) (string, string) {
-	args := []string{"status", release, "--namespace", namespace, "-o", "json"}
+	args := []string{"status", release, helmFlagNamespace, namespace, "-o", "json"}
 	args = appendKubeconfigArgs(args, kubeconfig, kubeContext)
 
 	var stdout, stderr bytes.Buffer
@@ -322,7 +328,7 @@ func helmReleaseStateAndVersion(helmPath, release, namespace, kubeconfig, kubeCo
 // returns the installed chart version, or "" when it cannot be determined.
 // Used only when `helm status` stripped the chart metadata from its payload.
 func helmReleaseMetadataVersion(helmPath, release, namespace, kubeconfig, kubeContext string) string {
-	args := []string{"get", "metadata", release, "--namespace", namespace, "-o", "json"}
+	args := []string{"get", "metadata", release, helmFlagNamespace, namespace, "-o", "json"}
 	args = appendKubeconfigArgs(args, kubeconfig, kubeContext)
 
 	var stdout bytes.Buffer

--- a/pkg/setup/helm_test.go
+++ b/pkg/setup/helm_test.go
@@ -31,7 +31,7 @@ func TestResolveHelmChartVersion(t *testing.T) {
 	t.Run("dev build requires override", func(t *testing.T) {
 		_, err := resolveHelmChartVersion("1.20.0-4-gabcdef-dirty", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--version")
+		assert.Contains(t, err.Error(), helmFlagVersion)
 	})
 
 	t.Run("pre-release tag needs no override", func(t *testing.T) {

--- a/pkg/setup/init_recovery_test.go
+++ b/pkg/setup/init_recovery_test.go
@@ -21,14 +21,18 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
+// testAPIVersionV1Alpha1 is the "v1alpha1" version string shared by the
+// NVCRE and Trainer GroupVersionKinds registered for tests in this package.
+const testAPIVersionV1Alpha1 = "v1alpha1"
+
 // registerTrainerKinds registers the Trainer-family kinds the recovery gate
 // lists, so the fake client can serve them as unstructured objects — the
 // same registration shape newSetupScheme uses for LogProfile.
 func registerTrainerKinds(s *runtime.Scheme) {
 	kinds := []schema.GroupVersionKind{
-		{Group: trainerAPIGroup, Version: "v1alpha1", Kind: "TrainJob"},
-		{Group: trainerAPIGroup, Version: "v1alpha1", Kind: "TrainingRuntime"},
-		{Group: trainerAPIGroup, Version: "v1alpha1", Kind: "ClusterTrainingRuntime"},
+		{Group: trainerAPIGroup, Version: testAPIVersionV1Alpha1, Kind: "TrainJob"},
+		{Group: trainerAPIGroup, Version: testAPIVersionV1Alpha1, Kind: "TrainingRuntime"},
+		{Group: trainerAPIGroup, Version: testAPIVersionV1Alpha1, Kind: "ClusterTrainingRuntime"},
 		{Group: jobsetAPIGroup, Version: "v1alpha2", Kind: "JobSet"},
 	}
 	for _, gvk := range kinds {
@@ -70,7 +74,7 @@ type initRecoveryInput struct {
 func TestInstallDepsPhaseRecovery(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "init-recovery",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in initRecoveryInput

--- a/pkg/setup/retained_test.go
+++ b/pkg/setup/retained_test.go
@@ -32,7 +32,7 @@ type retainedTestConfig struct {
 func TestPrintRetainedResources(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "print-retained-resources",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg retainedTestConfig

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -1232,11 +1231,9 @@ func EnsureNamespace(ctx context.Context, c client.Client, name string, out io.W
 			return false, fmt.Errorf("check namespace %s: %w", name, err)
 		}
 		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "nvcrectl",
-				},
+			Name: name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "nvcrectl",
 			},
 		}
 		_, _ = fmt.Fprintf(out, "[namespace] Creating namespace %s...\n", name)
@@ -1308,12 +1305,10 @@ func CreateImagePullSecret(ctx context.Context, c client.Client, namespace, secr
 	dockerConfig := string(dockerConfigBytes)
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "nvcrectl",
-			},
+		Name:      secretName,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by": "nvcrectl",
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -33,7 +33,7 @@ func newTestConfigFlags(kubeconfigPath, kubeContext string) *kubeconfig.ConfigFl
 func TestPromptForConfirmation(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "prompt-for-confirmation",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		input := tc.Inputs["input.txt"]
@@ -120,7 +120,7 @@ users:
 func TestParseSkipPhases(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse-skip-phases",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -148,7 +148,7 @@ func TestParseSkipPhases(t *testing.T) {
 func TestParseImage(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "parse-image",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -185,7 +185,7 @@ func TestDefaultImage(t *testing.T) {
 func TestSplitYAMLDocuments(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "split-yaml-documents",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		docs := splitYAMLDocuments([]byte(tc.Inputs["input.yaml"]))

--- a/pkg/setup/ssa_conflict_test.go
+++ b/pkg/setup/ssa_conflict_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,7 +46,7 @@ func TestClassifierMatchesRealSSAConflict(t *testing.T) {
 	c := suite.Client
 
 	require.NoError(t, c.Create(ctx,
-		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: trainerNamespace}}))
+		&corev1.Namespace{Name: trainerNamespace}))
 
 	const secretName = "kubeflow-trainer-webhook-cert"
 	webhookSecret := func(crt, key string) *corev1ac.SecretApplyConfiguration {
@@ -83,7 +82,7 @@ func TestClassifierMatchesRealSSAConflict(t *testing.T) {
 
 	p := testutil.TestCaseParser{
 		Subdir:         "ssa-conflict",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		paths := regexp.MustCompile(`\.data\.[^\s,:]+`).FindAllString(conflictErr.Error(), -1)

--- a/pkg/setup/status_test.go
+++ b/pkg/setup/status_test.go
@@ -18,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,10 +36,10 @@ func newSetupScheme(t *testing.T) *runtime.Scheme {
 	// LogProfile has no typed Go package here, so register the list kind the
 	// check function asks for.
 	s.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: nvcreAPIGroup, Version: "v1alpha1", Kind: "LogProfile"},
+		schema.GroupVersionKind{Group: nvcreAPIGroup, Version: testAPIVersionV1Alpha1, Kind: "LogProfile"},
 		&unstructured.Unstructured{})
 	s.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: nvcreAPIGroup, Version: "v1alpha1", Kind: "LogProfileList"},
+		schema.GroupVersionKind{Group: nvcreAPIGroup, Version: testAPIVersionV1Alpha1, Kind: "LogProfileList"},
 		&unstructured.UnstructuredList{})
 	return s
 }
@@ -50,10 +49,8 @@ func TestCheckDCGM(t *testing.T) {
 		c := fake.NewClientBuilder().
 			WithScheme(newSetupScheme(t)).
 			WithObjects(&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dcgmServiceName,
-					Namespace: dcgmServiceNamespace,
-				},
+				Name:      dcgmServiceName,
+				Namespace: dcgmServiceNamespace,
 			}).
 			Build()
 		assert.NoError(t, checkDCGM(context.Background(), c))
@@ -68,10 +65,8 @@ func TestCheckDCGM(t *testing.T) {
 		c := fake.NewClientBuilder().
 			WithScheme(newSetupScheme(t)).
 			WithObjects(&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dcgmServiceName,
-					Namespace: "default",
-				},
+				Name:      dcgmServiceName,
+				Namespace: "default",
 			}).
 			Build()
 		assert.True(t, apierrors.IsNotFound(checkDCGM(context.Background(), c)))
@@ -131,14 +126,12 @@ func baseClusterObjects() []client.Object {
 		crd("certifications."+nvcreAPIGroup, nvcreAPIGroup, "Certification"),
 		logProfile("megatron-training"),
 		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "cre-controller", Namespace: nvcreNamespace},
-			Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
+			Name: "cre-controller", Namespace: nvcreNamespace,
+			Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
 		},
 		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "gpu-node-0",
-				Labels: map[string]string{"nvidia.com/gpu.present": "true"},
-			},
+			Name:   "gpu-node-0",
+			Labels: map[string]string{"nvidia.com/gpu.present": "true"},
 		},
 	}
 }
@@ -168,7 +161,7 @@ func TestCollectSetupStatusDCGMIsOptional(t *testing.T) {
 
 	t.Run("ready with dcgm", func(t *testing.T) {
 		withDCGM := append(objs, &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: dcgmServiceName, Namespace: dcgmServiceNamespace},
+			Name: dcgmServiceName, Namespace: dcgmServiceNamespace,
 		})
 		c := fake.NewClientBuilder().WithScheme(newSetupScheme(t)).WithObjects(withDCGM...).Build()
 		s := collectSetupStatus(context.Background(), c, allDeployedHelmQuery, trainerNotInHelm)
@@ -191,7 +184,7 @@ func trainerNotInHelm() (string, string) { return helmStateNotInstalled, "" }
 func TestSetupStatusHelmReleases(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "setup-status-helm",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -247,7 +240,7 @@ func TestSetupStatusHelmReleases(t *testing.T) {
 func TestSetupStatusTrainerVersion(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "setup-status-trainer-version",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -294,10 +287,8 @@ func TestSetupStatusTrainerVersion(t *testing.T) {
 			containers = append(containers,
 				corev1.Container{Name: trainerContainerName, Image: in.DeploymentImage})
 			objs = append(objs, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      trainerDeploymentName,
-					Namespace: trainerNamespace,
-				},
+				Name:      trainerDeploymentName,
+				Namespace: trainerNamespace,
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{Containers: containers},

--- a/pkg/testutil/golden.go
+++ b/pkg/testutil/golden.go
@@ -22,6 +22,13 @@ import (
 
 const updateEnvVar = "TESTUTIL_UPDATE_EXPECTED"
 
+const (
+	// SuffixJSON is the default golden-file suffix for JSON expected output.
+	SuffixJSON = ".json"
+	// SuffixTXT is the golden-file suffix for plain-text expected output.
+	SuffixTXT = ".txt"
+)
+
 // TestCase is one golden-file test scenario (a testdata subdirectory).
 type TestCase struct {
 	T    testing.TB
@@ -102,7 +109,7 @@ func (p *TestCaseParser) TestDir(t *testing.T, fn func(tc *TestCase) error) {
 	update := os.Getenv(updateEnvVar) == "true"
 	suffix := p.ExpectedSuffix
 	if suffix == "" {
-		suffix = ".json"
+		suffix = SuffixJSON
 	}
 	expectedFile := "expected" + suffix
 

--- a/pkg/threshold/evaluator_test.go
+++ b/pkg/threshold/evaluator_test.go
@@ -14,13 +14,21 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
+// testMetricBusBandwidthGBps is the "busBandwidthGBps" metric key shared by
+// the threshold map fixtures below.
+const testMetricBusBandwidthGBps = "busBandwidthGBps"
+
+// testExprBusBandwidthGBps900 is the "value >= 900" CEL-like threshold
+// expression shared by the fixtures below.
+const testExprBusBandwidthGBps900 = "value >= 900"
+
 // Covers the >=, >, <=, < operators, ranges, ratio-typed thresholds, and the
 // three ways an expression can fail (undeclared variable, non-bool result,
 // syntax error).
 func TestEvaluate(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "evaluate",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -59,7 +67,7 @@ func TestEvaluate(t *testing.T) {
 func TestEvaluateAll(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "evaluate-all",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var in struct {
@@ -92,16 +100,16 @@ func TestEvaluateAll(t *testing.T) {
 func TestValidateKeys(t *testing.T) {
 	t.Run("all known", func(t *testing.T) {
 		unknown := ValidateKeys(map[string]string{
-			"busBandwidthGBps": "value >= 900",
-			"goodputRatio":     "value >= 0.85",
+			testMetricBusBandwidthGBps: testExprBusBandwidthGBps900,
+			"goodputRatio":             "value >= 0.85",
 		})
 		assert.Empty(t, unknown)
 	})
 
 	t.Run("unknown key", func(t *testing.T) {
 		unknown := ValidateKeys(map[string]string{
-			"busBandwidthGBps": "value >= 900",
-			"fooBar":           "value > 0",
+			testMetricBusBandwidthGBps: testExprBusBandwidthGBps900,
+			"fooBar":                   "value > 0",
 		})
 		assert.Equal(t, []string{"fooBar"}, unknown)
 	})
@@ -115,16 +123,16 @@ func TestValidateKeys(t *testing.T) {
 func TestValidateExpressions(t *testing.T) {
 	t.Run("all valid", func(t *testing.T) {
 		errs := ValidateExpressions(map[string]string{
-			"busBandwidthGBps": "value >= 900",
-			"avgStepTimeSec":   "value <= 3.0",
+			testMetricBusBandwidthGBps: testExprBusBandwidthGBps900,
+			"avgStepTimeSec":           "value <= 3.0",
 		})
 		assert.Empty(t, errs)
 	})
 
 	t.Run("invalid expression", func(t *testing.T) {
 		errs := ValidateExpressions(map[string]string{
-			"busBandwidthGBps": "value >= 900",
-			"goodputRatio":     "invalid expr !!",
+			testMetricBusBandwidthGBps: testExprBusBandwidthGBps900,
+			"goodputRatio":             "invalid expr !!",
 		})
 		assert.Len(t, errs, 1)
 		assert.Contains(t, errs, "goodputRatio")
@@ -132,7 +140,7 @@ func TestValidateExpressions(t *testing.T) {
 
 	t.Run("non-bool expression", func(t *testing.T) {
 		errs := ValidateExpressions(map[string]string{
-			"busBandwidthGBps": "value + 1.0",
+			testMetricBusBandwidthGBps: "value + 1.0",
 		})
 		assert.Len(t, errs, 1)
 	})

--- a/pkg/workload/adapter_test.go
+++ b/pkg/workload/adapter_test.go
@@ -24,7 +24,7 @@ import (
 func TestForSpec(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "for-spec",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var spec nvcrev1alpha1.WorkloadSpec
@@ -52,7 +52,7 @@ func TestForSpec(t *testing.T) {
 func TestTrainJobBuild(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-build",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -89,7 +89,7 @@ func TestTrainJobBuild(t *testing.T) {
 func TestTrainJobInjectPodLabel(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-inject-label",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -115,7 +115,7 @@ func TestTrainJobInjectPodLabel(t *testing.T) {
 func TestTrainJobSetNodeSelector(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-set-node-selector",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -140,7 +140,7 @@ func TestTrainJobSetNodeSelector(t *testing.T) {
 func TestTrainJobSetNodeAffinity(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-set-node-affinity",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -165,7 +165,7 @@ func TestTrainJobSetNodeAffinity(t *testing.T) {
 func TestTrainJobGetStatus(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-get-status",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var meta struct {
@@ -198,7 +198,7 @@ func TestTrainJobGetStatus(t *testing.T) {
 func TestTrainJobNodesRequired(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-nodes-required",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -226,7 +226,7 @@ func TestTrainJobNodesRequired(t *testing.T) {
 func TestTrainJobSetTolerations(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "trainjob-set-tolerations",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -256,7 +256,7 @@ func TestTrainJobSetTolerations(t *testing.T) {
 func TestEnsureLauncherTarget(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "ensure-launcher-target",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -291,7 +291,7 @@ func TestEnsureLauncherTarget(t *testing.T) {
 func TestHasLauncherTarget(t *testing.T) {
 	p := &testutil.TestCaseParser{
 		Subdir:         "has-launcher-target",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/workload/trainjob.go
+++ b/pkg/workload/trainjob.go
@@ -48,15 +48,11 @@ func (a *TrainJobAdapter) Build(name, namespace string, spec *nvcrev1alpha1.Work
 	}
 
 	trainJob := &trainerv1alpha1.TrainJob{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "trainer.kubeflow.org/v1alpha1",
-			Kind:       "TrainJob",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: *spec.TrainJob,
+		APIVersion: "trainer.kubeflow.org/v1alpha1",
+		Kind:       "TrainJob",
+		Name:       name,
+		Namespace:  namespace,
+		Spec:       *spec.TrainJob,
 	}
 	return trainJob, nil
 }

--- a/pkg/workloadrun/build_workflow_spec_test.go
+++ b/pkg/workloadrun/build_workflow_spec_test.go
@@ -30,7 +30,7 @@ import (
 func TestBuildWorkflowSpec(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "build-workflow-spec",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		// The tags below are json, not yaml. sigs.k8s.io/yaml converts the YAML
@@ -213,7 +213,7 @@ func runtimeLauncherEnv(s *nvcrev1alpha1.WorkflowSpec) []string {
 func TestValidateExecFramework(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "validate-exec-framework",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var spec nvcrev1alpha1.WorkloadRunSpec

--- a/pkg/workloadrun/platform_mpi_args_test.go
+++ b/pkg/workloadrun/platform_mpi_args_test.go
@@ -26,7 +26,7 @@ import (
 func TestApplyPlatformMPIArgs(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-platform-mpi-args",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/workloadrun/read_workloadrun_test.go
+++ b/pkg/workloadrun/read_workloadrun_test.go
@@ -22,7 +22,7 @@ import (
 func TestReadWorkloadRun(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "read-workloadrun",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		file := filepath.Join(tc.T.TempDir(), "workloadrun.yaml")

--- a/pkg/workloadrun/render_platform_test.go
+++ b/pkg/workloadrun/render_platform_test.go
@@ -22,7 +22,7 @@ import (
 func TestRenderPlatformFlag(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "render-platform-flag",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var cfg struct {

--- a/pkg/workloadrun/run_cleanup_test.go
+++ b/pkg/workloadrun/run_cleanup_test.go
@@ -110,7 +110,7 @@ func TestExecuteWorkloadRunRunCleanup(t *testing.T) {
 
 	p := testutil.TestCaseParser{
 		Subdir:         "run-cleanup",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -133,17 +133,16 @@ func TestExecuteWorkloadRunRunCleanup(t *testing.T) {
 			return err
 		}
 
-		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		node := &corev1.Node{
 			Name: "gpu-node-0",
 			Labels: map[string]string{
 				"nvidia.com/gpu.present": "true",
 				"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
-			},
-		}}
+			}}
 		objects := []client.Object{node}
 		if input.NamespaceExists {
 			objects = append(objects, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: run.Namespace},
+				Name: run.Namespace,
 			})
 		}
 		if input.RunPreexists {

--- a/pkg/workloadrun/run_overrides_test.go
+++ b/pkg/workloadrun/run_overrides_test.go
@@ -20,7 +20,7 @@ import (
 func TestApplyRunOverrides(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "apply-run-overrides",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/pkg/workloadrun/wait_timeout_test.go
+++ b/pkg/workloadrun/wait_timeout_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/NVIDIA/cluster-readiness-engine/pkg/testutil"
 )
 
+// Name/namespace literals reused across this file's fixtures.
+const (
+	testWorkloadRunTimeoutRun = "timeout-run"
+	testWorkloadRunNamespace  = "test-ns"
+)
+
 // newWorkloadRunFakeClient is defined in run_cleanup_test.go and shared by
 // the tests in this file.
 
@@ -77,7 +83,7 @@ func TestWatchWorkloadRunImmediateTimeout(t *testing.T) {
 	wc := newWorkloadRunFakeClient(t)
 	var out bytes.Buffer
 
-	run, err := watchWorkloadRun(context.Background(), wc, "timeout-run", "test-ns", 0, &out)
+	run, err := watchWorkloadRun(context.Background(), wc, testWorkloadRunTimeoutRun, testWorkloadRunNamespace, 0, &out)
 
 	assert.Nil(t, run)
 	require.Error(t, err)
@@ -93,7 +99,7 @@ func TestWatchWorkloadRunImmediateTimeout(t *testing.T) {
 func TestFinishWorkloadRunWaitTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "finish-workloadrun-wait-timeout",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		// json tags, not yaml: sigs.k8s.io/yaml converts YAML to JSON and
@@ -107,11 +113,11 @@ func TestFinishWorkloadRunWaitTimeout(t *testing.T) {
 			return err
 		}
 		if input.Name == "" {
-			input.Name = "timeout-run"
+			input.Name = testWorkloadRunTimeoutRun
 		}
 
 		run := &nvcrev1alpha1.WorkloadRun{
-			ObjectMeta: metav1.ObjectMeta{Name: input.Name, Namespace: "test-ns"},
+			Name: input.Name, Namespace: testWorkloadRunNamespace,
 			Status: nvcrev1alpha1.WorkloadRunStatus{
 				Conditions: []metav1.Condition{{
 					Type:   nvcrev1alpha1.WorkloadRunInProgress,
@@ -122,7 +128,7 @@ func TestFinishWorkloadRunWaitTimeout(t *testing.T) {
 			},
 		}
 		wf := &nvcrev1alpha1.Workflow{
-			ObjectMeta: metav1.ObjectMeta{Name: input.Name + "-wf", Namespace: "test-ns"},
+			Name: input.Name + "-wf", Namespace: testWorkloadRunNamespace,
 			Status: nvcrev1alpha1.WorkflowStatus{
 				Conditions: []metav1.Condition{{
 					Type:   nvcrev1alpha1.WorkflowInProgress,
@@ -180,7 +186,7 @@ func TestFinishWorkloadRunWaitTimeout(t *testing.T) {
 
 func TestFinishWorkloadRunWaitBoundsPostTimeoutReads(t *testing.T) {
 	run := &nvcrev1alpha1.WorkloadRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "timeout-run", Namespace: "test-ns"},
+		Name: testWorkloadRunTimeoutRun, Namespace: testWorkloadRunNamespace,
 	}
 	wc := &workloadRunDeadlineClient{WithWatch: newWorkloadRunFakeClient(t, run)}
 	var out bytes.Buffer
@@ -204,7 +210,7 @@ func TestFinishWorkloadRunWaitBoundsPostTimeoutReads(t *testing.T) {
 func TestFinishWorkloadRunWaitTerminalAtTimeout(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "finish-workloadrun-wait-terminal-at-timeout",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {
@@ -215,7 +221,7 @@ func TestFinishWorkloadRunWaitTerminalAtTimeout(t *testing.T) {
 		}
 
 		run := &nvcrev1alpha1.WorkloadRun{
-			ObjectMeta: metav1.ObjectMeta{Name: "timeout-run", Namespace: "test-ns"},
+			Name: testWorkloadRunTimeoutRun, Namespace: testWorkloadRunNamespace,
 			Status: nvcrev1alpha1.WorkloadRunStatus{Conditions: []metav1.Condition{{
 				Type: input.ConditionType, Status: metav1.ConditionTrue,
 			}}},
@@ -238,7 +244,7 @@ func TestFinishWorkloadRunWaitTerminalAtTimeout(t *testing.T) {
 
 func TestFinishWorkloadRunWaitDoesNotMaskOtherWatchErrors(t *testing.T) {
 	run := &nvcrev1alpha1.WorkloadRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-run", Namespace: "test-ns"},
+		Name: "test-run", Namespace: testWorkloadRunNamespace,
 	}
 	wc := newWorkloadRunFakeClient(t, run)
 	resultsFile := filepath.Join(t.TempDir(), "results.json")

--- a/pkg/workloadrun/watch_line_test.go
+++ b/pkg/workloadrun/watch_line_test.go
@@ -21,7 +21,7 @@ import (
 func TestWorkloadRunWatchLine(t *testing.T) {
 	p := testutil.TestCaseParser{
 		Subdir:         "watch-line",
-		ExpectedSuffix: ".txt",
+		ExpectedSuffix: testutil.SuffixTXT,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		// json tags, not yaml: sigs.k8s.io/yaml converts YAML to JSON and

--- a/pkg/workloadrun/workloadrun.go
+++ b/pkg/workloadrun/workloadrun.go
@@ -22,7 +22,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigyaml "sigs.k8s.io/yaml"
@@ -47,6 +46,10 @@ const (
 	outputJSON   = "json"
 	defaultNS    = "default"
 	statusFailed = "Failed"
+
+	// nvcreAPIVersion is the apiVersion string used for rendered nvcre.nvidia.com
+	// resources (Job, WorkloadRun, etc.).
+	nvcreAPIVersion = "nvcre.nvidia.com/v1alpha1"
 )
 
 // resolveWRTimeout turns a user-supplied timeoutPerJob into a duration, falling
@@ -191,20 +194,16 @@ func runWorkloadRunRender(file, outputFormat, platformFlag string) error {
 
 	// Build output Workflow.
 	workflow := &nvcrev1alpha1.Workflow{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "nvcre.nvidia.com/v1alpha1",
-			Kind:       "Workflow",
+		APIVersion: nvcreAPIVersion,
+		Kind:       "Workflow",
+		Name:       run.Name,
+		Namespace:  run.Namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by":  "nvcre",
+			"nvcre.nvidia.com/workload-run": run.Name,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      run.Name,
-			Namespace: run.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":  "nvcre",
-				"nvcre.nvidia.com/workload-run": run.Name,
-			},
-			Annotations: map[string]string{
-				"nvcrectl.nvidia.com/detected-gpu-architecture": gpuArch,
-			},
+		Annotations: map[string]string{
+			"nvcrectl.nvidia.com/detected-gpu-architecture": gpuArch,
 		},
 		Spec: *workflowSpec,
 	}
@@ -247,11 +246,9 @@ func BuildWorkflowSpec(
 		defaultMode := int32(0755)
 		volumes = append(volumes, corev1.Volume{
 			Name: "config-volume",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-					DefaultMode:          &defaultMode,
-				},
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				Name:        configMapName,
+				DefaultMode: &defaultMode,
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -500,7 +497,7 @@ func buildWRCLIConfigMapDep(name string, data map[string]string) nvcrev1alpha1.D
 	}
 	raw, _ := json.Marshal(cm)
 	return nvcrev1alpha1.DependencySpec{
-		RawExtension: kruntime.RawExtension{Raw: raw},
+		Raw: raw,
 	}
 }
 
@@ -575,21 +572,17 @@ func runWorkloadRunRenderDryRun(
 	workflowSpec.Overrides = nil
 
 	workflow := &nvcrev1alpha1.Workflow{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "nvcre.nvidia.com/v1alpha1",
-			Kind:       "Workflow",
+		APIVersion: nvcreAPIVersion,
+		Kind:       "Workflow",
+		Name:       run.Name,
+		Namespace:  run.Namespace,
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by":  "nvcre",
+			"nvcre.nvidia.com/workload-run": run.Name,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      run.Name,
-			Namespace: run.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":  "nvcre",
-				"nvcre.nvidia.com/workload-run": run.Name,
-			},
-			Annotations: map[string]string{
-				"nvcrectl.nvidia.com/detected-gpu-architecture": gpuArch,
-				"nvcrectl.nvidia.com/detected-platform":         detectedPlatform,
-			},
+		Annotations: map[string]string{
+			"nvcrectl.nvidia.com/detected-gpu-architecture": gpuArch,
+			"nvcrectl.nvidia.com/detected-platform":         detectedPlatform,
 		},
 		Spec: *workflowSpec,
 	}
@@ -861,9 +854,8 @@ func executeWorkloadRunRun(cfg *wrRunConfig) error {
 		// Only delete the secret on rollback if we actually created it —
 		// if we updated a pre-existing secret, deleting it would break a concurrent run.
 		if wasCreatedByUs {
-			pullSec := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name: setup.WorkloadPullSecretName(run.Name), Namespace: run.Namespace,
-			}}
+			pullSec := &corev1.Secret{
+				Name: setup.WorkloadPullSecretName(run.Name), Namespace: run.Namespace}
 			_ = wc.Delete(ctx, pullSec)
 		}
 		return fmt.Errorf("create WorkloadRun: %w", err)
@@ -1032,7 +1024,7 @@ func runWorkloadRunCleanup(wc client.Client, cfg *wrRunConfig, runCreated bool, 
 	// so the next run doesn't fail with "namespace is being terminated".
 	if createdNamespace != "" {
 		_, _ = fmt.Fprintf(out, "[cleanup] Deleting namespace %s...\n", createdNamespace)
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: createdNamespace}}
+		ns := &corev1.Namespace{Name: createdNamespace}
 		if err := wc.Delete(cleanupCtx, ns); err != nil && !apierrors.IsNotFound(err) {
 			_, _ = fmt.Fprintf(out, "[cleanup] Warning: failed to delete namespace %s: %v\n", createdNamespace, err)
 			warnings = true
@@ -1068,7 +1060,7 @@ func setPullSecretOwnerReference(ctx context.Context, wc client.Client, run *nvc
 		return
 	}
 	sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
-		APIVersion: "nvcre.nvidia.com/v1alpha1",
+		APIVersion: nvcreAPIVersion,
 		Kind:       "WorkloadRun",
 		Name:       run.Name,
 		UID:        run.UID,
@@ -1265,10 +1257,8 @@ func loadSyntheticNodes(platformName, gpuArch string) []corev1.Node {
 		labels["kubernetes.io/hostname"] = "synthetic-forge-node"
 	}
 	node := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "synthetic-node-0",
-			Labels: labels,
-		},
+		Name:   "synthetic-node-0",
+		Labels: labels,
 		Spec: corev1.NodeSpec{
 			ProviderID: render.SyntheticProviderID(platformName),
 		},
@@ -1609,10 +1599,8 @@ func newWorkloadRunCancelCommand() *cobra.Command {
 			var lastErr error
 			for _, name := range args {
 				run := &nvcrev1alpha1.WorkloadRun{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: namespace,
-					},
+					Name:      name,
+					Namespace: namespace,
 				}
 				if err := c.Delete(ctx, run); err != nil {
 					if apierrors.IsNotFound(err) {

--- a/test/helm/render_test.go
+++ b/test/helm/render_test.go
@@ -34,7 +34,7 @@ func TestHelmTemplateRendersConcurrencyArgs(t *testing.T) {
 
 	p := testutil.TestCaseParser{
 		Subdir:         "render-concurrency-args",
-		ExpectedSuffix: ".json",
+		ExpectedSuffix: testutil.SuffixJSON,
 	}
 	p.TestDir(t, func(tc *testutil.TestCase) error {
 		var input struct {

--- a/test/releasepolicy/attest_guards_test.go
+++ b/test/releasepolicy/attest_guards_test.go
@@ -31,6 +31,39 @@ const validDigest = "sha256:1111111111111111111111111111111111111111111111111111
 
 const managerImage = "ghcr.io/nvidia/cluster-readiness-engine/manager"
 
+// The environment names the validate step reads. They are the workflow_call
+// input surface, so the whole set is named here rather than spelled out in
+// every case table.
+const (
+	inSubjectKind    = "IN_SUBJECT_KIND"
+	inSubjectName    = "IN_SUBJECT_NAME"
+	inSubjectTag     = "IN_SUBJECT_TAG"
+	inPlatform       = "IN_PLATFORM"
+	inExpectedDigest = "IN_EXPECTED_DIGEST"
+	inArtifactName   = "IN_ARTIFACT_NAME"
+	inPredicateName  = "IN_PREDICATE_NAME"
+	inPredicateType  = "IN_PREDICATE_TYPE"
+	inCosignVersion  = "IN_COSIGN_VERSION"
+	inCraneVersion   = "IN_CRANE_VERSION"
+	inAllowUntagged  = "IN_ALLOW_UNTAGGED"
+	callerRef        = "CALLER_REF"
+)
+
+// Fixture values for the blob subject, which most of the artifact and
+// predicate cases build on.
+const (
+	kindBlob               = "blob"
+	blobSubject            = "nvcrectl-linux-amd64"
+	blobArtifact           = "cli-binaries"
+	predicateTypeCycloneDX = "cyclonedx"
+)
+
+// Rejection messages asserted by more than one case.
+const (
+	errDigestMustMatch = "expected_digest must match"
+	errInvalidTag      = "subject_tag is not a valid OCI tag"
+)
+
 // workflow is the subset of the workflow schema these tests read.
 type workflow struct {
 	Jobs map[string]struct {
@@ -79,18 +112,18 @@ type inputs map[string]string
 
 func defaultInputs() inputs {
 	return inputs{
-		"IN_SUBJECT_KIND":    "image",
-		"IN_SUBJECT_NAME":    managerImage,
-		"IN_SUBJECT_TAG":     "v1.2.3",
-		"IN_PLATFORM":        "",
-		"IN_EXPECTED_DIGEST": validDigest,
-		"IN_ARTIFACT_NAME":   "",
-		"IN_PREDICATE_NAME":  "",
-		"IN_PREDICATE_TYPE":  "",
-		"IN_COSIGN_VERSION":  "v3.1.3",
-		"IN_CRANE_VERSION":   "v0.20.6",
-		"IN_ALLOW_UNTAGGED":  "false",
-		"CALLER_REF":         "refs/tags/v1.2.3",
+		inSubjectKind:    "image",
+		inSubjectName:    managerImage,
+		inSubjectTag:     "v1.2.3",
+		inPlatform:       "",
+		inExpectedDigest: validDigest,
+		inArtifactName:   "",
+		inPredicateName:  "",
+		inPredicateType:  "",
+		inCosignVersion:  "v3.1.3",
+		inCraneVersion:   "v0.20.6",
+		inAllowUntagged:  "false",
+		callerRef:        "refs/tags/v1.2.3",
 	}
 }
 
@@ -136,32 +169,32 @@ func TestAttestValidationAccepts(t *testing.T) {
 	cases := map[string]inputs{
 		"tagged image": {},
 		"per-platform image": {
-			"IN_PLATFORM": "linux/amd64",
+			inPlatform: "linux/amd64",
 		},
 		"oci artifact (helm chart)": {
-			"IN_SUBJECT_KIND": "oci-artifact",
-			"IN_SUBJECT_NAME": "ghcr.io/nvidia/cluster-readiness-engine",
+			inSubjectKind: "oci-artifact",
+			inSubjectName: "ghcr.io/nvidia/cluster-readiness-engine",
 		},
 		"blob": {
-			"IN_SUBJECT_KIND":  "blob",
-			"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
-			"IN_SUBJECT_TAG":   "",
-			"IN_ARTIFACT_NAME": "cli-binaries",
+			inSubjectKind:  kindBlob,
+			inSubjectName:  blobSubject,
+			inSubjectTag:   "",
+			inArtifactName: blobArtifact,
 		},
 		"blob with sbom predicate": {
-			"IN_SUBJECT_KIND":   "blob",
-			"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
-			"IN_SUBJECT_TAG":    "",
-			"IN_ARTIFACT_NAME":  "cli-binaries",
-			"IN_PREDICATE_NAME": "sbom.cyclonedx.json",
-			"IN_PREDICATE_TYPE": "cyclonedx",
+			inSubjectKind:   kindBlob,
+			inSubjectName:   blobSubject,
+			inSubjectTag:    "",
+			inArtifactName:  blobArtifact,
+			inPredicateName: "sbom.cyclonedx.json",
+			inPredicateType: predicateTypeCycloneDX,
 		},
 		// The non-production escape hatch, which exists so the guards can be
 		// exercised by dispatch at all. It must still work.
 		"untagged ref with allow_untagged": {
-			"CALLER_REF":        "refs/heads/main",
-			"IN_SUBJECT_TAG":    "main-abc1234",
-			"IN_ALLOW_UNTAGGED": "true",
+			callerRef:       "refs/heads/main",
+			inSubjectTag:    "main-abc1234",
+			inAllowUntagged: "true",
 		},
 	}
 
@@ -189,48 +222,48 @@ func TestAttestValidationRejects(t *testing.T) {
 		// Release attestations come from tags. Without this, a branch build
 		// signs under an identity users are told to trust.
 		"non-tag ref without allow_untagged": {
-			inputs{"CALLER_REF": "refs/heads/main"},
+			inputs{callerRef: "refs/heads/main"},
 			"refuses to run on refs/heads/main",
 		},
 		"digest with non-hex characters": {
-			inputs{"IN_EXPECTED_DIGEST": "sha256:zzzz"},
-			"expected_digest must match",
+			inputs{inExpectedDigest: "sha256:zzzz"},
+			errDigestMustMatch,
 		},
 		// Uppercase hex is a different string to cosign and to the registry, so
 		// accepting it would let two spellings of one digest diverge.
 		"digest with uppercase hex": {
-			inputs{"IN_EXPECTED_DIGEST": "sha256:AAAA111111111111111111111111111111111111111111111111111111111111"},
-			"expected_digest must match",
+			inputs{inExpectedDigest: "sha256:AAAA111111111111111111111111111111111111111111111111111111111111"},
+			errDigestMustMatch,
 		},
 		"digest missing the sha256 prefix": {
-			inputs{"IN_EXPECTED_DIGEST": strings.TrimPrefix(validDigest, "sha256:")},
-			"expected_digest must match",
+			inputs{inExpectedDigest: strings.TrimPrefix(validDigest, "sha256:")},
+			errDigestMustMatch,
 		},
 		// A newline lets a value forge extra lines in GITHUB_OUTPUT.
 		"newline in subject_name": {
-			inputs{"IN_SUBJECT_NAME": managerImage + "\nevil=1"},
+			inputs{inSubjectName: managerImage + "\nevil=1"},
 			"newline or carriage return",
 		},
 		"carriage return in subject_tag": {
-			inputs{"IN_SUBJECT_TAG": "v1.2.3\rx"},
+			inputs{inSubjectTag: "v1.2.3\rx"},
 			"newline or carriage return",
 		},
 		"unknown subject_kind": {
-			inputs{"IN_SUBJECT_KIND": "sbom"},
+			inputs{inSubjectKind: "sbom"},
 			"subject_kind must be",
 		},
 		// Without a tag there is nothing to resolve the digest from except the
 		// digest itself, which is the tautology this guard exists to prevent.
 		"image without subject_tag": {
-			inputs{"IN_SUBJECT_TAG": ""},
+			inputs{inSubjectTag: ""},
 			"subject_tag is required",
 		},
 		"subject_name carrying a digest": {
-			inputs{"IN_SUBJECT_NAME": managerImage + "@" + validDigest},
+			inputs{inSubjectName: managerImage + "@" + validDigest},
 			"without a tag or digest",
 		},
 		"subject_name carrying a tag": {
-			inputs{"IN_SUBJECT_NAME": managerImage + ":v1.2.3"},
+			inputs{inSubjectName: managerImage + ":v1.2.3"},
 			"without a tag or digest",
 		},
 		// artifact_name and predicate_name each had a traversal case; this one
@@ -238,51 +271,51 @@ func TestAttestValidationRejects(t *testing.T) {
 		// in the job that holds the signing token.
 		"path traversal in blob subject_name": {
 			inputs{
-				"IN_SUBJECT_KIND":  "blob",
-				"IN_SUBJECT_NAME":  "../../etc/passwd",
-				"IN_SUBJECT_TAG":   "",
-				"IN_ARTIFACT_NAME": "cli-binaries",
+				inSubjectKind:  kindBlob,
+				inSubjectName:  "../../etc/passwd",
+				inSubjectTag:   "",
+				inArtifactName: blobArtifact,
 			},
 			"must be a plain file name for a blob subject",
 		},
 		"blob subject_name with a path separator": {
 			inputs{
-				"IN_SUBJECT_KIND":  "blob",
-				"IN_SUBJECT_NAME":  "nested/nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":   "",
-				"IN_ARTIFACT_NAME": "cli-binaries",
+				inSubjectKind:  kindBlob,
+				inSubjectName:  "nested/nvcrectl-linux-amd64",
+				inSubjectTag:   "",
+				inArtifactName: blobArtifact,
 			},
 			"must be a plain file name for a blob subject",
 		},
 		// Distinct from "subject_tag is required": an empty tag trips the
 		// emptiness guard and never reaches the format guard.
 		"malformed subject_tag": {
-			inputs{"IN_SUBJECT_TAG": "v1/2.3"},
-			"subject_tag is not a valid OCI tag",
+			inputs{inSubjectTag: "v1/2.3"},
+			errInvalidTag,
 		},
 		"subject_tag starting with a dash": {
-			inputs{"IN_SUBJECT_TAG": "-v1.2.3"},
-			"subject_tag is not a valid OCI tag",
+			inputs{inSubjectTag: "-v1.2.3"},
+			errInvalidTag,
 		},
 		"over-long subject_tag": {
-			inputs{"IN_SUBJECT_TAG": strings.Repeat("v", 129)},
-			"subject_tag is not a valid OCI tag",
+			inputs{inSubjectTag: strings.Repeat("v", 129)},
+			errInvalidTag,
 		},
 		// artifact_name is required whenever predicate_name is set, including
 		// for image subjects where it is otherwise optional. Only the blob
 		// requirement was covered.
 		"image predicate without artifact_name": {
 			inputs{
-				"IN_PREDICATE_NAME": "sbom.cyclonedx.json",
-				"IN_PREDICATE_TYPE": "cyclonedx",
+				inPredicateName: "sbom.cyclonedx.json",
+				inPredicateType: predicateTypeCycloneDX,
 			},
 			"artifact_name is required when predicate_name is set",
 		},
 		"blob without artifact_name": {
 			inputs{
-				"IN_SUBJECT_KIND": "blob",
-				"IN_SUBJECT_NAME": "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":  "",
+				inSubjectKind: kindBlob,
+				inSubjectName: blobSubject,
+				inSubjectTag:  "",
 			},
 			"artifact_name is required when subject_kind is blob",
 		},
@@ -290,67 +323,67 @@ func TestAttestValidationRejects(t *testing.T) {
 		// which no documented verification command asks for.
 		"predicate without predicate_type": {
 			inputs{
-				"IN_SUBJECT_KIND":   "blob",
-				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":    "",
-				"IN_ARTIFACT_NAME":  "cli-binaries",
-				"IN_PREDICATE_NAME": "sbom.json",
+				inSubjectKind:   kindBlob,
+				inSubjectName:   blobSubject,
+				inSubjectTag:    "",
+				inArtifactName:  blobArtifact,
+				inPredicateName: "sbom.json",
 			},
 			"predicate_type is required",
 		},
 		"predicate_type outside the allowed set": {
 			inputs{
-				"IN_SUBJECT_KIND":   "blob",
-				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":    "",
-				"IN_ARTIFACT_NAME":  "cli-binaries",
-				"IN_PREDICATE_NAME": "sbom.json",
-				"IN_PREDICATE_TYPE": "custom",
+				inSubjectKind:   kindBlob,
+				inSubjectName:   blobSubject,
+				inSubjectTag:    "",
+				inArtifactName:  blobArtifact,
+				inPredicateName: "sbom.json",
+				inPredicateType: "custom",
 			},
 			"predicate_type must be one of",
 		},
 		"path traversal in predicate_name": {
 			inputs{
-				"IN_SUBJECT_KIND":   "blob",
-				"IN_SUBJECT_NAME":   "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":    "",
-				"IN_ARTIFACT_NAME":  "cli-binaries",
-				"IN_PREDICATE_NAME": "../../etc/passwd",
-				"IN_PREDICATE_TYPE": "cyclonedx",
+				inSubjectKind:   kindBlob,
+				inSubjectName:   blobSubject,
+				inSubjectTag:    "",
+				inArtifactName:  blobArtifact,
+				inPredicateName: "../../etc/passwd",
+				inPredicateType: predicateTypeCycloneDX,
 			},
 			"predicate_name must match",
 		},
 		"path traversal in artifact_name": {
 			inputs{
-				"IN_SUBJECT_KIND":  "blob",
-				"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":   "",
-				"IN_ARTIFACT_NAME": "../secrets",
+				inSubjectKind:  kindBlob,
+				inSubjectName:  blobSubject,
+				inSubjectTag:   "",
+				inArtifactName: "../secrets",
 			},
 			"artifact_name must match",
 		},
 		"platform on a blob subject": {
 			inputs{
-				"IN_SUBJECT_KIND":  "blob",
-				"IN_SUBJECT_NAME":  "nvcrectl-linux-amd64",
-				"IN_SUBJECT_TAG":   "",
-				"IN_ARTIFACT_NAME": "cli-binaries",
-				"IN_PLATFORM":      "linux/amd64",
+				inSubjectKind:  kindBlob,
+				inSubjectName:  blobSubject,
+				inSubjectTag:   "",
+				inArtifactName: blobArtifact,
+				inPlatform:     "linux/amd64",
 			},
 			"platform is meaningless",
 		},
 		"platform without an os/arch pair": {
-			inputs{"IN_PLATFORM": "amd64"},
+			inputs{inPlatform: "amd64"},
 			"platform must be os/arch",
 		},
 		// The version pin is what fixes the emitted bundle format, so a
 		// floating value would let the on-registry layout drift.
 		"floating cosign version": {
-			inputs{"IN_COSIGN_VERSION": "latest"},
+			inputs{inCosignVersion: "latest"},
 			"cosign_version must be",
 		},
 		"floating crane version": {
-			inputs{"IN_CRANE_VERSION": "main"},
+			inputs{inCraneVersion: "main"},
 			"crane_version must be",
 		},
 	}

--- a/test/uat/tilt/dra-stub/main.go
+++ b/test/uat/tilt/dra-stub/main.go
@@ -36,6 +36,10 @@ var (
 	}
 )
 
+// mapKeyName is the "name" map key shared by the unstructured object
+// builders below.
+const mapKeyName = "name"
+
 func main() {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -85,7 +89,7 @@ func reconcileComputeDomains(ctx context.Context, client dynamic.Interface) {
 			"apiVersion": "resource.k8s.io/v1",
 			"kind":       "ResourceClaimTemplate",
 			"metadata": map[string]any{
-				"name":      templateName,
+				mapKeyName:  templateName,
 				"namespace": ns,
 				"labels": map[string]any{
 					"app.kubernetes.io/created-by": "dra-stub",
@@ -94,7 +98,7 @@ func reconcileComputeDomains(ctx context.Context, client dynamic.Interface) {
 					map[string]any{
 						"apiVersion": cd.GetAPIVersion(),
 						"kind":       cd.GetKind(),
-						"name":       cd.GetName(),
+						mapKeyName:   cd.GetName(),
 						"uid":        string(cd.GetUID()),
 					},
 				},
@@ -104,7 +108,7 @@ func reconcileComputeDomains(ctx context.Context, client dynamic.Interface) {
 					"devices": map[string]any{
 						"requests": []any{
 							map[string]any{
-								"name": "gpu-channel",
+								mapKeyName: "gpu-channel",
 								"exactly": map[string]any{
 									"deviceClassName": "gpu.nvidia.com",
 								},


### PR DESCRIPTION
## Summary

mechanical upgrade to go 1.27

## Related Issue

<!-- Pull requests need a linked, acknowledged issue (trivial fixes are exempt) -->

Closes #

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [X] 🔨 Build/CI

## Component(s) Affected
- [ ] API / CRDs
- [ ] Controller / Reconcilers
- [ ] Catalog / Workloads
- [ ] CLI (nvcrectl)
- [ ] Helm / Deployment
- [ ] Documentation / CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Commits are signed off for the DCO (`git commit -s`)
- [ ] `make manifests generate` run (if `*_types.go` was modified)
- [ ] Golden files updated (if integration test output changed)
- [ ] Documentation updated (if needed)
- [ ] Ready for review
