### PR TITLE
ci: sign and attest the Helm chart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,19 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
+          # Reject CR/LF before the value is echoed anywhere. A workflow command
+          # must start at the beginning of a line, so a dispatch input carrying
+          # a newline could forge one -- `::add-mask::`, or `::stop-commands::`
+          # to silence the rest of the log -- through any message that quotes
+          # it. Fixed message here: naming the value would be the very thing
+          # this rejects.
+          case "${INPUT_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::the dispatch tag input contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+
           if [[ -n "${INPUT_TAG}" ]]; then
             if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
               echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the signature carries the release identity."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,20 +85,31 @@ jobs:
               echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the signature carries the release identity."
               exit 1
             fi
-            echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+            value="${INPUT_TAG}"
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            value="${GITHUB_REF_NAME}"
           else
-            echo "value=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            value="main-${GITHUB_SHA::7}"
           fi
+
+          # Git permits `"`, `$( )`, backticks and `|` in a tag name, and this
+          # value reaches a `run:` block on a runner holding packages:write.
+          # Constrain it at the single point it enters the workflow: a release
+          # tag, or the main-<sha> form this workflow generates itself.
+          if [[ ! "${value}" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|main-[0-9a-f]{7})$ ]]; then
+            echo "::error::refusing to publish under a tag that is neither vMAJOR.MINOR.PATCH[-prerelease] nor main-<sha>: ${value}"
+            exit 1
+          fi
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: push
         run: |
+          set -euo pipefail
           make docker-buildx
           # Capture the image digest for signing
           DIGEST=$(docker buildx imagetools inspect \
-            "${IMAGE_NAME}:${{ steps.tag.outputs.value }}" \
+            "${IMAGE_NAME}:${IMAGE_TAG}" \
             --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         env:
@@ -106,6 +117,7 @@ jobs:
           # uppercase 'NVIDIA/...', so the path is hardcoded. Keep in sync with
           # the Makefile, helm values.yaml, and pkg/setup/setup.go.
           IMG: ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.value }}
+          IMAGE_TAG: ${{ steps.tag.outputs.value }}
 
       # An SBOM describes exactly one root filesystem, and this image is a
       # multi-platform index. Attaching one SBOM to the index digest -- what this

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
             echo "### Helm chart published"
             echo
             echo '```'
-            echo "oci://${{ steps.tag.outputs.chart_name }}:${{ steps.tag.outputs.value }}"
+            echo "oci://${CHART_NAME}:${CHART_TAG}"
             echo "${digest}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
@@ -102,6 +102,11 @@ jobs:
           # 'NVIDIA', so the value is hardcoded. Keep in sync with
           # RELEASE.md and pkg/setup/helm.go.
           HELM_OCI_REGISTRY: oci://ghcr.io/nvidia
+          # Through the environment rather than `${{ }}` inside the script, so a
+          # value is data and not code -- the rule attest.yml states and the tag
+          # step above already follows.
+          CHART_NAME: ${{ steps.tag.outputs.chart_name }}
+          CHART_TAG: ${{ steps.tag.outputs.value }}
 
   # The chart is the highest-leverage artifact in the release: it carries the
   # CRDs and the manager ClusterRole, so a tampered chart grants itself whatever
@@ -306,26 +311,29 @@ jobs:
 
             ## Helm Chart
 
-            ```bash
-            helm install nvcre \
-              oci://ghcr.io/nvidia/cluster-readiness-engine \
-              --version ${{ steps.tag.outputs.value }} \
-              --namespace nvcre \
-              --create-namespace
-            ```
-
-            The controller image for this release is `ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}`.
-
-            The chart above is published at digest `${{ needs.helm-publish.outputs.chart_digest }}`. That digest is what the release signature covers; the version tag is mutable. Verify before installing:
+            This release's chart is published at digest `${{ needs.helm-publish.outputs.chart_digest }}`. The signature covers that digest; the version tag is mutable, so verify and install the **same digest** rather than verifying a digest and installing a tag.
 
             ```bash
+            CHART=ghcr.io/nvidia/cluster-readiness-engine
+            DIGEST=${{ needs.helm-publish.outputs.chart_digest }}
+
+            # 1. Verify the chart. Requires cosign; the package is public, so no login is needed.
             cosign verify \
               --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-              ghcr.io/nvidia/cluster-readiness-engine@${{ needs.helm-publish.outputs.chart_digest }}
+              "${CHART}@${DIGEST}"
+
+            # 2. Pull that exact digest, then install the file you just verified.
+            helm pull "oci://${CHART}@${DIGEST}"
+            helm install nvcre ./cluster-readiness-engine@${DIGEST/:/-}.tgz \
+              --namespace nvcre --create-namespace
             ```
 
-            `helm install --verify` does **not** check this signature — that flag looks for a PGP `.prov` file, which is a different mechanism.
+            Installing with `--version ${{ steps.tag.outputs.value }}` instead resolves the tag at install time, which is not provably the digest you verified.
+
+            `helm install --verify` does **not** check this signature. That flag looks for a PGP `.prov` file, a mechanism unrelated to Sigstore, and we publish no `.prov` files.
+
+            The controller image for this release is `ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}` — a different artifact from the chart, verified separately.
 
             ## nvcrectl CLI
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      tag: ${{ steps.tag.outputs.value }}
+      chart_name: ${{ steps.tag.outputs.chart_name }}
+      chart_digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -47,14 +51,28 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # A dispatch that names a tag but runs from a branch would publish a
+      # release-versioned chart whose signature carries a `refs/heads/...`
+      # identity -- a release nothing can verify as one. Dispatch at the tag:
+      # `gh workflow run Release --ref v1.2.3 -f tag=v1.2.3`.
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
+              echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the chart signature carries the release identity."
+              exit 1
+            fi
+            echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
+          # GHCR requires lowercase; `helm push <chart>.tgz oci://ghcr.io/nvidia`
+          # lands the chart at <registry>/<chart-name>.
+          echo "chart_name=ghcr.io/nvidia/cluster-readiness-engine" >> "$GITHUB_OUTPUT"
 
       # VERSION is passed explicitly instead of trusting `git describe` on
       # the runner's checkout: a shallow or tag-less checkout makes
@@ -63,12 +81,84 @@ jobs:
       # helm-push depends on check-clean-version, which rejects anything
       # that is not a clean vX.Y.Z[-prerelease] tag.
       - name: Package and push Helm chart
-        run: make helm-push VERSION="${{ steps.tag.outputs.value }}"
+        id: push
+        run: |
+          set -euo pipefail
+          make helm-push VERSION="${{ steps.tag.outputs.value }}" CHART_DIGEST_FILE=chart-digest.txt
+          digest="$(cat chart-digest.txt)"
+          [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::chart digest is malformed: ${digest}"; exit 1; }
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Helm chart published"
+            echo
+            echo '```'
+            echo "oci://${{ steps.tag.outputs.chart_name }}:${{ steps.tag.outputs.value }}"
+            echo "${digest}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           # GHCR requires lowercase paths but the repo slug is uppercase
           # 'NVIDIA', so the value is hardcoded. Keep in sync with
           # RELEASE.md and pkg/setup/helm.go.
           HELM_OCI_REGISTRY: oci://ghcr.io/nvidia
+
+  # The chart is the highest-leverage artifact in the release: it carries the
+  # CRDs and the manager ClusterRole, so a tampered chart grants itself whatever
+  # RBAC it likes. Signed by digest, never by the tag the release notes quote.
+  #
+  # `oci-artifact` rather than `image`: a Helm chart is a plain OCI artifact
+  # (config `application/vnd.cncf.helm.config.v1+json`), and cosign is
+  # digest-addressed and media-type agnostic, so signing works identically. Note
+  # this signature does NOT satisfy `helm install --verify`, which checks a PGP
+  # `.prov` file and is unrelated to Sigstore; verification is a client-side
+  # `cosign verify` before install.
+  attest-chart:
+    name: Attest Helm chart
+    needs: [helm-publish]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/attest.yml
+    with:
+      subject_kind: oci-artifact
+      subject_name: ${{ needs.helm-publish.outputs.chart_name }}
+      subject_tag: ${{ needs.helm-publish.outputs.tag }}
+      expected_digest: ${{ needs.helm-publish.outputs.chart_digest }}
+
+  # A skipped job does not fail its caller, so without this a broken gate inside
+  # attest.yml would publish an unsigned chart under a green release.
+  chart-attested:
+    name: Confirm the chart was signed
+    needs: [helm-publish, attest-chart]
+    if: always() && github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require the chart attestation to have succeeded
+        env:
+          PUBLISH: ${{ needs.helm-publish.result }}
+          ATTEST: ${{ needs.attest-chart.result }}
+        run: |
+          set -euo pipefail
+          echo "helm-publish=${PUBLISH} attest-chart=${ATTEST}"
+          if [[ "${PUBLISH}" != "success" ]]; then
+            echo "::error::the chart publish job did not succeed (${PUBLISH}); no chart was published."
+            exit 1
+          fi
+          case "${ATTEST}" in
+            success) echo "chart signed and attested" ;;
+            skipped)
+              echo "::error::the chart attestation was SKIPPED. The chart is published and unsigned; a skipped job does not fail its caller, so this would otherwise have passed silently."
+              exit 1
+              ;;
+            *)
+              echo "::error::the chart attestation did not succeed (${ATTEST}). The chart is published; treat it as unsigned until this is resolved."
+              exit 1
+              ;;
+          esac
 
   build-cli:
     name: Build CLI Binaries
@@ -136,6 +226,7 @@ jobs:
     timeout-minutes: 10
     needs:
       - helm-publish
+      - chart-attested
       - build-cli
     permissions:
       contents: write
@@ -224,6 +315,17 @@ jobs:
             ```
 
             The controller image for this release is `ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}`.
+
+            The chart above is published at digest `${{ needs.helm-publish.outputs.chart_digest }}`. That digest is what the release signature covers; the version tag is mutable. Verify before installing:
+
+            ```bash
+            cosign verify \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              ghcr.io/nvidia/cluster-readiness-engine@${{ needs.helm-publish.outputs.chart_digest }}
+            ```
+
+            `helm install --verify` does **not** check this signature — that flag looks for a PGP `.prov` file, which is a different mechanism.
 
             ## nvcrectl CLI
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,10 @@ jobs:
           version: v3.19.2
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GHCR_USER}" --password-stdin
 
       # A dispatch that names a tag but runs from a branch would publish a
       # release-versioned chart whose signature carries a `refs/heads/...`
@@ -66,10 +69,20 @@ jobs:
               echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the chart signature carries the release identity."
               exit 1
             fi
-            echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+            value="${INPUT_TAG}"
           else
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            value="${GITHUB_REF_NAME}"
           fi
+          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
+          # unvalidated tag reaching a `run:` block is shell injection on a
+          # runner that holds packages:write. `check-clean-version` cannot help:
+          # it runs inside make, long after the shell has parsed the command.
+          # Validate here, at the single point the value enters the workflow.
+          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
+            exit 1
+          fi
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
           # GHCR requires lowercase; `helm push <chart>.tgz oci://ghcr.io/nvidia`
           # lands the chart at <registry>/<chart-name>.
           echo "chart_name=ghcr.io/nvidia/cluster-readiness-engine" >> "$GITHUB_OUTPUT"
@@ -84,7 +97,7 @@ jobs:
         id: push
         run: |
           set -euo pipefail
-          make helm-push VERSION="${{ steps.tag.outputs.value }}" CHART_DIGEST_FILE=chart-digest.txt
+          make helm-push VERSION="${CHART_TAG}" CHART_DIGEST_FILE=chart-digest.txt
           digest="$(cat chart-digest.txt)"
           [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
             echo "::error::chart digest is malformed: ${digest}"; exit 1; }
@@ -184,12 +197,25 @@ jobs:
 
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            value="${INPUT_TAG}"
           else
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            value="${GITHUB_REF_NAME}"
           fi
+          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
+          # unvalidated tag reaching a `run:` block is shell injection on a
+          # runner that holds packages:write. `check-clean-version` cannot help:
+          # it runs inside make, long after the shell has parsed the command.
+          # Validate here, at the single point the value enters the workflow.
+          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
+            exit 1
+          fi
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       # Stamp the binaries with the tag explicitly instead of trusting
       # `git describe` on the runner's checkout: a shallow or tag-less
@@ -199,17 +225,22 @@ jobs:
       # anything that is not a clean vX.Y.Z[-prerelease] tag, so a malformed
       # workflow_dispatch input fails here instead of mislabeling binaries.
       - name: Cross-compile nvcrectl
+        env:
+          TAG: ${{ steps.tag.outputs.value }}
         run: |
-          make check-clean-version VERSION="${{ steps.tag.outputs.value }}"
-          make build-nvcrectl-cross VERSION="${{ steps.tag.outputs.value }}"
+          set -euo pipefail
+          make check-clean-version VERSION="${TAG}"
+          make build-nvcrectl-cross VERSION="${TAG}"
 
       # The runner is linux/amd64, so that binary runs natively. Require the
       # self-reported version to equal the tag exactly — a `-N-gSHA`/`-dirty`
       # suffix or a broken ldflags -> main.version plumbing fails the release
       # here, before any artifact is published (issue #195).
       - name: Verify stamped version matches the tag
+        env:
+          TAG: ${{ steps.tag.outputs.value }}
         run: |
-          tag="${{ steps.tag.outputs.value }}"
+          tag="${TAG}"
           got="$(./bin/nvcrectl-linux-amd64 --version | awk '{print $NF}')"
           echo "tag=${tag} binary-reported=${got}"
           if [[ "${got}" != "${tag}" ]]; then
@@ -248,12 +279,25 @@ jobs:
 
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            value="${INPUT_TAG}"
           else
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            value="${GITHUB_REF_NAME}"
           fi
+          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
+          # unvalidated tag reaching a `run:` block is shell injection on a
+          # runner that holds packages:write. `check-clean-version` cannot help:
+          # it runs inside make, long after the shell has parsed the command.
+          # Validate here, at the single point the value enters the workflow.
+          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
+            exit 1
+          fi
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums
         run: |
@@ -384,8 +428,9 @@ jobs:
       - name: Verify published release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.value }}
         run: |
-          tag="${{ steps.tag.outputs.value }}"
+          tag="${TAG}"
           rm -rf verify-release && mkdir verify-release
           visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
           echo "repository visibility: ${visibility}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,19 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
+          # Reject CR/LF before the value is echoed anywhere. A workflow command
+          # must start at the beginning of a line, so a dispatch input carrying
+          # a newline could forge one -- `::add-mask::`, or `::stop-commands::`
+          # to silence the rest of the log -- through any message that quotes
+          # it. Fixed message here: naming the value would be the very thing
+          # this rejects.
+          case "${INPUT_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::the dispatch tag input contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
               echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the chart signature carries the release identity."
@@ -201,6 +214,18 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
+
+          # Reject CR/LF before the value reaches any message. A workflow
+          # command must start at the beginning of a line, so a dispatch input
+          # carrying a newline could forge one through the validation error
+          # below, which quotes the value. Fixed message here on purpose.
+          case "${INPUT_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::the dispatch tag input contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             value="${INPUT_TAG}"
           else
@@ -283,6 +308,18 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
+
+          # Reject CR/LF before the value reaches any message. A workflow
+          # command must start at the beginning of a line, so a dispatch input
+          # carrying a newline could forge one through the validation error
+          # below, which quotes the value. Fixed message here on purpose.
+          case "${INPUT_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::the dispatch tag input contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             value="${INPUT_TAG}"
           else

--- a/Makefile
+++ b/Makefile
@@ -299,8 +299,9 @@ helm-package: helm-lint ## Package the cluster-readiness-engine Helm chart.
 
 .PHONY: helm-push
 # The digest is what gets signed, so print it rather than leaving the operator
-# to look it up. `helm push` reports it on stderr, and CHART_DIGEST_FILE lets
-# CI capture the value without re-parsing the log.
+# to look it up. Both streams are captured because helm's output stream for the
+# digest line is not a documented contract, and CHART_DIGEST_FILE lets CI take
+# the value without re-parsing a log.
 helm-push: check-clean-version helm-package ## Push the Helm chart to the OCI registry and print its digest.
 	@set -eu; \
 	log="$$(mktemp)"; \

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,9 @@ HELM_PACKAGE_VERSION ?= $(VERSION)
 # OCI registry base for Helm chart publishing.
 # helm push pushes to $(HELM_OCI_REGISTRY)/<chart-name>:<version>.
 HELM_OCI_REGISTRY ?= oci://ghcr.io/nvidia
+# When set, helm-push writes the pushed chart's digest here. CI reads it to hand
+# the digest to the signing workflow without scraping the log.
+CHART_DIGEST_FILE ?=
 
 .PHONY: helm-lint
 helm-lint: ## Lint the cluster-readiness-engine Helm chart.
@@ -295,10 +298,27 @@ helm-package: helm-lint ## Package the cluster-readiness-engine Helm chart.
 		--app-version "$(VERSION)"
 
 .PHONY: helm-push
-helm-push: check-clean-version helm-package ## Push the Helm chart to the OCI registry.
-	"$(HELM)" push \
+# The digest is what gets signed, so print it rather than leaving the operator
+# to look it up. `helm push` reports it on stderr, and CHART_DIGEST_FILE lets
+# CI capture the value without re-parsing the log.
+helm-push: check-clean-version helm-package ## Push the Helm chart to the OCI registry and print its digest.
+	@set -eu; \
+	log="$$(mktemp)"; \
+	trap 'rm -f "$$log"' EXIT; \
+	if ! "$(HELM)" push \
 		cluster-readiness-engine-$(HELM_PACKAGE_VERSION).tgz \
-		$(HELM_OCI_REGISTRY)
+		$(HELM_OCI_REGISTRY) >"$$log" 2>&1; then \
+		cat "$$log" >&2; \
+		exit 1; \
+	fi; \
+	cat "$$log"; \
+	digest="$$(sed -n 's/.*[Dd]igest: \(sha256:[0-9a-f]\{64\}\).*/\1/p' "$$log" | tail -1)"; \
+	if [ -z "$$digest" ]; then \
+		echo "ERROR: helm push reported no sha256 digest; refusing to continue because the digest is what gets signed" >&2; \
+		exit 1; \
+	fi; \
+	echo "chart digest: $$digest"; \
+	if [ -n "$(CHART_DIGEST_FILE)" ]; then printf '%s' "$$digest" > "$(CHART_DIGEST_FILE)"; fi
 
 ##@ Dependencies
 


### PR DESCRIPTION
## Summary

The Helm chart was pushed and nothing else. It is the highest-leverage artifact in the release — it carries the CRDs and the manager ClusterRole, so a tampered chart grants itself whatever RBAC it likes — and the release notes tell every user to install it by name and version, a mutable tag resolved at install time with nothing to check.

It is now signed and attested through the same reusable workflow as every other artifact, so it carries one certificate identity users can pin. Signed **by digest**: `helm push` reports what the registry actually stored, the value is validated before it reaches the signer, and `attest.yml` independently re-resolves it from the tag with crane and fails closed on mismatch.

`subject_kind: oci-artifact`, the first caller of that subject kind. A Helm chart is a plain OCI artifact — config `application/vnd.cncf.helm.config.v1+json`, layer `application/vnd.cncf.helm.chart.content.v1.tar+gzip`, confirmed against the published v0.1.0 chart — and cosign is digest-addressed and media-type agnostic, so signing behaves exactly as it does for an image.

### `helm install --verify` is the wrong mechanism — a scope correction

This issue's original scope said to document "`helm install --verify` / cosign pre-install verification" as though they were two names for one thing. They are not. `--verify` checks a **PGP `.prov` file** against a GnuPG keyring; it predates Sigstore and cannot validate a cosign signature. We publish no `.prov` files, so following that instruction would fail on every chart we ship no matter how correctly it is signed.

Corrected on #267 with a consumer matrix. Two consequences: chart verification is **client-side and pre-install**, and #272's admission-policy samples cannot cover it — Kyverno and policy-controller gate Pod image references, and a chart is never pulled by a kubelet.

### Verify and install are now one flow

Three persona screens independently found that the notes told an operator to verify a digest, warned in the same paragraph that the tag is mutable, and then left them installing by tag. Verified one artifact, installed another.

Confirmed helm can close that rather than assuming it: `helm pull oci://<chart>@sha256:…` is accepted, issues `GET manifests/<digest>`, and pulls that exact digest anonymously from the public package. The notes now give one sequence — verify the digest, pull the digest, install the file just pulled — and state that `--version` resolves the tag instead and is not provably what was verified. The derived filename was checked against what helm actually writes, and the pulled chart confirmed loadable with `helm show chart`.

## Related Issue

Part of #267 — deliberately **not** `Closes`. See below.

## Type of Change
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Helm / Deployment
- [x] Documentation / CI

## Testing

Executed rather than reasoned about:

- **`helm pull` by digest**, anonymously against the public package: pulls the exact digest, filename matches what the documented install command derives, `helm show chart` loads it.
- **The chart is an OCI artifact** — media types fetched from ghcr.io, not assumed.
- **`helm-push` digest capture** across three cases: a normal push, a push reporting no digest (fails closed), and a failing push. An earlier draft piped through `tee /dev/stderr` and died with "Operation not permitted"; replaced with a temp file.
- **The `chart-attested` guard** across all four publish × attest result combinations.
- `actionlint` clean bar the repo-wide `runner-label` false positive. `make verify` and `go test ./test/releasepolicy/` pass.

### Self-review findings

Five screens ran before this PR opened. Distributed Systems returned no findings, confirming the TOCTOU window is closed by `attest.yml`'s re-resolution plus the workflow concurrency group, and that a flaky chart attestation blocks only the release, not the binary build.

- **Verify/install gap** (MAJOR, found by three screens) — fixed above.
- **Step summary interpolated `${{ }}` into the script body** (NIT). Not reachable with a hostile value today, since the tag passes `check-clean-version` first, but it contradicts the rule `attest.yml` states and the tag step in this same file already follows. Routed through `env`.
- **A Makefile comment claimed helm reports the digest on stderr** — not a documented contract, and I had not verified it. The code merges both streams, so the comment was the only thing asserting it. Corrected.

Two raised concerns that checking dismissed: `create-github-release` carries no `always()` override, so a failed `chart-attested` skips it as intended; and a wrong-but-well-formed scraped digest cannot be signed, because `attest.yml` re-resolves from the tag and fails closed.

## What is not proven

`release.yml` runs only on a release tag, so **none of this has executed**. The first exercise is the next release.

Also open, and part of this issue's scope: whether **Flux `OCIRepository`** and **Argo CD** can consume a cosign-signed chart. Flux is believed to support it via `.spec.verify.provider: cosign` but that is unconfirmed against a real version.

#267 therefore stays **open** until a release exercises the path and the GitOps consumer question is settled.

- [x] Tests pass locally
- [x] Manual testing completed — see above
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated (if needed) — release notes template
- [x] Ready for review
