### PR TITLE
ci: make the release authoritative about the image it advertises

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable workflow that builds and pushes the controller image and produces its
+# per-platform SBOMs.
+#
+# It exists so the RELEASE is authoritative about what it advertises. Previously
+# publish.yml and release.yml both fired on a tag push and raced: release.yml
+# created a GitHub Release naming an image tag it had never resolved, could not
+# confirm existed, and had no digest for -- so it could not have verified a
+# signature even in principle. Now release.yml calls this workflow and receives
+# the digests directly, and publish.yml builds only the main-branch dev images.
+#
+# It does NOT sign anything. Signing belongs to attest.yml, which every caller
+# invokes with the digests this workflow returns (ADR-074 decision 4).
+
+name: Build Image (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: >-
+          Tag to publish the image under. The caller is responsible for
+          validating it; this workflow re-checks the shape because the value
+          reaches a shell.
+        required: true
+        type: string
+    outputs:
+      image_name:
+        description: 'Registry path of the image, without tag or digest.'
+        value: ${{ jobs.build.outputs.image_name }}
+      index_digest:
+        description: 'Digest of the multi-platform index.'
+        value: ${{ jobs.build.outputs.index_digest }}
+      amd64_digest:
+        description: 'Digest of the linux/amd64 child manifest.'
+        value: ${{ jobs.build.outputs.amd64_digest }}
+      arm64_digest:
+        description: 'Digest of the linux/arm64 child manifest.'
+        value: ${{ jobs.build.outputs.arm64_digest }}
+      sbom_artifact:
+        description: 'Name of the uploaded artifact holding the per-platform SBOMs.'
+        value: image-sboms
+
+permissions: {}
+
+env:
+  IMAGE_NAME: ghcr.io/nvidia/cluster-readiness-engine/manager
+
+jobs:
+  build:
+    name: Build and Push Container
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: linux-amd64-cpu32
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_name: ${{ env.IMAGE_NAME }}
+      index_digest: ${{ steps.push.outputs.digest }}
+      amd64_digest: ${{ steps.platforms.outputs.amd64 }}
+      arm64_digest: ${{ steps.platforms.outputs.arm64 }}
+    steps:
+      # Re-validated here even though callers validate: this value reaches a
+      # shell in a job holding packages:write, and a reusable workflow must not
+      # rely on every future caller having done the check.
+      - name: Validate image tag
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          case "${IMAGE_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::image_tag contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+          if [[ ! "${IMAGE_TAG}" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|main-[0-9a-f]{7})$ ]]; then
+            echo "::error::image_tag is neither vMAJOR.MINOR.PATCH[-prerelease] nor main-<sha>: ${IMAGE_TAG}"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Use the pre-populated buildkitd config on NVIDIA GHA runners, which
+      # routes image pulls through a per-environment Docker mirror cache.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        run: |
+          set -euo pipefail
+          make docker-buildx
+          # Capture the image digest for signing
+          DIGEST=$(docker buildx imagetools inspect \
+            "${IMAGE_NAME}:${IMAGE_TAG}" \
+            --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        env:
+          # GHCR paths must be lowercase and github.repository expands to
+          # uppercase 'NVIDIA/...', so the path is hardcoded. Keep in sync with
+          # the Makefile, helm values.yaml, and pkg/setup/setup.go.
+          IMG: ${{ env.IMAGE_NAME }}:${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+
+      # An SBOM describes exactly one root filesystem, and this image is a
+      # multi-platform index. Attaching one SBOM to the index digest -- what this
+      # workflow used to do -- publishes one architecture's package list as if it
+      # described both, so an operator scanning the arm64 image reads amd64 data.
+      #
+      # Resolution uses `docker buildx imagetools`, which is already present for
+      # the push above. attest.yml re-resolves independently with crane before it
+      # signs, so the two paths do not share a tool or a failure mode.
+      - name: Resolve per-platform manifest digests
+        id: platforms
+        env:
+          REF: ${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
+          INDEX_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          manifest="$(docker buildx imagetools inspect "${REF}" --raw)"
+          amd64_digest=""
+          arm64_digest=""
+
+          for arch in amd64 arm64; do
+            digest="$(jq -r --arg a "${arch}" '
+              [ .manifests[]?
+                | select(.platform.os == "linux" and .platform.architecture == $a)
+                | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+                | .digest ] | first // empty' <<<"${manifest}")"
+
+            if [[ -z "${digest}" ]]; then
+              echo "::error::linux/${arch} is absent from the index; the release lost an architecture"
+              exit 1
+            fi
+            if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::linux/${arch} digest is malformed: ${digest}"
+              exit 1
+            fi
+            # Equal to the index means this reference is a plain manifest, not an
+            # index, so the "per-platform" SBOM would describe the wrong subject.
+            if [[ "${digest}" == "${INDEX_DIGEST}" ]]; then
+              echo "::error::linux/${arch} resolved to the index digest; ${REF} is not a multi-platform index"
+              exit 1
+            fi
+            echo "${arch}=${digest}" >> "$GITHUB_OUTPUT"
+            echo "linux/${arch} -> ${digest}"
+            case "${arch}" in
+              amd64) amd64_digest="${digest}" ;;
+              arm64) arm64_digest="${digest}" ;;
+            esac
+          done
+
+          # Identical digests mean the index carries one manifest advertised
+          # under both architectures, so one SBOM would be published twice under
+          # two names -- the same defect this job removes, in a new disguise.
+          if [[ "${amd64_digest}" == "${arm64_digest}" ]]; then
+            echo "::error::amd64 and arm64 resolved to the same digest; the image is not multi-platform"
+            exit 1
+          fi
+
+      # syft writes to the path it is given and will not create the directory.
+      - name: Create SBOM output directory
+        run: mkdir -p sboms
+
+      # SYFT_PLATFORM plus a per-platform digest is what makes these two
+      # documents actually differ. Format stays CycloneDX (ADR-074 decision 5);
+      # this changes the SBOM's subject, not its format.
+      - name: Generate linux/amd64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        env:
+          SYFT_PLATFORM: linux/amd64
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64 }}
+          format: cyclonedx-json
+          output-file: sboms/sbom-linux-amd64.cyclonedx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate linux/arm64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        env:
+          SYFT_PLATFORM: linux/arm64
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64 }}
+          format: cyclonedx-json
+          output-file: sboms/sbom-linux-arm64.cyclonedx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      # Each SBOM is generated against a per-platform MANIFEST digest, not the
+      # tag, so syft can only see that platform's root filesystem; the
+      # distinctness checks above already reject the case where both digests are
+      # the same. What is not covered upstream is a wiring mistake between these
+      # two near-identical steps -- the amd64 SBOM generated against the arm64
+      # digest, or one digest used twice -- so that is what this checks.
+      #
+      # Deliberately NOT a comparison of the two package sets. The image is a
+      # static Go binary on distroless: both platforms legitimately resolve the
+      # same Go module list, so requiring the sets to differ would fail correct
+      # releases. Comparing whole-document bytes is worse still -- a CycloneDX
+      # document carries a random serialNumber and a timestamp, so two documents
+      # are never byte-identical and such a check can never fire.
+      - name: Verify each SBOM describes its own platform
+        env:
+          AMD64: ${{ steps.platforms.outputs.amd64 }}
+          ARM64: ${{ steps.platforms.outputs.arm64 }}
+        run: |
+          set -euo pipefail
+          amd64_file=sboms/sbom-linux-amd64.cyclonedx.json
+          arm64_file=sboms/sbom-linux-arm64.cyclonedx.json
+
+          for f in "${amd64_file}" "${arm64_file}"; do
+            [[ -s "${f}" ]] || { echo "::error::${f} is missing or empty"; exit 1; }
+            jq -e . "${f}" >/dev/null || { echo "::error::${f} is not valid JSON"; exit 1; }
+          done
+
+          # A document referencing the other platform's digest was generated
+          # against the wrong subject. Where syft records no digest at all,
+          # neither branch fires and the check stays silent rather than failing
+          # on an assumption about syft's output shape.
+          if grep -q "${ARM64#sha256:}" "${amd64_file}"; then
+            echo "::error::the amd64 SBOM references the arm64 manifest digest; the two generation steps are wired to the wrong subjects"
+            exit 1
+          fi
+          if grep -q "${AMD64#sha256:}" "${arm64_file}"; then
+            echo "::error::the arm64 SBOM references the amd64 manifest digest; the two generation steps are wired to the wrong subjects"
+            exit 1
+          fi
+
+          for pair in "amd64:${amd64_file}" "arm64:${arm64_file}"; do
+            arch="${pair%%:*}"; file="${pair#*:}"
+            count="$(jq '[.components[]?] | length' "${file}")"
+            if [[ "${count}" -eq 0 ]]; then
+              echo "::error::the ${arch} SBOM lists no components; syft produced an empty inventory"
+              exit 1
+            fi
+            echo "${arch} components: ${count}"
+          done
+
+      - name: Upload SBOMs for attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-sboms
+          path: sboms/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,7 +58,10 @@ jobs:
       contents: read
       packages: write
     outputs:
-      image_name: ${{ env.IMAGE_NAME }}
+      # From a step, not `${{ env.* }}`. Availability of the env context in a
+      # job-level outputs block is not a guarantee worth resting the release on:
+      # an empty value here would flow into every attest call as the subject.
+      image_name: ${{ steps.name.outputs.value }}
       index_digest: ${{ steps.push.outputs.digest }}
       amd64_digest: ${{ steps.platforms.outputs.amd64 }}
       arm64_digest: ${{ steps.platforms.outputs.arm64 }}
@@ -66,6 +69,13 @@ jobs:
       # Re-validated here even though callers validate: this value reaches a
       # shell in a job holding packages:write, and a reusable workflow must not
       # rely on every future caller having done the check.
+      - name: Resolve image name
+        id: name
+        run: |
+          set -euo pipefail
+          [[ -n "${IMAGE_NAME}" ]] || { echo "::error::IMAGE_NAME is empty"; exit 1; }
+          echo "value=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
       - name: Validate image tag
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -66,9 +66,6 @@ jobs:
       amd64_digest: ${{ steps.platforms.outputs.amd64 }}
       arm64_digest: ${{ steps.platforms.outputs.arm64 }}
     steps:
-      # Re-validated here even though callers validate: this value reaches a
-      # shell in a job holding packages:write, and a reusable workflow must not
-      # rely on every future caller having done the check.
       - name: Resolve image name
         id: name
         run: |
@@ -76,6 +73,9 @@ jobs:
           [[ -n "${IMAGE_NAME}" ]] || { echo "::error::IMAGE_NAME is empty"; exit 1; }
           echo "value=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
+      # Re-validated here even though callers validate: this value reaches a
+      # shell in a job holding packages:write, and a reusable workflow must not
+      # rely on every future caller having done the check.
       - name: Validate image tag
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Development images for the main branch.
+#
+# This workflow no longer runs on tags. It used to, and so did release.yml, so a
+# tag push started both and they raced: release.yml created a GitHub Release
+# advertising an image tag it had never resolved and had no digest for, while
+# publish.yml was independently building and signing that image. release.yml now
+# builds the release image itself through the same reusable workflow this one
+# calls, which makes the release authoritative about what it publishes and
+# leaves this workflow responsible only for `main-<sha>` dev images.
+
 name: Publish
 
 on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Existing tag to build and publish (e.g., v1.2.3)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -23,263 +26,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  IMAGE_NAME: ghcr.io/nvidia/cluster-readiness-engine/manager
-
 jobs:
-  # Build and push only. This job no longer signs anything: signing moved to the
-  # reusable attest.yml (ADR-074 decision 4), which gives every released
-  # artifact one certificate identity to pin and keeps the signing token out of
-  # the job that runs the build.
-  publish:
-    name: Build and Push Container
-    runs-on: linux-amd64-cpu32
+  tag:
+    name: Compute image tag
+    runs-on: ubuntu-latest
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
-    timeout-minutes: 40
-    permissions:
-      contents: read
-      packages: write
+    timeout-minutes: 5
+    permissions: {}
     outputs:
-      # Exported because a reusable-workflow `with:` block cannot see the `env`
-      # context, so the three attest jobs below cannot read IMAGE_NAME directly.
-      # Routing it through an output keeps one definition of the registry path.
-      image_name: ${{ env.IMAGE_NAME }}
-      tag: ${{ steps.tag.outputs.value }}
-      index_digest: ${{ steps.push.outputs.digest }}
-      amd64_digest: ${{ steps.platforms.outputs.amd64 }}
-      arm64_digest: ${{ steps.platforms.outputs.arm64 }}
+      value: ${{ steps.tag.outputs.value }}
     steps:
-      # Check out the requested tag on workflow_dispatch. Without the ref,
-      # a dispatched run builds whatever branch the workflow ran from (main)
-      # while tagging the image with the input tag — publishing an image
-      # whose contents and stamped version do not match its tag.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
-
-      # Use the pre-populated buildkitd config on NVIDIA GHA runners, which
-      # routes image pulls through a per-environment Docker mirror cache.
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        with:
-          buildkitd-config: /etc/buildkit/buildkitd.toml
-
-      - name: Log in to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # A dispatch that supplies `tag` but runs from a branch would build a
-      # release-tagged image while the OIDC claims -- and therefore the Fulcio
-      # identity -- say `refs/heads/...`. The image would carry a release tag
-      # that no release verification command can match. Dispatch at the tag
-      # instead: `gh workflow run Publish --ref v1.2.3 -f tag=v1.2.3`.
-      - name: Compute image tag
+      - name: Compute
         id: tag
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          # Reject CR/LF before the value is echoed anywhere. A workflow command
-          # must start at the beginning of a line, so a dispatch input carrying
-          # a newline could forge one -- `::add-mask::`, or `::stop-commands::`
-          # to silence the rest of the log -- through any message that quotes
-          # it. Fixed message here: naming the value would be the very thing
-          # this rejects.
-          case "${INPUT_TAG}" in
-            *$'\n'*|*$'\r'*)
-              echo "::error::the dispatch tag input contains a newline or carriage return"
-              exit 1
-              ;;
-          esac
-
-          if [[ -n "${INPUT_TAG}" ]]; then
-            if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
-              echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the signature carries the release identity."
-              exit 1
-            fi
-            value="${INPUT_TAG}"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            value="${GITHUB_REF_NAME}"
-          else
-            value="main-${GITHUB_SHA::7}"
-          fi
-
-          # Git permits `"`, `$( )`, backticks and `|` in a tag name, and this
-          # value reaches a `run:` block on a runner holding packages:write.
-          # Constrain it at the single point it enters the workflow: a release
-          # tag, or the main-<sha> form this workflow generates itself.
-          if [[ ! "${value}" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|main-[0-9a-f]{7})$ ]]; then
-            echo "::error::refusing to publish under a tag that is neither vMAJOR.MINOR.PATCH[-prerelease] nor main-<sha>: ${value}"
+          set -euo pipefail
+          value="main-${GITHUB_SHA::7}"
+          # Derived here rather than taken from an input, so there is nothing to
+          # inject -- but the shape is still asserted, so a future edit to this
+          # line cannot silently widen what reaches the build.
+          if [[ ! "${value}" =~ ^main-[0-9a-f]{7}$ ]]; then
+            echo "::error::computed tag is malformed: ${value}"
             exit 1
           fi
           echo "value=${value}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
-        id: push
-        run: |
-          set -euo pipefail
-          make docker-buildx
-          # Capture the image digest for signing
-          DIGEST=$(docker buildx imagetools inspect \
-            "${IMAGE_NAME}:${IMAGE_TAG}" \
-            --format '{{.Manifest.Digest}}')
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-        env:
-          # GHCR paths must be lowercase and github.repository expands to
-          # uppercase 'NVIDIA/...', so the path is hardcoded. Keep in sync with
-          # the Makefile, helm values.yaml, and pkg/setup/setup.go.
-          IMG: ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.value }}
-          IMAGE_TAG: ${{ steps.tag.outputs.value }}
-
-      # An SBOM describes exactly one root filesystem, and this image is a
-      # multi-platform index. Attaching one SBOM to the index digest -- what this
-      # workflow used to do -- publishes one architecture's package list as if it
-      # described both, so an operator scanning the arm64 image reads amd64 data.
-      #
-      # Resolution uses `docker buildx imagetools`, which is already present for
-      # the push above. attest.yml re-resolves independently with crane before it
-      # signs, so the two paths do not share a tool or a failure mode.
-      - name: Resolve per-platform manifest digests
-        id: platforms
-        env:
-          REF: ${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
-          INDEX_DIGEST: ${{ steps.push.outputs.digest }}
-        run: |
-          set -euo pipefail
-          manifest="$(docker buildx imagetools inspect "${REF}" --raw)"
-          amd64_digest=""
-          arm64_digest=""
-
-          for arch in amd64 arm64; do
-            digest="$(jq -r --arg a "${arch}" '
-              [ .manifests[]?
-                | select(.platform.os == "linux" and .platform.architecture == $a)
-                | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
-                | .digest ] | first // empty' <<<"${manifest}")"
-
-            if [[ -z "${digest}" ]]; then
-              echo "::error::linux/${arch} is absent from the index; the release lost an architecture"
-              exit 1
-            fi
-            if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              echo "::error::linux/${arch} digest is malformed: ${digest}"
-              exit 1
-            fi
-            # Equal to the index means this reference is a plain manifest, not an
-            # index, so the "per-platform" SBOM would describe the wrong subject.
-            if [[ "${digest}" == "${INDEX_DIGEST}" ]]; then
-              echo "::error::linux/${arch} resolved to the index digest; ${REF} is not a multi-platform index"
-              exit 1
-            fi
-            echo "${arch}=${digest}" >> "$GITHUB_OUTPUT"
-            echo "linux/${arch} -> ${digest}"
-            case "${arch}" in
-              amd64) amd64_digest="${digest}" ;;
-              arm64) arm64_digest="${digest}" ;;
-            esac
-          done
-
-          # Identical digests mean the index carries one manifest advertised
-          # under both architectures, so one SBOM would be published twice under
-          # two names -- the same defect this job removes, in a new disguise.
-          if [[ "${amd64_digest}" == "${arm64_digest}" ]]; then
-            echo "::error::amd64 and arm64 resolved to the same digest; the image is not multi-platform"
-            exit 1
-          fi
-
-      # syft writes to the path it is given and will not create the directory.
-      - name: Create SBOM output directory
-        run: mkdir -p sboms
-
-      # SYFT_PLATFORM plus a per-platform digest is what makes these two
-      # documents actually differ. Format stays CycloneDX (ADR-074 decision 5);
-      # this changes the SBOM's subject, not its format.
-      - name: Generate linux/amd64 SBOM
-        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
-        env:
-          SYFT_PLATFORM: linux/amd64
-        with:
-          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64 }}
-          format: cyclonedx-json
-          output-file: sboms/sbom-linux-amd64.cyclonedx.json
-          upload-artifact: false
-          upload-release-assets: false
-
-      - name: Generate linux/arm64 SBOM
-        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
-        env:
-          SYFT_PLATFORM: linux/arm64
-        with:
-          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64 }}
-          format: cyclonedx-json
-          output-file: sboms/sbom-linux-arm64.cyclonedx.json
-          upload-artifact: false
-          upload-release-assets: false
-
-      # Each SBOM is generated against a per-platform MANIFEST digest, not the
-      # tag, so syft can only see that platform's root filesystem; the
-      # distinctness checks above already reject the case where both digests are
-      # the same. What is not covered upstream is a wiring mistake between these
-      # two near-identical steps -- the amd64 SBOM generated against the arm64
-      # digest, or one digest used twice -- so that is what this checks.
-      #
-      # Deliberately NOT a comparison of the two package sets. The image is a
-      # static Go binary on distroless: both platforms legitimately resolve the
-      # same Go module list, so requiring the sets to differ would fail correct
-      # releases. Comparing whole-document bytes is worse still -- a CycloneDX
-      # document carries a random serialNumber and a timestamp, so two documents
-      # are never byte-identical and such a check can never fire.
-      - name: Verify each SBOM describes its own platform
-        env:
-          AMD64: ${{ steps.platforms.outputs.amd64 }}
-          ARM64: ${{ steps.platforms.outputs.arm64 }}
-        run: |
-          set -euo pipefail
-          amd64_file=sboms/sbom-linux-amd64.cyclonedx.json
-          arm64_file=sboms/sbom-linux-arm64.cyclonedx.json
-
-          for f in "${amd64_file}" "${arm64_file}"; do
-            [[ -s "${f}" ]] || { echo "::error::${f} is missing or empty"; exit 1; }
-            jq -e . "${f}" >/dev/null || { echo "::error::${f} is not valid JSON"; exit 1; }
-          done
-
-          # A document referencing the other platform's digest was generated
-          # against the wrong subject. Where syft records no digest at all,
-          # neither branch fires and the check stays silent rather than failing
-          # on an assumption about syft's output shape.
-          if grep -q "${ARM64#sha256:}" "${amd64_file}"; then
-            echo "::error::the amd64 SBOM references the arm64 manifest digest; the two generation steps are wired to the wrong subjects"
-            exit 1
-          fi
-          if grep -q "${AMD64#sha256:}" "${arm64_file}"; then
-            echo "::error::the arm64 SBOM references the amd64 manifest digest; the two generation steps are wired to the wrong subjects"
-            exit 1
-          fi
-
-          for pair in "amd64:${amd64_file}" "arm64:${arm64_file}"; do
-            arch="${pair%%:*}"; file="${pair#*:}"
-            count="$(jq '[.components[]?] | length' "${file}")"
-            if [[ "${count}" -eq 0 ]]; then
-              echo "::error::the ${arch} SBOM lists no components; syft produced an empty inventory"
-              exit 1
-            fi
-            echo "${arch} components: ${count}"
-          done
-
-      - name: Upload SBOMs for attestation
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: image-sboms
-          path: sboms/
-          retention-days: 7
-          if-no-files-found: error
+  build:
+    name: Build image
+    needs: [tag]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image_tag: ${{ needs.tag.outputs.value }}
 
   # Provenance goes on the INDEX digest: it describes the build that produced
-  # the release image as a whole, which is what the index identifies.
+  # the image as a whole, which is what the index identifies.
   attest-index:
     name: Attest index (signature + provenance)
-    needs: [publish]
+    needs: [tag, build]
     permissions:
       contents: read
       packages: write
@@ -287,17 +72,17 @@ jobs:
     uses: ./.github/workflows/attest.yml
     with:
       subject_kind: image
-      subject_name: ${{ needs.publish.outputs.image_name }}
-      subject_tag: ${{ needs.publish.outputs.tag }}
-      expected_digest: ${{ needs.publish.outputs.index_digest }}
-      allow_untagged: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      subject_name: ${{ needs.build.outputs.image_name }}
+      subject_tag: ${{ needs.tag.outputs.value }}
+      expected_digest: ${{ needs.build.outputs.index_digest }}
+      allow_untagged: true
 
-  # SBOMs go on the PER-PLATFORM manifest digests, one each, and carry no
-  # provenance: the index already holds the provenance statement for this build,
-  # and a second one on a child manifest would be a competing claim.
+  # SBOMs go on the PER-PLATFORM manifest digests and carry no provenance: the
+  # index already holds the provenance statement for this build, and a second
+  # one on a child manifest would be a competing claim.
   attest-amd64-sbom:
     name: Attest linux/amd64 SBOM
-    needs: [publish]
+    needs: [tag, build]
     permissions:
       contents: read
       packages: write
@@ -305,19 +90,19 @@ jobs:
     uses: ./.github/workflows/attest.yml
     with:
       subject_kind: image
-      subject_name: ${{ needs.publish.outputs.image_name }}
-      subject_tag: ${{ needs.publish.outputs.tag }}
+      subject_name: ${{ needs.build.outputs.image_name }}
+      subject_tag: ${{ needs.tag.outputs.value }}
       platform: linux/amd64
-      expected_digest: ${{ needs.publish.outputs.amd64_digest }}
-      artifact_name: image-sboms
+      expected_digest: ${{ needs.build.outputs.amd64_digest }}
+      artifact_name: ${{ needs.build.outputs.sbom_artifact }}
       predicate_name: sbom-linux-amd64.cyclonedx.json
       predicate_type: cyclonedx
       emit_provenance: false
-      allow_untagged: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      allow_untagged: true
 
   attest-arm64-sbom:
     name: Attest linux/arm64 SBOM
-    needs: [publish]
+    needs: [tag, build]
     permissions:
       contents: read
       packages: write
@@ -325,22 +110,22 @@ jobs:
     uses: ./.github/workflows/attest.yml
     with:
       subject_kind: image
-      subject_name: ${{ needs.publish.outputs.image_name }}
-      subject_tag: ${{ needs.publish.outputs.tag }}
+      subject_name: ${{ needs.build.outputs.image_name }}
+      subject_tag: ${{ needs.tag.outputs.value }}
       platform: linux/arm64
-      expected_digest: ${{ needs.publish.outputs.arm64_digest }}
-      artifact_name: image-sboms
+      expected_digest: ${{ needs.build.outputs.arm64_digest }}
+      artifact_name: ${{ needs.build.outputs.sbom_artifact }}
       predicate_name: sbom-linux-arm64.cyclonedx.json
       predicate_type: cyclonedx
       emit_provenance: false
-      allow_untagged: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      allow_untagged: true
 
   # A job whose `if` is false is SKIPPED, and a skipped job does not fail its
-  # caller. Without this, a broken caller gate inside attest.yml would leave
-  # this workflow green while publishing an image that nothing had signed.
+  # caller. Without this, a broken caller gate inside attest.yml would leave this
+  # workflow green while publishing an image that nothing had signed.
   attested:
     name: Confirm the image was signed
-    needs: [publish, attest-index, attest-amd64-sbom, attest-arm64-sbom]
+    needs: [build, attest-index, attest-amd64-sbom, attest-arm64-sbom]
     if: always() && github.repository == 'NVIDIA/cluster-readiness-engine'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -348,21 +133,19 @@ jobs:
     steps:
       - name: Require every attestation job to have succeeded
         env:
-          PUBLISH: ${{ needs.publish.result }}
+          BUILD: ${{ needs.build.result }}
           INDEX: ${{ needs.attest-index.result }}
           AMD64: ${{ needs.attest-amd64-sbom.result }}
           ARM64: ${{ needs.attest-arm64-sbom.result }}
         run: |
           set -euo pipefail
-          echo "publish=${PUBLISH} index=${INDEX} amd64=${AMD64} arm64=${ARM64}"
+          echo "build=${BUILD} index=${INDEX} amd64=${AMD64} arm64=${ARM64}"
 
-          # When publish itself failed, the attest jobs are skipped as its
-          # dependents. Saying "published and unsigned" there would send someone
-          # hunting the registry for an image that was never pushed.
-          if [[ "${PUBLISH}" != "success" ]]; then
-            echo "::error::the build and push job did not succeed (${PUBLISH}); no image was published. Attestation was not attempted."
+          if [[ "${BUILD}" != "success" ]]; then
+            echo "::error::the build did not succeed (${BUILD}); no image was published. Attestation was not attempted."
             exit 1
           fi
+
           failed=0
           for pair in "index:${INDEX}" "amd64-sbom:${AMD64}" "arm64-sbom:${ARM64}"; do
             name="${pair%%:*}"; result="${pair#*:}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,17 @@ jobs:
   tag:
     name: Compute image tag
     runs-on: ubuntu-latest
-    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    # The ref guard is load-bearing, not hygiene. workflow_dispatch accepts a
+    # TAG as its ref, and this workflow always tags the image `main-<sha>`
+    # regardless. Dispatched from `refs/tags/v1.2.3`, the OIDC claims would be
+    # genuinely release-shaped, so attest.yml's tag check would pass on its own
+    # and Fulcio would mint `attest.yml@refs/tags/v1.2.3` -- the exact identity
+    # SECURITY.md tells users proves an official release -- for a dev image at a
+    # digest no release ever advertised. allow_untagged cannot prevent this: it
+    # only relaxes a check, it does not influence the certificate.
+    if: >-
+      github.repository == 'NVIDIA/cluster-readiness-engine'
+      && github.ref == 'refs/heads/main'
     timeout-minutes: 5
     permissions: {}
     outputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,15 @@ jobs:
   attested:
     name: Confirm the image was signed
     needs: [build, attest-index, attest-amd64-sbom, attest-arm64-sbom]
-    if: always() && github.repository == 'NVIDIA/cluster-readiness-engine'
+    # Carries the same ref guard as the jobs it watches. Without it a
+    # workflow_dispatch from a non-main ref skips everything upstream -- which is
+    # correct, that is what the guard is for -- and then this job still runs on
+    # `always()` and reports "no image was published", turning a deliberate
+    # no-op into a red run that looks like a broken release.
+    if: >-
+      always()
+      && github.repository == 'NVIDIA/cluster-readiness-engine'
+      && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
   # `cosign verify` before install.
   attest-chart:
     name: Attest Helm chart
-    needs: [helm-publish]
+    needs: [release-tag, helm-publish]
     permissions:
       contents: read
       packages: write
@@ -263,7 +263,7 @@ jobs:
     with:
       subject_kind: oci-artifact
       subject_name: ${{ needs.helm-publish.outputs.chart_name }}
-      subject_tag: ${{ needs.helm-publish.outputs.tag }}
+      subject_tag: ${{ needs.release-tag.outputs.value }}
       expected_digest: ${{ needs.helm-publish.outputs.chart_digest }}
 
   # A skipped job does not fail its caller, so without this a broken gate inside
@@ -597,10 +597,6 @@ jobs:
           [[ "${missing}" -eq 0 ]] || exit 1
           ls -la
 
-      # checksums.txt stays -- it is cheap and costs nothing -- but it now
-      # covers every published asset rather than only the binaries. It is not
-      # the verification story: it is served from the same origin as the
-      # artifacts and is itself unsigned, which is why the bundles exist.
       # The notes now state digests as fact. If any is missing or malformed the
       # release would advertise a broken or empty reference, so fail here rather
       # than publish one.
@@ -622,6 +618,10 @@ jobs:
             echo "${name} -> ${value}"
           done
 
+      # checksums.txt stays -- it is cheap -- but it now covers every published
+      # asset rather than only the binaries. It is not the verification story:
+      # it is served from the same origin as the artifacts and is itself
+      # unsigned, which is why the bundles exist.
       - name: Generate checksums
         run: |
           set -euo pipefail
@@ -723,7 +723,7 @@ jobs:
 
             `helm install --verify` does **not** check this signature. That flag looks for a PGP `.prov` file, a mechanism unrelated to Sigstore, and we publish no `.prov` files.
 
-            ### Controller image
+            ## Controller image
 
             A different artifact from the chart, verified separately. The release built and signed these exact digests:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,17 @@ jobs:
           [[ "${failed}" -eq 0 ]] || exit 1
           echo "release image fully attested"
 
+  # Waits for the image to exist AND be signed. The chart's values.yaml pins
+  # `manager:<tag>`, and `helm push` is not something the workflow can take
+  # back: publishing the chart first would put a chart referencing a tag that
+  # does not exist yet -- or, if the build then failed, never will -- into the
+  # OCI registry that Flux, Argo CD Image Updater and Renovate actually watch.
+  # A cluster reconciling in that window gets ImagePullBackOff and no GitHub
+  # Release to explain why. Gating create-github-release is not enough, because
+  # GitOps automation does not wait for the GitHub Release.
   helm-publish:
     name: Publish Helm Chart
-    needs: [release-tag]
+    needs: [release-tag, image-attested]
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,153 @@ permissions:
   contents: read
 
 jobs:
+  # The release builds the image itself rather than racing publish.yml for it.
+  # Previously both fired on a tag push: this workflow created a GitHub Release
+  # naming an image tag it had never resolved, could not confirm existed, and had
+  # no digest for -- so the notes asserted something the release had not checked,
+  # and #270's verification gate would have had nothing to verify against.
+  release-tag:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      value: ${{ steps.tag.outputs.value }}
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          case "${INPUT_TAG}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::the dispatch tag input contains a newline or carriage return"
+              exit 1
+              ;;
+          esac
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
+              echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so signatures carry the release identity."
+              exit 1
+            fi
+            value="${INPUT_TAG}"
+          else
+            value="${GITHUB_REF_NAME}"
+          fi
+          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
+            exit 1
+          fi
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
+
+  build-image:
+    name: Build release image
+    needs: [release-tag]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image_tag: ${{ needs.release-tag.outputs.value }}
+
+  attest-image-index:
+    name: Attest image index (signature + provenance)
+    needs: [release-tag, build-image]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/attest.yml
+    with:
+      subject_kind: image
+      subject_name: ${{ needs.build-image.outputs.image_name }}
+      subject_tag: ${{ needs.release-tag.outputs.value }}
+      expected_digest: ${{ needs.build-image.outputs.index_digest }}
+
+  attest-image-amd64-sbom:
+    name: Attest image linux/amd64 SBOM
+    needs: [release-tag, build-image]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/attest.yml
+    with:
+      subject_kind: image
+      subject_name: ${{ needs.build-image.outputs.image_name }}
+      subject_tag: ${{ needs.release-tag.outputs.value }}
+      platform: linux/amd64
+      expected_digest: ${{ needs.build-image.outputs.amd64_digest }}
+      artifact_name: ${{ needs.build-image.outputs.sbom_artifact }}
+      predicate_name: sbom-linux-amd64.cyclonedx.json
+      predicate_type: cyclonedx
+      emit_provenance: false
+
+  attest-image-arm64-sbom:
+    name: Attest image linux/arm64 SBOM
+    needs: [release-tag, build-image]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/attest.yml
+    with:
+      subject_kind: image
+      subject_name: ${{ needs.build-image.outputs.image_name }}
+      subject_tag: ${{ needs.release-tag.outputs.value }}
+      platform: linux/arm64
+      expected_digest: ${{ needs.build-image.outputs.arm64_digest }}
+      artifact_name: ${{ needs.build-image.outputs.sbom_artifact }}
+      predicate_name: sbom-linux-arm64.cyclonedx.json
+      predicate_type: cyclonedx
+      emit_provenance: false
+
+  image-attested:
+    name: Confirm the release image was signed
+    needs: [build-image, attest-image-index, attest-image-amd64-sbom, attest-image-arm64-sbom]
+    if: always() && github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require every image attestation to have succeeded
+        env:
+          BUILD: ${{ needs.build-image.result }}
+          INDEX: ${{ needs.attest-image-index.result }}
+          AMD64: ${{ needs.attest-image-amd64-sbom.result }}
+          ARM64: ${{ needs.attest-image-arm64-sbom.result }}
+        run: |
+          set -euo pipefail
+          echo "build=${BUILD} index=${INDEX} amd64=${AMD64} arm64=${ARM64}"
+          if [[ "${BUILD}" != "success" ]]; then
+            echo "::error::the release image build did not succeed (${BUILD}); no image was published."
+            exit 1
+          fi
+          failed=0
+          for pair in "index:${INDEX}" "amd64-sbom:${AMD64}" "arm64-sbom:${ARM64}"; do
+            name="${pair%%:*}"; result="${pair#*:}"
+            case "${result}" in
+              success) ;;
+              skipped)
+                echo "::error::${name} attestation was SKIPPED. The release image is published and unsigned; a skipped job does not fail its caller."
+                failed=1
+                ;;
+              *)
+                echo "::error::${name} attestation did not succeed (${result}). Treat the published image as unsigned."
+                failed=1
+                ;;
+            esac
+          done
+          [[ "${failed}" -eq 0 ]] || exit 1
+          echo "release image fully attested"
+
   helm-publish:
     name: Publish Helm Chart
+    needs: [release-tag]
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
     timeout-minutes: 15
@@ -31,8 +176,9 @@ jobs:
       contents: read
       packages: write
     outputs:
-      tag: ${{ steps.tag.outputs.value }}
-      chart_name: ${{ steps.tag.outputs.chart_name }}
+      # GHCR requires lowercase; `helm push <chart>.tgz oci://ghcr.io/nvidia`
+      # lands the chart at <registry>/<chart-name>.
+      chart_name: ghcr.io/nvidia/cluster-readiness-engine
       chart_digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,52 +199,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
         run: printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GHCR_USER}" --password-stdin
-
-      # A dispatch that names a tag but runs from a branch would publish a
-      # release-versioned chart whose signature carries a `refs/heads/...`
-      # identity -- a release nothing can verify as one. Dispatch at the tag:
-      # `gh workflow run Release --ref v1.2.3 -f tag=v1.2.3`.
-      - name: Resolve tag
-        id: tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-          # Reject CR/LF before the value is echoed anywhere. A workflow command
-          # must start at the beginning of a line, so a dispatch input carrying
-          # a newline could forge one -- `::add-mask::`, or `::stop-commands::`
-          # to silence the rest of the log -- through any message that quotes
-          # it. Fixed message here: naming the value would be the very thing
-          # this rejects.
-          case "${INPUT_TAG}" in
-            *$'\n'*|*$'\r'*)
-              echo "::error::the dispatch tag input contains a newline or carriage return"
-              exit 1
-              ;;
-          esac
-
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            if [[ "${GITHUB_REF}" != "refs/tags/${INPUT_TAG}" ]]; then
-              echo "::error::dispatched with tag=${INPUT_TAG} but running from ${GITHUB_REF}. Re-dispatch with --ref ${INPUT_TAG} so the chart signature carries the release identity."
-              exit 1
-            fi
-            value="${INPUT_TAG}"
-          else
-            value="${GITHUB_REF_NAME}"
-          fi
-          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
-          # unvalidated tag reaching a `run:` block is shell injection on a
-          # runner that holds packages:write. `check-clean-version` cannot help:
-          # it runs inside make, long after the shell has parsed the command.
-          # Validate here, at the single point the value enters the workflow.
-          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
-            exit 1
-          fi
-          echo "value=${value}" >> "$GITHUB_OUTPUT"
-          # GHCR requires lowercase; `helm push <chart>.tgz oci://ghcr.io/nvidia`
-          # lands the chart at <registry>/<chart-name>.
-          echo "chart_name=ghcr.io/nvidia/cluster-readiness-engine" >> "$GITHUB_OUTPUT"
 
       # VERSION is passed explicitly instead of trusting `git describe` on
       # the runner's checkout: a shallow or tag-less checkout makes
@@ -131,8 +231,8 @@ jobs:
           # Through the environment rather than `${{ }}` inside the script, so a
           # value is data and not code -- the rule attest.yml states and the tag
           # step above already follows.
-          CHART_NAME: ${{ steps.tag.outputs.chart_name }}
-          CHART_TAG: ${{ steps.tag.outputs.value }}
+          CHART_NAME: ghcr.io/nvidia/cluster-readiness-engine
+          CHART_TAG: ${{ needs.release-tag.outputs.value }}
 
   # The chart is the highest-leverage artifact in the release: it carries the
   # CRDs and the manager ClusterRole, so a tampered chart grants itself whatever
@@ -193,6 +293,7 @@ jobs:
 
   build-cli:
     name: Build CLI Binaries
+    needs: [release-tag]
     runs-on: linux-amd64-cpu16
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
     timeout-minutes: 15
@@ -210,39 +311,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Resolve tag
-        id: tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-
-          # Reject CR/LF before the value reaches any message. A workflow
-          # command must start at the beginning of a line, so a dispatch input
-          # carrying a newline could forge one through the validation error
-          # below, which quotes the value. Fixed message here on purpose.
-          case "${INPUT_TAG}" in
-            *$'\n'*|*$'\r'*)
-              echo "::error::the dispatch tag input contains a newline or carriage return"
-              exit 1
-              ;;
-          esac
-
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            value="${INPUT_TAG}"
-          else
-            value="${GITHUB_REF_NAME}"
-          fi
-          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
-          # unvalidated tag reaching a `run:` block is shell injection on a
-          # runner that holds packages:write. `check-clean-version` cannot help:
-          # it runs inside make, long after the shell has parsed the command.
-          # Validate here, at the single point the value enters the workflow.
-          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
-            exit 1
-          fi
-          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       # Stamp the binaries with the tag explicitly instead of trusting
       # `git describe` on the runner's checkout: a shallow or tag-less
@@ -279,7 +347,7 @@ jobs:
 
       - name: Cross-compile nvcrectl
         env:
-          TAG: ${{ steps.tag.outputs.value }}
+          TAG: ${{ needs.release-tag.outputs.value }}
         run: |
           set -euo pipefail
           make check-clean-version VERSION="${TAG}"
@@ -291,7 +359,7 @@ jobs:
       # here, before any artifact is published (issue #195).
       - name: Verify stamped version matches the tag
         env:
-          TAG: ${{ steps.tag.outputs.value }}
+          TAG: ${{ needs.release-tag.outputs.value }}
         run: |
           tag="${TAG}"
           got="$(./bin/nvcrectl-linux-amd64 --version | awk '{print $NF}')"
@@ -462,6 +530,9 @@ jobs:
     if: github.repository == 'NVIDIA/cluster-readiness-engine'
     timeout-minutes: 10
     needs:
+      - release-tag
+      - build-image
+      - image-attested
       - helm-publish
       - chart-attested
       - build-cli
@@ -479,39 +550,6 @@ jobs:
           name: release-assets
           path: dist/
 
-      - name: Resolve tag
-        id: tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-
-          # Reject CR/LF before the value reaches any message. A workflow
-          # command must start at the beginning of a line, so a dispatch input
-          # carrying a newline could forge one through the validation error
-          # below, which quotes the value. Fixed message here on purpose.
-          case "${INPUT_TAG}" in
-            *$'\n'*|*$'\r'*)
-              echo "::error::the dispatch tag input contains a newline or carriage return"
-              exit 1
-              ;;
-          esac
-
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            value="${INPUT_TAG}"
-          else
-            value="${GITHUB_REF_NAME}"
-          fi
-          # Git permits `"`, `$( )`, backticks and `|` in a tag name, so an
-          # unvalidated tag reaching a `run:` block is shell injection on a
-          # runner that holds packages:write. `check-clean-version` cannot help:
-          # it runs inside make, long after the shell has parsed the command.
-          # Validate here, at the single point the value enters the workflow.
-          if [[ ! "${value}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::refusing to release from a tag that is not vMAJOR.MINOR.PATCH[-prerelease]: ${value}"
-            exit 1
-          fi
-          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       # Every bundle the matrix produced, flattened next to the assets it
       # signs. Loose files, not an archive: a user should be able to curl one
@@ -555,6 +593,27 @@ jobs:
       # covers every published asset rather than only the binaries. It is not
       # the verification story: it is served from the same origin as the
       # artifacts and is itself unsigned, which is why the bundles exist.
+      # The notes now state digests as fact. If any is missing or malformed the
+      # release would advertise a broken or empty reference, so fail here rather
+      # than publish one.
+      - name: Require every advertised digest
+        env:
+          INDEX: ${{ needs.build-image.outputs.index_digest }}
+          AMD64: ${{ needs.build-image.outputs.amd64_digest }}
+          ARM64: ${{ needs.build-image.outputs.arm64_digest }}
+          CHART: ${{ needs.helm-publish.outputs.chart_digest }}
+        run: |
+          set -euo pipefail
+          for pair in "image index:${INDEX}" "image amd64:${AMD64}" \
+                      "image arm64:${ARM64}" "helm chart:${CHART}"; do
+            name="${pair%%:*}"; value="${pair#*:}"
+            if [[ ! "${value}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::the ${name} digest is missing or malformed: '${value}'"
+              exit 1
+            fi
+            echo "${name} -> ${value}"
+          done
+
       - name: Generate checksums
         run: |
           set -euo pipefail
@@ -589,19 +648,19 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ steps.tag.outputs.value }}
-          name: Release ${{ steps.tag.outputs.value }}
+          tag_name: ${{ needs.release-tag.outputs.value }}
+          name: Release ${{ needs.release-tag.outputs.value }}
           body: |
-            NVCRE ${{ steps.tag.outputs.value }}
+            NVCRE ${{ needs.release-tag.outputs.value }}
 
-            The NVIDIA Cluster Readiness Engine (NVCRE) is a Kubernetes controller that certifies GPU clusters before production use. It runs real training and communication workloads across topology-aware node groups, measures goodput and bandwidth, detects hardware failures, and reports every failed node with a reason. See the [README](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.value }}/README.md) for the full feature list.
+            The NVIDIA Cluster Readiness Engine (NVCRE) is a Kubernetes controller that certifies GPU clusters before production use. It runs real training and communication workloads across topology-aware node groups, measures goodput and bandwidth, detects hardware failures, and reports every failed node with a reason. See the [README](https://github.com/${{ github.repository }}/blob/${{ needs.release-tag.outputs.value }}/README.md) for the full feature list.
 
             ## Install nvcrectl
 
             The installer is signed. Download it with its bundle, verify, then run — piping it into a shell executes it before anything has checked it.
 
             ```bash
-            REL=https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}
+            REL=https://github.com/${{ github.repository }}/releases/download/${{ needs.release-tag.outputs.value }}
 
             curl -fsSLO "${REL}/installer"
             curl -fsSLO "${REL}/installer.sigstore.json"
@@ -609,18 +668,18 @@ jobs:
             cosign verify-blob-attestation \
               --bundle installer.sigstore.json \
               --type https://slsa.dev/provenance/v1 \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               installer
 
-            bash installer -v ${{ steps.tag.outputs.value }}
+            bash installer -v ${{ needs.release-tag.outputs.value }}
             ```
 
             <details>
             <summary>Without cosign</summary>
 
             ```bash
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}/installer | bash -s -- -v ${{ steps.tag.outputs.value }}
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.release-tag.outputs.value }}/installer | bash -s -- -v ${{ needs.release-tag.outputs.value }}
             ```
 
             This runs the installer before anything verifies it. TLS proves you reached GitHub; it proves nothing about the asset if the release itself was tampered with. Use it only where installing cosign first is genuinely impractical.
@@ -642,7 +701,7 @@ jobs:
 
             # 1. Verify the chart. Requires cosign; the package is public, so no login is needed.
             cosign verify \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${CHART}@${DIGEST}"
 
@@ -652,11 +711,31 @@ jobs:
               --namespace nvcre --create-namespace
             ```
 
-            Installing with `--version ${{ steps.tag.outputs.value }}` instead resolves the tag at install time, which is not provably the digest you verified.
+            Installing with `--version ${{ needs.release-tag.outputs.value }}` instead resolves the tag at install time, which is not provably the digest you verified.
 
             `helm install --verify` does **not** check this signature. That flag looks for a PGP `.prov` file, a mechanism unrelated to Sigstore, and we publish no `.prov` files.
 
-            The controller image for this release is `ghcr.io/nvidia/cluster-readiness-engine/manager:${{ steps.tag.outputs.value }}` — a different artifact from the chart, verified separately.
+            ### Controller image
+
+            A different artifact from the chart, verified separately. The release built and signed these exact digests:
+
+            | Subject | Digest |
+            |---|---|
+            | index (multi-platform) | `${{ needs.build-image.outputs.index_digest }}` |
+            | `linux/amd64` | `${{ needs.build-image.outputs.amd64_digest }}` |
+            | `linux/arm64` | `${{ needs.build-image.outputs.arm64_digest }}` |
+
+            The index carries the signature and the SLSA provenance; each platform digest carries a signature and its own CycloneDX SBOM. Pin the index digest rather than the tag:
+
+            ```bash
+            IMAGE=${{ needs.build-image.outputs.image_name }}
+            INDEX=${{ needs.build-image.outputs.index_digest }}
+
+            cosign verify \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${IMAGE}@${INDEX}"
+            ```
 
             ## nvcrectl CLI
 
@@ -674,7 +753,7 @@ jobs:
             Every asset ships with a Sigstore bundle, `<asset>.sigstore.json`, carrying a SLSA Build Provenance v1 statement. Verify the artifact itself, not a checksum served from the same place as the artifact:
 
             ```bash
-            REL=https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.value }}
+            REL=https://github.com/${{ github.repository }}/releases/download/${{ needs.release-tag.outputs.value }}
             ASSET=nvcrectl-linux-amd64   # or installer, or any published asset
 
             # The bundle is a separate asset; fetch both.
@@ -684,7 +763,7 @@ jobs:
             cosign verify-blob-attestation \
               --bundle "${ASSET}.sigstore.json" \
               --type https://slsa.dev/provenance/v1 \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${ASSET}"
             ```
@@ -702,7 +781,7 @@ jobs:
             cosign verify-blob-attestation \
               --bundle "${ASSET}.cyclonedx.sigstore.json" \
               --type cyclonedx \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${ASSET}"
 
@@ -710,7 +789,7 @@ jobs:
             cosign verify-blob-attestation \
               --bundle "${ASSET}.cyclonedx.json.sigstore.json" \
               --type https://slsa.dev/provenance/v1 \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ steps.tag.outputs.value }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.release-tag.outputs.value }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${ASSET}.cyclonedx.json"
             ```
@@ -725,7 +804,7 @@ jobs:
 
             ## Third-Party Notices
 
-            Third-party Go module licenses are listed in [`THIRD_PARTY_NOTICES.md`](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.value }}/THIRD_PARTY_NOTICES.md) and attached as a release asset.
+            Third-party Go module licenses are listed in [`THIRD_PARTY_NOTICES.md`](https://github.com/${{ github.repository }}/blob/${{ needs.release-tag.outputs.value }}/THIRD_PARTY_NOTICES.md) and attached as a release asset.
 
             ## Support
 
@@ -740,7 +819,7 @@ jobs:
             dist/THIRD_PARTY_NOTICES.md.sigstore.json
             dist/checksums.txt
           draft: false
-          prerelease: ${{ contains(steps.tag.outputs.value, '-') }}
+          prerelease: ${{ contains(needs.release-tag.outputs.value, '-') }}
           generate_release_notes: true
 
       # Post-publish gate (issues #194, #195): download the just-published
@@ -755,7 +834,7 @@ jobs:
       - name: Verify published release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.value }}
+          TAG: ${{ needs.release-tag.outputs.value }}
         run: |
           tag="${TAG}"
           rm -rf verify-release && mkdir verify-release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,16 +73,34 @@ in the `releases/download/<tag>/installer` URL and pass `-v <tag>` to the instal
 
 ## What a release publishes
 
-Pushing a `v*` tag runs three jobs in `.github/workflows/release.yml`:
+Pushing a `v*` tag runs `.github/workflows/release.yml`, which owns every release artifact:
 
 | Job | Publishes |
 |---|---|
+| Build release image | `ghcr.io/nvidia/cluster-readiness-engine/manager:<tag>`, multi-platform |
+| Attest image (index, amd64 SBOM, arm64 SBOM) | signature, SLSA provenance, per-platform CycloneDX SBOMs |
 | Publish Helm Chart | `oci://ghcr.io/nvidia/cluster-readiness-engine` |
+| Attest Helm chart | signature and provenance on the chart digest |
 | Build CLI Binaries | cross-compiled `nvcrectl` for linux and macOS, amd64 and arm64 |
+| Attest binaries | a Sigstore bundle per binary, per SBOM, and for the installer |
 | Create GitHub Release | the GitHub Release, its notes, and the assets below |
 
-The container image is published separately by `.github/workflows/publish.yml` as
-`ghcr.io/nvidia/cluster-readiness-engine/manager:<tag>`.
+The release builds the container image itself. `.github/workflows/publish.yml` no longer
+runs on tags — it now builds only `main-<sha>` development images, and is pinned to
+`refs/heads/main` so it cannot be dispatched against a release tag. Previously both
+workflows fired on a tag push and raced, and the release notes named an image the release
+had never resolved.
+
+Each artifact is published only after the one it depends on is signed: the chart is not
+pushed until the image it references exists and is attested, and the GitHub Release is not
+created until all three families are attested.
+
+**Re-running part of a release.** There is no longer a workflow that rebuilds only the
+image for an existing tag. Re-run the whole release with
+`gh workflow run Release --ref vX.Y.Z -f tag=vX.Y.Z` — dispatching at the tag is required,
+because signatures take their identity from the ref the run was dispatched from. That
+re-executes the chart, binary and release steps as well, which is a wider blast radius
+than the old image-only rebuild.
 
 Release assets:
 

--- a/test/releasepolicy/workflow_graph_test.go
+++ b/test/releasepolicy/workflow_graph_test.go
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+const workflowDir = "../../.github/workflows"
+
+// job is the subset of a workflow job these tests reason about.
+type job struct {
+	Needs   stringOrSlice     `json:"needs"`
+	Uses    string            `json:"uses"`
+	Outputs map[string]string `json:"outputs"`
+	// Raw carries every remaining key, including `with:` on a reusable-workflow
+	// call. Without it, marshalling a job back to YAML to scan for references
+	// silently drops the very block those references live in -- which is how the
+	// first version of this test passed against a defect it was written to catch.
+	Raw map[string]any `json:"-"`
+}
+
+// wf is the subset of a workflow file these tests reason about. `on` is not
+// modelled: YAML parses a bare `on:` key as the boolean true, and nothing here
+// needs the trigger block.
+type wf struct {
+	Jobs map[string]job `json:"jobs"`
+	// CallOutputs are the outputs a reusable workflow declares in its own
+	// `workflow_call` block. Populated by hand rather than by a struct tag: YAML
+	// 1.1 reads a bare `on:` key as the boolean true, so `json:"on"` never
+	// matches and the block silently reads as empty.
+	CallOutputs map[string]any
+}
+
+// stringOrSlice accepts both `needs: build` and `needs: [a, b]`.
+type stringOrSlice []string
+
+func (s *stringOrSlice) UnmarshalJSON(b []byte) error {
+	var one string
+	if err := yaml.Unmarshal(b, &one); err == nil {
+		*s = []string{one}
+		return nil
+	}
+	var many []string
+	if err := yaml.Unmarshal(b, &many); err != nil {
+		return err
+	}
+	*s = many
+	return nil
+}
+
+var needsRef = regexp.MustCompile(`needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)`)
+
+func loadWorkflows(t *testing.T) map[string]wf {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil {
+		t.Fatalf("glob workflows: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no workflows found under %s", workflowDir)
+	}
+
+	out := map[string]wf{}
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var w wf
+		if err := yaml.Unmarshal(raw, &w); err != nil {
+			t.Fatalf("parse %s: %v", p, err)
+		}
+
+		// Re-parse untyped so every job key is available for the reference scan.
+		var generic struct {
+			Jobs map[string]map[string]any `json:"jobs"`
+		}
+		if err := yaml.Unmarshal(raw, &generic); err != nil {
+			t.Fatalf("parse %s untyped: %v", p, err)
+		}
+		for jobName, body := range generic.Jobs {
+			j := w.Jobs[jobName]
+			j.Raw = body
+			w.Jobs[jobName] = j
+		}
+
+		w.CallOutputs = workflowCallOutputs(raw, t)
+		out[filepath.Base(p)] = w
+	}
+	return out
+}
+
+// TestJobOutputReferencesResolve is the check that a real defect got past.
+//
+// A `needs.<job>.outputs.<field>` reference is not validated by actionlint or by
+// YAML parsing. When the release workflow's tag resolution was consolidated into
+// a single job, a downstream `subject_tag: ${{ needs.helm-publish.outputs.tag }}`
+// was left pointing at an output that no longer existed. It expands to the empty
+// string, which meant the chart signing job would have failed on every release —
+// after the image and chart were already public.
+//
+// Checking that the producing job is listed in `needs:` is not enough; the
+// specific field has to still exist.
+func TestJobOutputReferencesResolve(t *testing.T) {
+	workflows := loadWorkflows(t)
+
+	for name, w := range workflows {
+		for jobName, j := range w.Jobs {
+			body, err := yaml.Marshal(j.Raw)
+			if err != nil {
+				t.Fatalf("%s: re-marshal job %s: %v", name, jobName, err)
+			}
+
+			for _, m := range needsRef.FindAllStringSubmatch(string(body), -1) {
+				producer, field := m[1], m[2]
+
+				if !slices.Contains(j.Needs, producer) {
+					t.Errorf("%s: job %q reads needs.%s.outputs.%s but does not declare %q in needs",
+						name, jobName, producer, field, producer)
+					continue
+				}
+
+				pj, ok := w.Jobs[producer]
+				if !ok {
+					t.Errorf("%s: job %q depends on %q, which does not exist", name, jobName, producer)
+					continue
+				}
+
+				declared := pj.Outputs
+				// A job that calls a reusable workflow declares its outputs in
+				// the called file, not here.
+				if pj.Uses != "" {
+					called, ok := workflows[filepath.Base(pj.Uses)]
+					if !ok {
+						// Not a local workflow; nothing to resolve against.
+						continue
+					}
+					declared = map[string]string{}
+					for k := range called.CallOutputs {
+						declared[k] = ""
+					}
+				}
+
+				if _, ok := declared[field]; !ok {
+					t.Errorf("%s: job %q reads needs.%s.outputs.%s, which %q does not declare (declares: %v)",
+						name, jobName, producer, field, producer, sortedKeys(declared))
+				}
+			}
+		}
+	}
+}
+
+// TestNoExpressionInterpolationInRunBlocks keeps the release path free of
+// `${{ }}` inside shell bodies. A git tag may contain `"`, `$( )`, backticks and
+// `|`, so an interpolated value is executed rather than read. Values must cross
+// into a shell through `env:`.
+func TestNoExpressionInterpolationInRunBlocks(t *testing.T) {
+	releasePath := map[string]bool{
+		"release.yml":     true,
+		"publish.yml":     true,
+		"attest.yml":      true,
+		"build-image.yml": true,
+	}
+
+	paths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil {
+		t.Fatalf("glob workflows: %v", err)
+	}
+
+	var steps struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `json:"name"`
+				Run  string `json:"run"`
+			} `json:"steps"`
+		} `json:"jobs"`
+	}
+
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if !releasePath[base] {
+			continue
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		steps.Jobs = nil
+		if err := yaml.Unmarshal(raw, &steps); err != nil {
+			t.Fatalf("parse %s: %v", p, err)
+		}
+		for jobName, j := range steps.Jobs {
+			for _, s := range j.Steps {
+				if strings.Contains(s.Run, "${{") {
+					t.Errorf("%s: job %q step %q interpolates ${{ }} inside a run block; "+
+						"pass the value through env: instead so it is data, not code",
+						base, jobName, s.Name)
+				}
+			}
+		}
+	}
+}
+
+// workflowCallOutputs reads on.workflow_call.outputs, tolerating YAML 1.1
+// turning the bare `on:` key into the boolean true.
+func workflowCallOutputs(raw []byte, t *testing.T) map[string]any {
+	t.Helper()
+
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse workflow triggers: %v", err)
+	}
+	for _, key := range []string{"on", "true"} {
+		trig, ok := doc[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		call, ok := trig["workflow_call"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if outs, ok := call["outputs"].(map[string]any); ok {
+			return outs
+		}
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary

`publish.yml` and `release.yml` both fired on a tag push and raced. `release.yml` created a GitHub Release asserting the controller image was `manager:<tag>` — a claim it never checked. It had no digest, could not confirm the image existed, and could not have verified a signature even in principle. #270's verification gate would have had nothing to verify against.

Resolved as the epic's **open question 2, option (a)**: the image build moves into a reusable `build-image.yml`. `release.yml` calls it on a tag and receives the index and both platform digests directly as job outputs. `publish.yml` now triggers on `main` only and owns `main-<sha>` dev images. **The race is removed, not mitigated.**

The release notes now state the digests the release actually built and signed — index, both platforms, and the chart — with a `cosign verify` command that pins the index rather than the tag. A gate immediately before publication rejects any digest that is missing or malformed.

### Publication ordering

Each artifact is published only after the one it depends on is signed:

```
release-tag → build-image → attest ×3 → image-attested
                                          ├→ helm-publish → attest-chart → chart-attested
build-cli → attest-binaries → binaries-attested
                                          └→ create-github-release
```

The chart is not pushed until the image it references exists and is attested. That ordering matters because the chart's `values.yaml` pins `manager:<tag>`, and GitOps automation watches the OCI registry rather than the GitHub Release.

## Related Issue

Part of #269 — deliberately **not** `Closes`. `release.yml` runs only on a tag, so none of this has executed.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation / CI

## Testing

Two new tests in `test/releasepolicy`, both mutation-tested against reintroduced defects:

- **`TestJobOutputReferencesResolve`** — every `needs.<job>.outputs.<field>` reference must resolve to a field the producing job actually declares, resolving through reusable-workflow calls.
- **`TestNoExpressionInterpolationInRunBlocks`** — no `${{ }}` inside any `run:` block in the release path.

Also verified: `actionlint` clean, `make verify`, `make lint` (0 issues), full `go test`. The digest gate was executed directly (all-present accepted, missing index rejected, malformed chart digest rejected).

### Self-review findings

Five persona screens. **Three independently found the same BLOCKER**, and it is the one worth reading:

`attest-chart` still read `needs.helm-publish.outputs.tag`. That output was dropped when tag resolution was consolidated into `release-tag`, and **an undefined output expands to the empty string rather than erroring**. `attest.yml` rejects an empty `subject_tag` for an `oci-artifact` subject, so chart signing would have failed on **every release** — after the image and chart were already public — and `create-github-release` would never have run. No release could ever have been published.

That was fallout from my own consolidation, and my verification missed it: I checked that every referenced job was declared in `needs:`, not that the field being read still existed. Hence the first new test.

**Writing that test paid for itself twice before it worked.** Version one passed against the very defect it was written for, because a reusable-workflow call keeps its references in `with:` and the struct I marshalled didn't model that field. Version two was still wrong, because YAML reads a bare `on:` key as the boolean `true`, so reusable-workflow outputs resolved as empty. Only mutation testing surfaced either.

The rest:

- **`publish.yml` could be dispatched against a release tag** (MAJOR). It always tags the image `main-<sha>`, but `github.ref` would genuinely be `refs/tags/v*`, so Fulcio would mint `attest.yml@refs/tags/vX.Y.Z` — the identity `SECURITY.md` tells users proves an official release — for a dev image at a digest no release advertised. `allow_untagged` cannot prevent that: it relaxes a check, it does not shape the certificate. Job pinned to `refs/heads/main`.
- **The chart could be published before the image existed** (MAJOR). `helm-publish` was a sibling of `build-image` with no edge between them, and does a `helm push` in a 15-minute budget against a 40-minute image build. A Flux `OCIRepository`, Argo CD Image Updater or Renovate could reconcile a chart pinning a tag that didn't exist yet — or never would, if the build failed. `helm push` cannot be taken back. Now gated on `image-attested`.
- **`build-image.yml` emitted `image_name` from `${{ env.* }}` in a job-level `outputs:` block** — an empty value there would have flowed into every attest call as the subject. Moved to a step output; swept the other workflows for the same pattern.
- **The controller-image section was an H3 under "Helm Chart"** — a separately signed artifact reading as a detail of the chart. Promoted.
- **Two comments described steps inserted above them**; each now sits above the step it describes.
- **`RELEASE.md` said three release jobs and that the image is published separately by `publish.yml`.** Both now false. It documents the new ownership, the publication ordering, and that the image-only rebuild path is gone.

## What is not proven

`release.yml` runs only on a release tag, so this has not executed. **#269 stays open** until it has.

Per the agreed plan, an `-rc` tag right after this merges would exercise the whole path and settle the deferred criteria on **#267, #268 and #269** in one run.

- [x] Tests pass locally
- [x] Manual testing completed — see above
- [x] No breaking changes — but note the removed image-only rebuild path, documented in `RELEASE.md`

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated (if needed) — `RELEASE.md`, release notes template
- [x] Ready for review
