### PR TITLE
ci: verify every published artifact before the release becomes visible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -665,13 +665,35 @@ jobs:
           TAG: ${{ needs.release-tag.outputs.value }}
         run: |
           set -euo pipefail
-          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            --json isDraft --jq .isDraft 2>/dev/null || echo absent)"
+
+          # Only a confirmed "not found" means no release exists. An API,
+          # auth or permission failure must not read as absent: that would let
+          # an already-published release take the upload, which is the one
+          # outcome this guard exists to stop. Everything else fails closed.
+          state=""
+          for attempt in 1 2 3; do
+            if out="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+                 --json isDraft --jq .isDraft 2>&1)"; then
+              state="${out}"
+              break
+            fi
+            if grep -qiE "release not found|could not find|HTTP 404" <<<"${out}"; then
+              state="absent"
+              break
+            fi
+            echo "attempt ${attempt}: could not read release state: ${out}"
+            sleep $((attempt * 5))
+          done
+
           case "${state}" in
             absent) echo "no release exists for ${TAG} yet" ;;
             true)   echo "release ${TAG} exists and is a draft" ;;
-            *)
+            false)
               echo "::error::release ${TAG} is already published; refusing to upload assets the gate has not verified. Cut the next patch version instead (see RELEASE.md)."
+              exit 1
+              ;;
+            *)
+              echo "::error::could not determine the release state for ${TAG} after 3 attempts; refusing to upload rather than assume no release exists."
               exit 1
               ;;
           esac
@@ -1217,9 +1239,35 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft || echo unknown)"
-          if [[ "${state}" == "false" ]]; then
-            gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=true
-            echo "::error::verification failed after publication; release ${TAG} has been returned to draft"
+          set -uo pipefail
+
+          # An unreadable state must not read as "nothing to do". Leaving a
+          # release public after its verification failed is the worst available
+          # outcome, so an unknown state is treated as published and the
+          # retraction is attempted anyway. `gh release edit --draft=true` is
+          # idempotent, so doing it to an already-draft release costs nothing.
+          state="unknown"
+          for attempt in 1 2 3; do
+            if out="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+                 --json isDraft --jq .isDraft 2>&1)"; then
+              state="${out}"
+              break
+            fi
+            echo "attempt ${attempt}: could not read release state: ${out}"
+            sleep $((attempt * 5))
+          done
+
+          if [[ "${state}" == "true" ]]; then
+            echo "release ${TAG} is already a draft; nothing to retract"
+            exit 0
           fi
+
+          for attempt in 1 2 3; do
+            if gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=true; then
+              echo "::error::verification failed after publication; release ${TAG} has been returned to draft"
+              exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+          echo "::error::verification failed AND release ${TAG} could not be returned to draft. It may still be public. Retract it manually before doing anything else."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -949,11 +949,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # Every network call in this job is retried. `gh` retries release
+          # asset *uploads* and its attestation calls, but not `release
+          # download`, `release view/edit` or `api`, so a single 502 would fail
+          # the gate on a release that is fine. Defined per step because each
+          # `run:` block is its own shell.
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
           mkdir -p verify && cd verify
           # Drafts are not reachable unauthenticated, so the gate downloads over
           # the authenticated channel. The public channel is re-checked after
           # the release is made visible.
-          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir . --clobber
+          retry gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir . --clobber
           ls -la
 
       # The expected set below is static and reviewed on change. Deriving it
@@ -999,7 +1014,7 @@ jobs:
                  "${a}" >>"../verify.log" 2>&1; then
               echo "ok   ${a}"
             else
-              echo "::error::${a} does not verify against ${IDENTITY}"; failed=1
+              echo "::error::${a} does not verify against ${IDENTITY} after 3 attempts"; failed=1
             fi
           done
 
@@ -1018,7 +1033,7 @@ jobs:
                  "${b}" >>"../verify.log" 2>&1; then
               echo "ok   ${b} <- its SBOM"
             else
-              echo "::error::${b}'s SBOM binding does not verify"; failed=1
+              echo "::error::${b}'s SBOM binding does not verify after 3 attempts"; failed=1
             fi
           done
 
@@ -1063,7 +1078,7 @@ jobs:
                  --certificate-oidc-issuer "${OIDC_ISSUER}" >>verify.log 2>&1; then
               echo "ok   ${what}"
             else
-              echo "::error::${what} does not verify"
+              echo "::error::${what} does not verify after 3 attempts"
               failed=1
             fi
           }
@@ -1109,7 +1124,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          payloads="$(cosign verify-attestation --type slsaprovenance1 \
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
+          payloads="$(retry cosign verify-attestation --type slsaprovenance1 \
             --certificate-identity "${IDENTITY}" \
             --certificate-oidc-issuer "${OIDC_ISSUER}" \
             "${IMAGE}@${INDEX}" 2>>verify.log | jq -r .payload)" || true
@@ -1152,20 +1176,30 @@ jobs:
         run: |
           set -euo pipefail
           failed=0
-          if cosign verify --certificate-identity "${IDENTITY}" \
+
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
+          if retry cosign verify --certificate-identity "${IDENTITY}" \
                --certificate-oidc-issuer "${OIDC_ISSUER}" \
                "${CHART_NAME}@${CHART_DIGEST}" >>verify.log 2>&1; then
             echo "ok   chart signature"
           else
-            echo "::error::chart signature does not verify"; failed=1
+            echo "::error::chart signature does not verify after 3 attempts"; failed=1
           fi
-          if cosign verify-attestation --type slsaprovenance1 \
+          if retry cosign verify-attestation --type slsaprovenance1 \
                --certificate-identity "${IDENTITY}" \
                --certificate-oidc-issuer "${OIDC_ISSUER}" \
                "${CHART_NAME}@${CHART_DIGEST}" >>verify.log 2>&1; then
             echo "ok   chart provenance"
           else
-            echo "::error::chart provenance does not verify"; failed=1
+            echo "::error::chart provenance does not verify after 3 attempts"; failed=1
           fi
           [[ "${failed}" -eq 0 ]] || exit 1
 
@@ -1184,7 +1218,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
+          retry gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           echo "release ${TAG} verified and published"
 
       # The channel a user actually takes. Everything above ran authenticated
@@ -1196,7 +1240,21 @@ jobs:
           IDENTITY: ${{ steps.identity.outputs.value }}
         run: |
           set -euo pipefail
-          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
+
+          # This step runs after the release is public, so every failure here
+          # retracts it. A transient one must not: a release that passed every
+          # signature, SBOM, digest and provenance check would be pulled back to
+          # draft with an error that reads like tampering.
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
+          visibility="$(retry gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
           if [[ "${visibility}" != "public" ]]; then
             echo "NOTICE: repository is ${visibility}; skipping the anonymous re-check."
             exit 0
@@ -1208,7 +1266,7 @@ jobs:
           done
           [[ "$(head -c 2 installer)" == '#!' ]] || { echo "::error::installer is not a shell script"; exit 1; }
           bash -n installer
-          cosign verify-blob-attestation \
+          retry cosign verify-blob-attestation \
             --bundle installer.sigstore.json \
             --type https://slsa.dev/provenance/v1 \
             --certificate-identity "${IDENTITY}" \
@@ -1219,7 +1277,7 @@ jobs:
           # the point of downloading it. Checking only the installer would let
           # the step report the channel good while the asset most users take
           # was never checked on it.
-          cosign verify-blob-attestation \
+          retry cosign verify-blob-attestation \
             --bundle nvcrectl-linux-amd64.sigstore.json \
             --type https://slsa.dev/provenance/v1 \
             --certificate-identity "${IDENTITY}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -653,6 +653,29 @@ jobs:
             --max-filesize=512M --max-scansize=2048M \
             /scan
 
+      # action-gh-release honours `draft:` only when it CREATES the release. For
+      # a tag that already has one it passes `draft: existingRelease.draft` and
+      # ignores the input, so re-running against an already-published tag would
+      # upload freshly built, unverified assets straight into a live release --
+      # where they are public immediately and the gate has nothing left to
+      # withhold. This must therefore run BEFORE the upload, not after it.
+      - name: Require any existing release to be a draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-tag.outputs.value }}
+        run: |
+          set -euo pipefail
+          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --json isDraft --jq .isDraft 2>/dev/null || echo absent)"
+          case "${state}" in
+            absent) echo "no release exists for ${TAG} yet" ;;
+            true)   echo "release ${TAG} exists and is a draft" ;;
+            *)
+              echo "::error::release ${TAG} is already published; refusing to upload assets the gate has not verified. Cut the next patch version instead (see RELEASE.md)."
+              exit 1
+              ;;
+          esac
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -841,20 +864,18 @@ jobs:
   # wrong permissions, an expired OIDC token, a renamed cosign flag -- and the
   # release would still have gone out green.
   #
-      # `draft: true` above is honoured only when the action CREATES the
-      # release. For a tag that already has one, action-gh-release passes
-      # `draft: existingRelease.draft` and ignores the input, so a re-run
-      # against an already-published tag uploads freshly built, unverified
-      # assets straight into a live release and the gate below has nothing
-      # left to withhold. Fail before that is observable rather than after.
-      - name: Require the release to be a draft
+      # The pre-upload guard proves no published release existed; this proves
+      # the action actually created a draft, which is a separate claim and the
+      # one the gate's control depends on.
+      - name: Confirm the release is a draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-tag.outputs.value }}
         run: |
           set -euo pipefail
           state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
           if [[ "${state}" != "true" ]]; then
-            echo "::error::release ${TAG} is already published; refusing to publish assets that the gate has not verified. Cut the next patch version instead (see RELEASE.md)."
+            echo "::error::release ${TAG} is not a draft after creation; the gate cannot withhold it"
             exit 1
           fi
           echo "release ${TAG} is a draft; the gate controls when it becomes visible"
@@ -999,6 +1020,17 @@ jobs:
         run: |
           set -euo pipefail
           failed=0
+
+          # Defined per step: each `run:` block is its own shell, so a helper
+          # defined in an earlier step is not in scope here.
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
 
           # if/else rather than `cmd && echo ok || err`: in that form the error
           # branch also runs when the echo fails, which in a gate is a false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1165,21 +1165,6 @@ jobs:
           gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           echo "release ${TAG} verified and published"
 
-      # Publication is not the last step, so a failure after it would leave the
-      # release visible with the run red -- the exact state the draft exists to
-      # prevent. Retract it instead.
-      - name: Retract the release if anything after publication failed
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft || echo unknown)"
-          if [[ "${state}" == "false" ]]; then
-            gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=true
-            echo "::error::verification failed after publication; release ${TAG} has been returned to draft"
-          fi
-
       # The channel a user actually takes. Everything above ran authenticated
       # because a draft is not reachable otherwise; this confirms the assets are
       # served, and correctly, over the anonymous path.
@@ -1220,3 +1205,21 @@ jobs:
             nvcrectl-linux-amd64
 
           echo "public channel serves verifiable installer and binary"
+
+      # Last step in the job, deliberately. Steps run in declaration order, so
+      # an `if: failure()` step only catches failures from steps ABOVE it -- one
+      # placed before the public re-check would already have been evaluated and
+      # skipped by the time that check failed, and would never retract anything.
+      # Anything that fails after publication must leave the release withheld
+      # rather than visible with the run red.
+      - name: Retract the release if anything after publication failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft || echo unknown)"
+          if [[ "${state}" == "false" ]]; then
+            gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=true
+            echo "::error::verification failed after publication; release ${TAG} has been returned to draft"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -826,48 +826,365 @@ jobs:
             dist/THIRD_PARTY_NOTICES.md
             dist/THIRD_PARTY_NOTICES.md.sigstore.json
             dist/checksums.txt
-          draft: false
+          # Created as a draft. The gate below verifies every published
+          # artifact and only then flips it public, so a release whose signing
+          # silently no-opped never becomes visible. Registry artifacts (image,
+          # chart) are necessarily already pushed by this point; the gate
+          # verifies those too and fails the run if they do not hold.
+          draft: true
           prerelease: ${{ contains(needs.release-tag.outputs.value, '-') }}
           generate_release_notes: true
 
-      # Post-publish gate (issues #194, #195): download the just-published
-      # assets over the same channel users take and verify them. On a public
-      # repository that is the unauthenticated browser URL
-      # (releases/download/<tag>/<asset>); v0.1.0-rc.7 users piped the 404
-      # "Not Found" page that URL serves on non-public repositories into
-      # bash (issue #194), and only an unauthenticated download can catch
-      # that. While the repository is not public the gate falls back to the
-      # authenticated channel so a release cut before a visibility flip
-      # still verifies instead of failing on the 404.
-      - name: Verify published release assets
+  # Verifies everything the release advertises, then makes it public. Producing
+  # attestations without checking them means the first party to discover they
+  # are broken is a user: every signing step in this pipeline could no-op --
+  # wrong permissions, an expired OIDC token, a renamed cosign flag -- and the
+  # release would still have gone out green.
+  #
+      # `draft: true` above is honoured only when the action CREATES the
+      # release. For a tag that already has one, action-gh-release passes
+      # `draft: existingRelease.draft` and ignores the input, so a re-run
+      # against an already-published tag uploads freshly built, unverified
+      # assets straight into a live release and the gate below has nothing
+      # left to withhold. Fail before that is observable rather than after.
+      - name: Require the release to be a draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.release-tag.outputs.value }}
         run: |
-          tag="${TAG}"
-          rm -rf verify-release && mkdir verify-release
-          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
-          echo "repository visibility: ${visibility}"
-          if [[ "${visibility}" == "public" ]]; then
-            base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
-            for asset in installer checksums.txt nvcrectl-linux-amd64; do
-              curl -fsSL -o "verify-release/${asset}" "${base}/${asset}"
-            done
-          else
-            echo "NOTICE: repository is not public; verifying over the" \
-              "authenticated channel. The public download URLs in the" \
-              "release notes will not work until the repository is public."
-            gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
-              --pattern installer --pattern checksums.txt --pattern nvcrectl-linux-amd64 \
-              --dir verify-release
+          set -euo pipefail
+          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+          if [[ "${state}" != "true" ]]; then
+            echo "::error::release ${TAG} is already published; refusing to publish assets that the gate has not verified. Cut the next patch version instead (see RELEASE.md)."
+            exit 1
           fi
-          # The installer must be a shell script, not an HTML/text error page.
-          [[ "$(head -c 2 verify-release/installer)" == '#!' ]]
-          bash -n verify-release/installer
-          # Every downloaded asset must match its published checksum.
-          (cd verify-release && sha256sum --check --ignore-missing checksums.txt)
-          # The published binary must self-report exactly the released tag.
-          chmod +x verify-release/nvcrectl-linux-amd64
-          got="$(./verify-release/nvcrectl-linux-amd64 --version | awk '{print $NF}')"
-          echo "tag=${tag} binary-reported=${got}"
-          [[ "${got}" == "${tag}" ]]
+          echo "release ${TAG} is a draft; the gate controls when it becomes visible"
+
+  # The release is a draft until this passes.
+  verify-release:
+    name: Verify the published release
+    needs: [release-tag, build-image, helm-publish, create-github-release]
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      packages: read
+      id-token: none
+    env:
+      COSIGN_VERSION: v3.1.3
+      TAG: ${{ needs.release-tag.outputs.value }}
+      IMAGE: ${{ needs.build-image.outputs.image_name }}
+      INDEX: ${{ needs.build-image.outputs.index_digest }}
+      AMD64: ${{ needs.build-image.outputs.amd64_digest }}
+      ARM64: ${{ needs.build-image.outputs.arm64_digest }}
+      CHART_NAME: ${{ needs.helm-publish.outputs.chart_name }}
+      CHART_DIGEST: ${{ needs.helm-publish.outputs.chart_digest }}
+      OIDC_ISSUER: https://token.actions.githubusercontent.com
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      # The identity every check below pins. Exact, never a regexp: a pattern
+      # naming no workflow and no ref also accepts a branch build, which is how
+      # the pre-epic verification command accepted a main image as a release.
+      - name: Build the identity to pin
+        id: identity
+        run: |
+          set -euo pipefail
+          value="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/attest.yml@refs/tags/${TAG}"
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
+          echo "pinning ${value}"
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p verify && cd verify
+          # Drafts are not reachable unauthenticated, so the gate downloads over
+          # the authenticated channel. The public channel is re-checked after
+          # the release is made visible.
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir . --clobber
+          ls -la
+
+      # The expected set below is static and reviewed on change. Deriving it
+      # from the release's own inventory would mean deleting an asset makes the
+      # check verify the survivors and report clean.
+      - name: Verify every release asset and its bundle
+        id: assets
+        env:
+          IDENTITY: ${{ steps.identity.outputs.value }}
+        run: |
+          set -euo pipefail
+          cd verify
+          failed=0
+
+          # cosign has no native retry and Rekor/GHCR are real network
+          # dependencies. attest.yml retries its signing calls for the same
+          # reason; a single blip must not fail a correct release.
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              [[ "${n}" -ge 3 ]] && return 1
+              sleep $((n * 5))
+            done
+          }
+
+          BINARIES="nvcrectl-linux-amd64 nvcrectl-linux-arm64 nvcrectl-darwin-amd64 nvcrectl-darwin-arm64"
+          ASSETS="${BINARIES} installer THIRD_PARTY_NOTICES.md"
+          for b in ${BINARIES}; do ASSETS="${ASSETS} ${b}.cyclonedx.json"; done
+
+          for a in ${ASSETS}; do
+            if [[ ! -s "${a}" ]]; then
+              echo "::error::asset ${a} is missing from the release"; failed=1; continue
+            fi
+            if [[ ! -s "${a}.sigstore.json" ]]; then
+              echo "::error::asset ${a} has no signature bundle"; failed=1; continue
+            fi
+            if retry cosign verify-blob-attestation \
+                 --bundle "${a}.sigstore.json" \
+                 --type https://slsa.dev/provenance/v1 \
+                 --certificate-identity "${IDENTITY}" \
+                 --certificate-oidc-issuer "${OIDC_ISSUER}" \
+                 "${a}" >>"../verify.log" 2>&1; then
+              echo "ok   ${a}"
+            else
+              echo "::error::${a} does not verify against ${IDENTITY}"; failed=1
+            fi
+          done
+
+          # The bundle binding each SBOM to its binary. Distinct from the SBOM
+          # file's own provenance above: this one proves the document describes
+          # that binary rather than merely being unaltered.
+          for b in ${BINARIES}; do
+            bundle="${b}.cyclonedx.sigstore.json"
+            if [[ ! -s "${bundle}" ]]; then
+              echo "::error::${b} has no bundle binding its SBOM to it"; failed=1; continue
+            fi
+            if retry cosign verify-blob-attestation \
+                 --bundle "${bundle}" --type cyclonedx \
+                 --certificate-identity "${IDENTITY}" \
+                 --certificate-oidc-issuer "${OIDC_ISSUER}" \
+                 "${b}" >>"../verify.log" 2>&1; then
+              echo "ok   ${b} <- its SBOM"
+            else
+              echo "::error::${b}'s SBOM binding does not verify"; failed=1
+            fi
+          done
+
+          # checksums.txt intentionally carries no bundle, so it is absent from
+          # the loop above. The step this gate replaced did check it, and the
+          # release notes still hand users this exact command, so it is checked
+          # here rather than silently dropped.
+          if [[ ! -s checksums.txt ]]; then
+            echo "::error::checksums.txt is missing from the release"; failed=1
+          elif sha256sum --check --ignore-missing checksums.txt >>"../verify.log" 2>&1; then
+            echo "ok   checksums.txt"
+          else
+            echo "::error::checksums.txt does not describe the published assets"; failed=1
+          fi
+
+          [[ "${failed}" -eq 0 ]] || exit 1
+
+      - name: Verify the container image
+        env:
+          IDENTITY: ${{ steps.identity.outputs.value }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          # if/else rather than `cmd && echo ok || err`: in that form the error
+          # branch also runs when the echo fails, which in a gate is a false
+          # pass one broken pipe away.
+          verify() {
+            local what="$1"; shift
+            if retry cosign "$@" --certificate-identity "${IDENTITY}" \
+                 --certificate-oidc-issuer "${OIDC_ISSUER}" >>verify.log 2>&1; then
+              echo "ok   ${what}"
+            else
+              echo "::error::${what} does not verify"
+              failed=1
+            fi
+          }
+
+          # Everything else here is digest-addressed, but the chart pins
+          # manager:<tag> (values.yaml leaves tag empty and the deployment
+          # falls back to .Chart.AppVersion), so the reference users actually
+          # deploy is resolved at install time. Bind the tag to the digest that
+          # was verified, or a repointed tag passes a fully green gate.
+          resolved="$(retry cosign verify --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer "${OIDC_ISSUER}" \
+            --output json "${IMAGE}:${TAG}" 2>>verify.log \
+            | jq -r '.[].critical.image."docker-manifest-digest"' | sort -u)" || resolved=""
+          if [[ "${resolved}" != "${INDEX}" ]]; then
+            echo "::error::${IMAGE}:${TAG} resolves to '${resolved}', not the verified index ${INDEX}"
+            failed=1
+          else
+            echo "ok   tag ${TAG} resolves to the verified index"
+          fi
+
+          verify "index signature"  verify "${IMAGE}@${INDEX}"
+          verify "index provenance" verify-attestation --type slsaprovenance1 "${IMAGE}@${INDEX}"
+          for pair in "amd64:${AMD64}" "arm64:${ARM64}"; do
+            verify "${pair%%:*} SBOM" verify-attestation --type cyclonedx "${IMAGE}@${pair#*:}"
+          done
+
+          [[ "${failed}" -eq 0 ]] || exit 1
+
+      # A signature says who signed and on which ref. Only the predicate says
+      # what was built -- a tag repointed after the build still satisfies an
+      # identity-only check.
+      # attest.yml records that a retry can leave more than one valid
+      # attestation on a digest, and that a consumer "must tolerate more than
+      # one attestation per digest and must not treat a duplicate as
+      # tampering". cosign prints one DSSE envelope per verified attestation,
+      # so the payloads are read one per line and every statement must agree.
+      # Concatenating them instead yields a multi-line value that matches
+      # nothing, failing a correct release with an error that reads like
+      # tampering.
+      - name: Verify the provenance predicate
+        env:
+          IDENTITY: ${{ steps.identity.outputs.value }}
+        run: |
+          set -euo pipefail
+
+          payloads="$(cosign verify-attestation --type slsaprovenance1 \
+            --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer "${OIDC_ISSUER}" \
+            "${IMAGE}@${INDEX}" 2>>verify.log | jq -r .payload)" || true
+          if [[ -z "${payloads}" ]]; then
+            echo "::error::could not read the provenance predicate; see the verification log artifact"
+            exit 1
+          fi
+
+          seen=0
+          failed=0
+          while IFS= read -r encoded; do
+            [[ -n "${encoded}" ]] || continue
+            seen=$((seen + 1))
+            statement="$(base64 -d <<<"${encoded}")"
+
+            got_repo="$(jq -r '.predicate.buildDefinition.externalParameters.repository' <<<"${statement}")"
+            got_ref="$(jq -r '.predicate.buildDefinition.externalParameters.ref' <<<"${statement}")"
+            got_commit="$(jq -r '.predicate.buildDefinition.resolvedDependencies[0].digest.gitCommit' <<<"${statement}")"
+
+            [[ "${got_repo}" == "${GITHUB_REPOSITORY}" ]] \
+              || { echo "::error::attestation ${seen} names repository ${got_repo}, expected ${GITHUB_REPOSITORY}"; failed=1; }
+            [[ "${got_ref}" == "refs/tags/${TAG}" ]] \
+              || { echo "::error::attestation ${seen} names ref ${got_ref}, expected refs/tags/${TAG}"; failed=1; }
+            [[ "${got_commit}" == "${GITHUB_SHA}" ]] \
+              || { echo "::error::attestation ${seen} names commit ${got_commit}, but ${TAG} is ${GITHUB_SHA}"; failed=1; }
+
+            echo "ok   attestation ${seen}: repository=${got_repo} ref=${got_ref} commit=${got_commit}"
+          done <<<"${payloads}"
+
+          if [[ "${seen}" -eq 0 ]]; then
+            echo "::error::no provenance statement was returned for ${IMAGE}@${INDEX}"
+            exit 1
+          fi
+          echo "${seen} provenance attestation(s) checked"
+          [[ "${failed}" -eq 0 ]] || exit 1
+
+      - name: Verify the Helm chart
+        env:
+          IDENTITY: ${{ steps.identity.outputs.value }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if cosign verify --certificate-identity "${IDENTITY}" \
+               --certificate-oidc-issuer "${OIDC_ISSUER}" \
+               "${CHART_NAME}@${CHART_DIGEST}" >>verify.log 2>&1; then
+            echo "ok   chart signature"
+          else
+            echo "::error::chart signature does not verify"; failed=1
+          fi
+          if cosign verify-attestation --type slsaprovenance1 \
+               --certificate-identity "${IDENTITY}" \
+               --certificate-oidc-issuer "${OIDC_ISSUER}" \
+               "${CHART_NAME}@${CHART_DIGEST}" >>verify.log 2>&1; then
+            echo "ok   chart provenance"
+          else
+            echo "::error::chart provenance does not verify"; failed=1
+          fi
+          [[ "${failed}" -eq 0 ]] || exit 1
+
+      - name: Upload verification log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-verification-log
+          path: verify.log
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Only now does the release become visible.
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+          echo "release ${TAG} verified and published"
+
+      # Publication is not the last step, so a failure after it would leave the
+      # release visible with the run red -- the exact state the draft exists to
+      # prevent. Retract it instead.
+      - name: Retract the release if anything after publication failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          state="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft || echo unknown)"
+          if [[ "${state}" == "false" ]]; then
+            gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=true
+            echo "::error::verification failed after publication; release ${TAG} has been returned to draft"
+          fi
+
+      # The channel a user actually takes. Everything above ran authenticated
+      # because a draft is not reachable otherwise; this confirms the assets are
+      # served, and correctly, over the anonymous path.
+      - name: Re-check over the public channel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IDENTITY: ${{ steps.identity.outputs.value }}
+        run: |
+          set -euo pipefail
+          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .visibility)"
+          if [[ "${visibility}" != "public" ]]; then
+            echo "NOTICE: repository is ${visibility}; skipping the anonymous re-check."
+            exit 0
+          fi
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          rm -rf public && mkdir public && cd public
+          for a in installer installer.sigstore.json nvcrectl-linux-amd64 nvcrectl-linux-amd64.sigstore.json; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o "${a}" "${base}/${a}"
+          done
+          [[ "$(head -c 2 installer)" == '#!' ]] || { echo "::error::installer is not a shell script"; exit 1; }
+          bash -n installer
+          cosign verify-blob-attestation \
+            --bundle installer.sigstore.json \
+            --type https://slsa.dev/provenance/v1 \
+            --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer "${OIDC_ISSUER}" \
+            installer
+
+          # The binary was downloaded over this channel too; verifying it is
+          # the point of downloading it. Checking only the installer would let
+          # the step report the channel good while the asset most users take
+          # was never checked on it.
+          cosign verify-blob-attestation \
+            --bundle nvcrectl-linux-amd64.sigstore.json \
+            --type https://slsa.dev/provenance/v1 \
+            --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer "${OIDC_ISSUER}" \
+            nvcrectl-linux-amd64
+
+          echo "public channel serves verifiable installer and binary"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,11 +46,15 @@ people do not tag at the same time.
    If you work from a fork, push the tag to the remote that points at
    `NVIDIA/cluster-readiness-engine`, which is usually `upstream`.
 
-   Sign the tag (`-s`). Pushing the tag is the release trigger; there is no button to
-   press afterwards.
-4. Watch the `Release` workflow. If it fails, the release is incomplete — see
-   Troubleshooting.
+   Sign the tag (`-s`). Pushing the tag is the release trigger.
+4. Watch the `Release` workflow. The GitHub Release is created as a **draft** and is
+   made visible only by the `Verify release` job, after it has verified every published
+   artifact. If that job fails, the release stays a draft — see Troubleshooting.
 5. Check the published release, then announce it.
+
+Do not publish a draft release by hand. A draft left behind by a failed `Verify release`
+is a release the pipeline determined it could not verify; publishing it from the UI is
+the one action that bypasses the gate entirely. Re-run the job instead.
 
 Tags must be clean. `make check-clean-version` refuses to publish a Helm chart when the
 version contains `-dirty`, a `-N-gSHA` suffix, or is `dev`, which is what you get from
@@ -83,7 +87,8 @@ Pushing a `v*` tag runs `.github/workflows/release.yml`, which owns every releas
 | Attest Helm chart | signature and provenance on the chart digest |
 | Build CLI Binaries | cross-compiled `nvcrectl` for linux and macOS, amd64 and arm64 |
 | Attest binaries | a Sigstore bundle per binary, per SBOM, and for the installer |
-| Create GitHub Release | the GitHub Release, its notes, and the assets below |
+| Create GitHub Release | the GitHub Release as a **draft**, its notes, and the assets below |
+| Verify release | verifies every published artifact, then makes the release visible |
 
 The release builds the container image itself. `.github/workflows/publish.yml` no longer
 runs on tags — it now builds only `main-<sha>` development images, and is pinned to
@@ -111,12 +116,23 @@ Release assets:
 
 ## Verifying a release
 
-The release workflow verifies its own output: the Build CLI Binaries job stamps the
-binaries with the tag explicitly and fails if `nvcrectl --version` does not report the
-tag exactly, and the Create GitHub Release job re-downloads the published `installer`,
-`checksums.txt`, and `nvcrectl-linux-amd64` assets, checks the installer is a runnable
-shell script (not an error page), verifies checksums, and re-checks the binary's
-self-reported version.
+The release workflow verifies its own output before anyone can see it. The Build CLI
+Binaries job stamps the binaries with the tag and fails if `nvcrectl --version` does not
+report it exactly. The release is then created as a draft, and the `Verify release` job
+holds it there until it has checked, against the exact signing identity
+`…/attest.yml@refs/tags/<tag>`:
+
+- every release asset against its Sigstore bundle, and each binary against the bundle
+  binding its SBOM to it
+- `checksums.txt` against the downloaded assets
+- the image index signature and provenance, and both per-platform SBOMs
+- that `manager:<tag>` still resolves to the index digest that was verified
+- the provenance predicate itself — repository, ref and commit — not just the signature
+- the chart's signature and provenance
+
+Only then is the release published, after which the assets are re-fetched anonymously
+and re-verified over the channel a user actually takes. If anything fails after
+publication, the release is returned to draft.
 
 To verify manually:
 
@@ -137,6 +153,25 @@ half-published: the chart pushed but no GitHub Release, or the reverse. Read the
 fix the cause, and re-run the failed jobs from the Actions tab. Do not delete and re-push
 a tag that has already published artifacts — consumers may have it. Cut the next patch
 version instead.
+
+**`Verify release` failed and the release is stuck as a draft.** This is the designed
+failure mode, not a broken run: the release is withheld precisely because something did
+not verify. Read `release-verification-log` on the run, which records every cosign
+invocation, and fix the cause. Then re-run the failed jobs. Do not publish the draft from
+the UI.
+
+Note what the draft does **not** hold back. The image and the chart are pushed to GHCR
+before the gate runs and cannot be unpublished, and GitOps automation watching the
+registry — Flux `OCIRepository`, Argo CD Image Updater, Renovate — does not wait for the
+GitHub Release. If the gate failed on the image or the chart rather than on a release
+asset, treat those registry tags as suspect and say so in the follow-up release, because
+`<tag>` remains the newest version in the registry until the next one ships.
+
+**A release already exists for this tag.** The `Require the release to be a draft` step
+fails when the tag already has a *published* release. That is deliberate: the action
+that creates the release honours `draft:` only on creation, so re-running against a
+published tag would upload freshly built, unverified assets into a live release. Cut the
+next patch version instead.
 
 **The Helm push failed on `check-clean-version`.** The tag was not clean. Delete the tag
 if nothing published, commit your work, and tag again.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -167,6 +167,13 @@ still working — or after it had refused a build — would install exactly what
 exists to withhold. Draft assets are reachable only with push access, so this never
 affected anonymous users; it affected the accounts closest to the release.
 
+The installer also refuses when it cannot *tell* — `Could not determine whether release
+<tag> is a draft after 3 attempts`. An unreadable state is not a published one, so it
+stops rather than guess. That is a GitHub API problem, not a bad release: retry, or check
+GitHub status. Anonymous installs never hit it, because no draft is reachable without
+push access and so there is nothing to determine. `test/releasepolicy` covers every
+branch of that decision, including the two ways it previously got it wrong.
+
 Note what the draft does **not** hold back. The image and the chart are pushed to GHCR
 before the gate runs and cannot be unpublished, and GitOps automation watching the
 registry — Flux `OCIRepository`, Argo CD Image Updater, Renovate — does not wait for the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -160,6 +160,13 @@ not verify. Read `release-verification-log` on the run, which records every cosi
 invocation, and fix the cause. Then re-run the failed jobs. Do not publish the draft from
 the UI.
 
+The draft is also invisible to `installer`, deliberately. It resolves the newest
+*published* release on every path, and refuses outright when `-v <tag>` names a draft.
+Without that, a maintainer or an in-repo CI job running the installer while the gate was
+still working — or after it had refused a build — would install exactly what the draft
+exists to withhold. Draft assets are reachable only with push access, so this never
+affected anonymous users; it affected the accounts closest to the release.
+
 Note what the draft does **not** hold back. The image and the chart are pushed to GHCR
 before the gate runs and cannot be unpublished, and GitOps automation watching the
 registry — Flux `OCIRepository`, Argo CD Image Updater, Renovate — does not wait for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,7 +83,25 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
 
   Retrieve the provenance with `cosign verify-attestation --type slsaprovenance1` against the index digest, and a platform's SBOM with `--type cyclonedx` against that platform's manifest digest (`crane digest --platform linux/amd64 "${IMAGE}:${TAG}"`).
 
-- CLI binaries include SHA256 checksums in each release.
+- CLI binaries, the installer and the SBOMs are each signed, and every release asset ships with a detached Sigstore bundle (`<asset>.sigstore.json`) verified under the same identity as the image:
+
+  ```bash
+  TAG=v1.2.3
+  BASE="https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${TAG}"
+  curl -fsSLO "${BASE}/nvcrectl-linux-amd64"
+  curl -fsSLO "${BASE}/nvcrectl-linux-amd64.sigstore.json"
+
+  cosign verify-blob-attestation \
+    --bundle nvcrectl-linux-amd64.sigstore.json \
+    --type https://slsa.dev/provenance/v1 \
+    --certificate-identity "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}" \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    nvcrectl-linux-amd64
+  ```
+
+  Each binary additionally carries `<binary>.cyclonedx.sigstore.json`, which binds its SBOM to that binary — verify it with `--type cyclonedx` against the **binary**, not against the SBOM file.
+
+  `checksums.txt` is also published, but it is served from the same origin as the assets and is itself unsigned, so it detects corruption rather than tampering. Verify the bundle, not the checksum.
 
 ## Product Security Resources
 

--- a/installer
+++ b/installer
@@ -209,26 +209,61 @@ fi
 # failed, so installing one means installing the build the gate has not cleared,
 # or has refused.
 #
-# Anonymous callers never reach this: GET /releases omits drafts for them and
-# /releases/latest is non-draft by definition. The exposure is push-access
-# accounts and in-repo CI, which is where a lot of installs happen.
-IS_DRAFT=""
+# Anonymous callers cannot reach a draft at all: GET /releases omits drafts for
+# them and /releases/latest is non-draft by definition. The exposure is
+# push-access accounts and in-repo CI, which is where a lot of installs happen.
+#
+# The lookup fails closed. "I could not read the state" is not "it is published"
+# — treating it as such is the whole reason this guard would be worth adding and
+# then not worth having. `skipped` is the one benign unknown: with no gh and no
+# token there is no draft to install, so there is nothing to determine.
+IS_DRAFT="unknown"
 if [[ "${GH_AVAILABLE}" == "true" ]]; then
-  IS_DRAFT=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json isDraft -q '.isDraft' 2>/dev/null || true)
+  for attempt in 1 2 3; do
+    if OUT=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json isDraft -q '.isDraft' 2>&1); then
+      IS_DRAFT="${OUT}"
+      break
+    fi
+    # A confirmed "no such release" is an answer, not an outage: there is no
+    # draft to refuse, and the download below reports the missing release with
+    # a message that actually says so.
+    if echo "${OUT}" | grep -qiE 'release not found|could not find|HTTP 404'; then
+      IS_DRAFT="absent"
+      break
+    fi
+    sleep $((attempt * 2))
+  done
 elif [[ -n "${GH_TOKEN}" ]]; then
   # A single release object, so no key-ordering assumption is needed. This also
   # primes RELEASE_JSON for the asset lookup below.
-  if [[ -z "${RELEASE_JSON:-}" ]]; then
-    RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
-      -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/tags/${VERSION}" || true)
-  fi
-  if echo "${RELEASE_JSON}" | grep -q '"draft" *: *true'; then
-    IS_DRAFT=true
-  fi
+  for attempt in 1 2 3; do
+    if [[ -z "${RELEASE_JSON:-}" ]]; then
+      RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
+        -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/tags/${VERSION}" || true)
+    fi
+    if [[ -n "${RELEASE_JSON:-}" ]]; then
+      if echo "${RELEASE_JSON}" | grep -q '"draft" *: *true'; then
+        IS_DRAFT=true
+      else
+        IS_DRAFT=false
+      fi
+      break
+    fi
+    sleep $((attempt * 2))
+  done
+else
+  IS_DRAFT="skipped"
 fi
-if [[ "${IS_DRAFT}" == "true" ]]; then
-  err "Release ${VERSION} is a draft: the release workflow has not finished verifying it, or refused it. Drafts are visible only to accounts with push access. Pin a published release with -v <tag>."
-fi
+
+case "${IS_DRAFT}" in
+  true)
+    err "Release ${VERSION} is a draft: the release workflow has not finished verifying it, or refused it. Drafts are visible only to accounts with push access. Pin a published release with -v <tag>."
+    ;;
+  false | absent | skipped) ;;
+  *)
+    err "Could not determine whether release ${VERSION} is a draft after 3 attempts. Refusing to install rather than risk installing a build the release gate has not cleared. Retry, or check GitHub API availability."
+    ;;
+esac
 
 # Decide whether this is a fresh install or an upgrade and print intent.
 if [[ -n "${CURRENT_VERSION}" ]]; then

--- a/installer
+++ b/installer
@@ -156,7 +156,11 @@ if [[ -n "${VERSION}" ]]; then
 elif [[ "${GH_AVAILABLE}" == "true" ]]; then
   msg "Fetching latest version..."
   if [[ "${PRERELEASE}" == "true" ]]; then
-    VERSION=$(gh release list --repo "${GH_REPO}" --limit 1 --json tagName -q '.[0].tagName')
+    # --exclude-drafts is load-bearing: `gh release list` includes drafts, and a
+    # release is a draft while the release workflow is still verifying it (and
+    # stays one if that verification fails). Without this, anyone with repo
+    # access installs the build the release gate has not cleared, or refused.
+    VERSION=$(gh release list --repo "${GH_REPO}" --exclude-drafts --limit 1 --json tagName -q '.[0].tagName')
   else
     VERSION=$(gh release view --repo "${GH_REPO}" --json tagName -q '.tagName' || true)
   fi

--- a/installer
+++ b/installer
@@ -217,40 +217,78 @@ fi
 # — treating it as such is the whole reason this guard would be worth adding and
 # then not worth having. `skipped` is the one benign unknown: with no gh and no
 # token there is no draft to install, so there is nothing to determine.
+#
+# Only a positively identified answer counts. Neither branch infers "published"
+# from the absence of evidence for "draft": `gh` output that is not literally
+# `true` or `false` is not an answer, and an HTTP body without a readable
+# `draft` field is not an answer either. A TLS-interception page, a WAF block or
+# a CDN glitch can all return 200 with a body that contains no `"draft": true`,
+# and reading that as "not a draft" would be the same fail-open in a new place.
 IS_DRAFT="unknown"
 if [[ "${GH_AVAILABLE}" == "true" ]]; then
+  GH_ERR=$(mktemp)
   for attempt in 1 2 3; do
-    if OUT=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json isDraft -q '.isDraft' 2>&1); then
-      IS_DRAFT="${OUT}"
-      break
-    fi
+    # stderr goes to a file, never into the captured value. `gh` prints an
+    # upgrade notice to stderr once every 24h, and merging the two streams put
+    # that notice inside IS_DRAFT on a perfectly successful call — which then
+    # matched no case arm and refused a published release. Ephemeral CI runners
+    # do not persist gh's state, so they see that notice constantly.
+    if OUT=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json isDraft -q '.isDraft' 2>"${GH_ERR}"); then
+      case "${OUT}" in
+        true | false)
+          IS_DRAFT="${OUT}"
+          break
+          ;;
+      esac
     # A confirmed "no such release" is an answer, not an outage: there is no
     # draft to refuse, and the download below reports the missing release with
     # a message that actually says so.
-    if echo "${OUT}" | grep -qiE 'release not found|could not find|HTTP 404'; then
+    elif grep -qiE 'release not found|could not find|HTTP 404' "${GH_ERR}"; then
       IS_DRAFT="absent"
       break
     fi
-    sleep $((attempt * 2))
+    if [[ "${attempt}" -lt 3 ]]; then sleep $((attempt * 2)); fi
   done
+  rm -f "${GH_ERR}"
 elif [[ -n "${GH_TOKEN}" ]]; then
   # A single release object, so no key-ordering assumption is needed. This also
   # primes RELEASE_JSON for the asset lookup below.
+  BODY=$(mktemp)
   for attempt in 1 2 3; do
-    if [[ -z "${RELEASE_JSON:-}" ]]; then
-      RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
-        -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/tags/${VERSION}" || true)
-    fi
     if [[ -n "${RELEASE_JSON:-}" ]]; then
-      if echo "${RELEASE_JSON}" | grep -q '"draft" *: *true'; then
-        IS_DRAFT=true
-      else
-        IS_DRAFT=false
-      fi
+      HTTP_CODE=200
+    else
+      # -f is deliberately absent: it discards the body and collapses every
+      # HTTP error into one exit code, which is what made a 404 on a mistyped
+      # -v tag indistinguishable from an outage.
+      HTTP_CODE=$(curl -sS -o "${BODY}" -w '%{http_code}' \
+        "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "${GH_API_URL}/releases/tags/${VERSION}" 2>/dev/null || echo "000")
+    fi
+
+    if [[ "${HTTP_CODE}" == "404" ]]; then
+      IS_DRAFT="absent"
       break
     fi
-    sleep $((attempt * 2))
+    if [[ "${HTTP_CODE}" == "200" ]]; then
+      if [[ -z "${RELEASE_JSON:-}" ]]; then
+        RELEASE_JSON=$(cat "${BODY}")
+      fi
+      if echo "${RELEASE_JSON}" | grep -q '"draft" *: *true'; then
+        IS_DRAFT=true
+        break
+      elif echo "${RELEASE_JSON}" | grep -q '"draft" *: *false'; then
+        IS_DRAFT=false
+        break
+      fi
+      # 200 with no readable draft field: not a release object, so not an
+      # answer. Drop it rather than let the asset lookup below inherit it.
+      RELEASE_JSON=""
+    fi
+    if [[ "${attempt}" -lt 3 ]]; then sleep $((attempt * 2)); fi
   done
+  rm -f "${BODY}"
 else
   IS_DRAFT="skipped"
 fi

--- a/installer
+++ b/installer
@@ -168,10 +168,25 @@ else
   msg "Fetching latest version..."
   # curl + token fallback
   if [[ "${PRERELEASE}" == "true" ]]; then
-    ENDPOINT="${GH_API_URL}/releases?per_page=1"
+    # This is the `gh release list --exclude-drafts` above, done with curl. The
+    # REST list endpoint returns draft releases to any caller with push access,
+    # so the newest entry can be the release the gate is still verifying, or has
+    # refused. Ask for several and walk past the drafts.
+    #
+    # `tag_name` precedes `draft` inside a release object, so the first
+    # "draft": false after a tag_name belongs to that tag. The draft guard below
+    # re-checks the resolved tag on its own, so a wrong answer here is caught
+    # rather than installed.
+    ENDPOINT="${GH_API_URL}/releases?per_page=10"
     RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
       -H "Accept: application/vnd.github.v3+json" "${ENDPOINT}" || true)
-    VERSION=$(echo "${RELEASE_JSON}" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+    VERSION=$(echo "${RELEASE_JSON}" | tr ',' '\n' | awk -F'"' '
+      /"tag_name"[[:space:]]*:/ { tag = $4 }
+      /"draft"[[:space:]]*:[[:space:]]*false/ { if (tag != "") { print tag; exit } }
+    ' || true)
+    # RELEASE_JSON now holds a list, not the selected release; the asset lookup
+    # further down must not read assets out of it.
+    RELEASE_JSON=""
   else
     RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
       -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/latest" || true)
@@ -181,6 +196,38 @@ fi
 
 if [[ -z "${VERSION}" ]]; then
   err "Failed to determine latest version from GitHub releases. If every release is a pre-release, re-run with -p, or pin a version with -v <tag>."
+fi
+
+# ---------------------------------------------------------------------------
+# Refuse a draft release
+# ---------------------------------------------------------------------------
+# Resolution above walks past drafts, but -v names a tag directly and both
+# `gh release download` and GET /releases/tags/<tag> resolve a draft for a caller
+# with push access — gh races a published lookup against an explicit draft
+# lookup, so a pinned tag finds the draft too. A release is a draft while the
+# release workflow is still verifying it, and stays one if that verification
+# failed, so installing one means installing the build the gate has not cleared,
+# or has refused.
+#
+# Anonymous callers never reach this: GET /releases omits drafts for them and
+# /releases/latest is non-draft by definition. The exposure is push-access
+# accounts and in-repo CI, which is where a lot of installs happen.
+IS_DRAFT=""
+if [[ "${GH_AVAILABLE}" == "true" ]]; then
+  IS_DRAFT=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json isDraft -q '.isDraft' 2>/dev/null || true)
+elif [[ -n "${GH_TOKEN}" ]]; then
+  # A single release object, so no key-ordering assumption is needed. This also
+  # primes RELEASE_JSON for the asset lookup below.
+  if [[ -z "${RELEASE_JSON:-}" ]]; then
+    RELEASE_JSON=$(curl -sSf "${AUTH_HEADERS[@]+"${AUTH_HEADERS[@]}"}" \
+      -H "Accept: application/vnd.github.v3+json" "${GH_API_URL}/releases/tags/${VERSION}" || true)
+  fi
+  if echo "${RELEASE_JSON}" | grep -q '"draft" *: *true'; then
+    IS_DRAFT=true
+  fi
+fi
+if [[ "${IS_DRAFT}" == "true" ]]; then
+  err "Release ${VERSION} is a draft: the release workflow has not finished verifying it, or refused it. Drafts are visible only to accounts with push access. Pin a published release with -v <tag>."
 fi
 
 # Decide whether this is a fresh install or an upgrade and print intent.

--- a/test/releasepolicy/installer_draft_guard_test.go
+++ b/test/releasepolicy/installer_draft_guard_test.go
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installerPath is the script under test. It is shell, so nothing type-checks
+// it, and a weakened guard would not break a build -- it would just stop
+// refusing things. That is the same reason attest.yml's input validation is
+// tested here rather than trusted.
+const installerPath = "../../installer"
+
+// draftGuard returns the installer's draft-refusal block, from the line that
+// seeds the state to the end of the case statement that acts on it.
+//
+// Extracted from the real script rather than copied, so the test cannot drift
+// from the code it covers. If the markers move, the test fails loudly instead
+// of silently covering nothing.
+func draftGuard(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(installerPath)
+	if err != nil {
+		t.Fatalf("read installer: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, `IS_DRAFT="unknown"`) {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatal(`could not find the start of the draft guard (IS_DRAFT="unknown") in installer; ` +
+			"if the guard was renamed or removed, update this test rather than deleting it")
+	}
+
+	// The closing `esac` of the outer case, matched unindented. The guard
+	// contains an inner `case` inside a retry loop, and stopping at the first
+	// `esac` truncated the block into a syntax error -- which exits non-zero and
+	// so read as "the guard refused", passing the refusal cases for the wrong
+	// reason. runGuard syntax-checks the result to keep that from recurring.
+	for i := start; i < len(lines); i++ {
+		if lines[i] == "esac" {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatal("could not find the end of the draft guard (unindented esac) in installer")
+	return ""
+}
+
+// guardCase is one run of the guard against a stubbed GitHub.
+type guardCase struct {
+	name string
+	// ghAvailable and token select which of the three branches runs.
+	ghAvailable string
+	token       string
+	// ghStdout, ghStderr and ghExit stub the `gh release view` call.
+	ghStdout, ghStderr string
+	ghExit             int
+	// httpCode and body stub the curl call.
+	httpCode, body string
+	// refused is whether the guard must stop the install.
+	refused bool
+	// state is the value the guard must settle on when it does not refuse.
+	state string
+}
+
+// harness wraps the extracted guard with the variables and commands it reads,
+// so the block runs exactly as it does in the script but against a stub.
+const harness = `
+set -uo pipefail
+err() { echo "REFUSED: $*"; exit 9; }
+VERSION="v1.2.3"
+GH_REPO="NVIDIA/cluster-readiness-engine"
+GH_API_URL="https://api.github.com/repos/NVIDIA/cluster-readiness-engine"
+AUTH_HEADERS=()
+RELEASE_JSON=""
+GH_AVAILABLE="%s"
+GH_TOKEN="%s"
+
+# Never actually wait: the retry backoff is not what these cases exercise.
+sleep() { :; }
+
+gh() {
+  printf '%%s' "${STUB_GH_STDOUT}"
+  printf '%%s' "${STUB_GH_STDERR}" >&2
+  return "${STUB_GH_EXIT}"
+}
+
+curl() {
+  # Mirror the real call's -o <file> handling so the guard reads a body.
+  local out=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then out="$2"; shift 2; continue; fi
+    shift
+  done
+  [ -n "${out}" ] && printf '%%s' "${STUB_BODY}" > "${out}"
+  printf '%%s' "${STUB_HTTP_CODE}"
+  return 0
+}
+
+%s
+
+echo "PROCEEDED:${IS_DRAFT}"
+`
+
+func runGuard(t *testing.T, guard string, c guardCase) (string, bool) {
+	t.Helper()
+
+	script := fmt.Sprintf(harness, c.ghAvailable, c.token, guard)
+	path := filepath.Join(t.TempDir(), "guard.sh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write harness: %v", err)
+	}
+
+	// A malformed harness exits non-zero, which is indistinguishable from the
+	// guard refusing an install. Without this, every refusal case would pass
+	// even if the extracted block were garbage.
+	if out, err := exec.Command("bash", "-n", path).CombinedOutput(); err != nil {
+		t.Fatalf("extracted guard is not valid shell: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command("bash", path)
+	cmd.Env = append(os.Environ(),
+		"STUB_GH_STDOUT="+c.ghStdout,
+		"STUB_GH_STDERR="+c.ghStderr,
+		"STUB_GH_EXIT="+fmt.Sprint(c.ghExit),
+		"STUB_HTTP_CODE="+c.httpCode,
+		"STUB_BODY="+c.body,
+	)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err != nil
+}
+
+// TestInstallerDraftGuard pins the state machine that decides whether the
+// installer will install a release.
+//
+// A draft is a build the release gate has not cleared, or has refused. The
+// guard must refuse one, must install a published release, and must refuse
+// rather than guess when it cannot read the state -- an unreadable state is not
+// "published". The one benign unknown is the anonymous path, where no draft is
+// reachable at all, so refusing there would break every unauthenticated install
+// to guard against something that cannot happen.
+//
+// Three of these cases are regressions for defects that shipped in this guard:
+// stderr merged into the captured value, a 200 with no readable draft field
+// read as "published", and a 404 retried as though it were an outage.
+func TestInstallerDraftGuard(t *testing.T) {
+	guard := draftGuard(t)
+
+	cases := []guardCase{
+		{
+			name:        "gh reports a draft",
+			ghAvailable: boolTrue, ghStdout: boolTrue + "\n",
+			refused: true,
+		},
+		{
+			name:        "gh reports a published release",
+			ghAvailable: boolTrue, ghStdout: boolFalse + "\n",
+			state: boolFalse,
+		},
+		{
+			// gh prints an upgrade notice to stderr once every 24h. Merging it
+			// into the captured value put it inside IS_DRAFT on a successful
+			// call, which matched no case arm and refused a published release.
+			name:        "gh succeeds while writing an upgrade notice to stderr",
+			ghAvailable: boolTrue, ghStdout: boolFalse + "\n",
+			ghStderr: "A new release of gh is available: 2.97.0 -> 2.98.0\n",
+			state:    boolFalse,
+		},
+		{
+			name:        "gh reports no such release",
+			ghAvailable: boolTrue, ghExit: 1, ghStderr: "release not found\n",
+			state: "absent",
+		},
+		{
+			name:        "gh fails with an outage on every attempt",
+			ghAvailable: boolTrue, ghExit: 1, ghStderr: "HTTP 503 Service Unavailable\n",
+			refused: true,
+		},
+		{
+			// Not an answer. Treating anything that is not "true" as published
+			// is the fail-open this guard exists to prevent.
+			name:        "gh succeeds but prints something unexpected",
+			ghAvailable: boolTrue, ghStdout: "null\n",
+			refused: true,
+		},
+		{
+			name:  "token path reports a draft",
+			token: "t", httpCode: "200", body: `{"tag_name":"v1.2.3","draft": true}`,
+			refused: true,
+		},
+		{
+			name:  "token path reports a published release",
+			token: "t", httpCode: "200", body: `{"tag_name":"v1.2.3","draft": false}`,
+			state: boolFalse,
+		},
+		{
+			name:  "token path reports no such release",
+			token: "t", httpCode: "404", body: `{"message":"Not Found"}`,
+			state: "absent",
+		},
+		{
+			// A TLS-interception page, a WAF block or a CDN glitch can answer
+			// 200 with a body that has no draft field. That is not evidence the
+			// release is published.
+			name:  "token path gets 200 with a body that has no draft field",
+			token: "t", httpCode: "200", body: "<html><body>Blocked by policy</body></html>",
+			refused: true,
+		},
+		{
+			name:  "token path gets a server error on every attempt",
+			token: "t", httpCode: "500", body: "",
+			refused: true,
+		},
+		{
+			// No gh and no token: drafts are not reachable, so there is nothing
+			// to determine and refusing would break every anonymous install.
+			name:  "anonymous caller",
+			state: "skipped",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, failed := runGuard(t, guard, c)
+
+			if c.refused {
+				if !failed {
+					t.Errorf("guard allowed the install but must refuse it; output: %s", out)
+				}
+				return
+			}
+			if failed {
+				t.Fatalf("guard refused the install but must allow it; output: %s", out)
+			}
+			want := "PROCEEDED:" + c.state
+			if !strings.Contains(out, want) {
+				t.Errorf("guard settled on the wrong state\n got: %s\nwant: %s", out, want)
+			}
+		})
+	}
+}
+
+// TestInstallerDraftGuardRefusesUnknownStates is the negative half: every value
+// the guard does not positively recognise must refuse.
+//
+// The exhaustive list matters because the guard reads values produced by two
+// external commands. `true` is the only value that means "draft", but anything
+// that is not a recognised answer must also stop the install rather than fall
+// through to it.
+func TestInstallerDraftGuardRefusesUnknownStates(t *testing.T) {
+	guard := draftGuard(t)
+
+	// Values a broken or changed `gh` could plausibly emit on exit 0.
+	for _, out := range []string{"", "null", "TRUE", "true false", "{\"isDraft\":false}"} {
+		t.Run("gh emits "+strings.ReplaceAll(out, " ", "_"), func(t *testing.T) {
+			_, failed := runGuard(t, guard, guardCase{
+				ghAvailable: boolTrue, ghStdout: out + "\n",
+			})
+			if !failed {
+				t.Errorf("guard accepted %q as an answer; only a literal true or false is one", out)
+			}
+		})
+	}
+}

--- a/test/releasepolicy/predicate_parse_test.go
+++ b/test/releasepolicy/predicate_parse_test.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+const releaseWorkflow = "../../.github/workflows/release.yml"
+
+// Values the extracted step compares the predicate against. They stand in for
+// the workflow's own environment, so a case fails on the field it is about.
+const (
+	predRepo   = "NVIDIA/cluster-readiness-engine"
+	predTag    = "v1.2.3"
+	predRef    = "refs/tags/" + predTag
+	predCommit = "1111111111111111111111111111111111111111"
+)
+
+// predicateScript returns the body of release.yml's provenance-predicate step.
+//
+// Extracted rather than copied for the same reason as attest.yml's validation:
+// a copy would drift, and a drifted copy would keep passing while the real
+// check rotted.
+func predicateScript(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(releaseWorkflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", releaseWorkflow, err)
+	}
+
+	var wf struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `json:"name"`
+				Run  string `json:"run"`
+			} `json:"steps"`
+		} `json:"jobs"`
+	}
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse %s: %v", releaseWorkflow, err)
+	}
+
+	job, ok := wf.Jobs["verify-release"]
+	if !ok {
+		t.Fatalf("%s has no `verify-release` job; the release gate must not be removed", releaseWorkflow)
+	}
+	for _, step := range job.Steps {
+		if step.Name == "Verify the provenance predicate" {
+			return step.Run
+		}
+	}
+	t.Fatalf("%s `verify-release` has no `Verify the provenance predicate` step", releaseWorkflow)
+	return ""
+}
+
+// envelope renders one DSSE envelope as cosign prints it: a JSON object whose
+// `payload` is the base64-encoded in-toto statement.
+func envelope(repo, ref, commit string) string {
+	statement := map[string]any{
+		"predicate": map[string]any{
+			"buildDefinition": map[string]any{
+				"externalParameters": map[string]any{
+					"repository": repo,
+					"ref":        ref,
+				},
+				"resolvedDependencies": []any{
+					map[string]any{"digest": map[string]any{"gitCommit": commit}},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(statement)
+	if err != nil {
+		panic(err)
+	}
+	out, err := json.Marshal(map[string]string{
+		"payload": base64.StdEncoding.EncodeToString(body),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// runPredicate executes the extracted step with a stub cosign that prints the
+// given envelopes, one per line, the way cosign emits one per verified
+// attestation.
+func runPredicate(t *testing.T, envelopes []string) (string, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	stub := "#!/usr/bin/env bash\n"
+	if len(envelopes) == 0 {
+		stub += "exit 1\n"
+	} else {
+		stub += fmt.Sprintf("cat <<'ENVELOPES'\n%s\nENVELOPES\n", strings.Join(envelopes, "\n"))
+	}
+	stubPath := filepath.Join(dir, "cosign")
+	if err := os.WriteFile(stubPath, []byte(stub), 0o755); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatalf("write cosign stub: %v", err)
+	}
+
+	cmd := exec.Command("bash", "-c", predicateScript(t))
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"IDENTITY=https://github.com/"+predRepo+"/.github/workflows/attest.yml@"+predRef,
+		"OIDC_ISSUER=https://token.actions.githubusercontent.com",
+		"IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager",
+		"INDEX="+validDigest,
+		"GITHUB_REPOSITORY="+predRepo,
+		"GITHUB_SHA="+predCommit,
+		"TAG="+predTag,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestPredicateCheckToleratesDuplicateAttestations pins the contract attest.yml
+// states about its own retries: an attempt killed after its registry push and
+// Rekor entry landed publishes a second valid attestation for the same digest,
+// and "any consumer that walks attestations must therefore tolerate more than
+// one attestation per digest and must not treat a duplicate as tampering".
+//
+// This gate is that consumer. Reading cosign's output into a single variable
+// concatenates the statements, so every scalar comparison sees a multi-line
+// value and fails — turning a harmless duplicate into a tampering-shaped error
+// that strands a correct release as an invisible draft.
+func TestPredicateCheckToleratesDuplicateAttestations(t *testing.T) {
+	good := envelope(predRepo, predRef, predCommit)
+
+	cases := []struct {
+		name      string
+		envelopes []string
+		wantPass  bool
+		wantText  string
+	}{
+		{
+			name:      "one attestation",
+			envelopes: []string{good},
+			wantPass:  true,
+		},
+		{
+			name:      "duplicate attestations from a retry",
+			envelopes: []string{good, good},
+			wantPass:  true,
+			wantText:  "2 provenance attestation(s) checked",
+		},
+		{
+			name:      "one good and one for a different commit",
+			envelopes: []string{good, envelope(predRepo, predRef, "deadbeef")},
+			wantPass:  false,
+			wantText:  "names commit deadbeef",
+		},
+		{
+			name:      "wrong repository",
+			envelopes: []string{envelope("attacker/repo", predRef, predCommit)},
+			wantPass:  false,
+			wantText:  "names repository attacker/repo",
+		},
+		{
+			name:      "wrong ref",
+			envelopes: []string{envelope(predRepo, "refs/heads/main", predCommit)},
+			wantPass:  false,
+			wantText:  "names ref refs/heads/main",
+		},
+		{
+			name:      "no attestation at all",
+			envelopes: nil,
+			wantPass:  false,
+			wantText:  "could not read the provenance predicate",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runPredicate(t, tc.envelopes)
+			if tc.wantPass && err != nil {
+				t.Errorf("expected the predicate check to pass, got %v\n%s", err, out)
+			}
+			if !tc.wantPass && err == nil {
+				t.Errorf("expected the predicate check to fail, it passed\n%s", out)
+			}
+			if tc.wantText != "" && !strings.Contains(out, tc.wantText) {
+				t.Errorf("expected output to contain %q, got:\n%s", tc.wantText, out)
+			}
+		})
+	}
+}

--- a/test/releasepolicy/shell_scope_test.go
+++ b/test/releasepolicy/shell_scope_test.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// The workflows that can produce or verify a release artifact. Every policy
+// test in this package scans this set, so it is defined once: a workflow added
+// to the release path must be added here to come under the invariants.
+const (
+	wfRelease     = "release.yml"
+	wfPublish     = "publish.yml"
+	wfAttest      = "attest.yml"
+	wfBuildImage  = "build-image.yml"
+	wfAttestSmoke = "attest-selftest.yml"
+)
+
+var releasePathWorkflows = []string{wfRelease, wfPublish, wfAttest, wfBuildImage, wfAttestSmoke}
+
+// onReleasePath reports whether a workflow file is part of the release path.
+func onReleasePath(base string) bool {
+	return slices.Contains(releasePathWorkflows, base)
+}
+
+// workflowFiles lists the workflow definitions, sorted for stable output.
+func workflowFiles(t *testing.T) []string {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil {
+		t.Fatalf("glob workflows: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no workflows found under %s", workflowDir)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// step is one run step plus the environment it can actually see.
+type runStep struct {
+	workflow string
+	job      string
+	name     string
+	run      string
+	env      map[string]bool
+}
+
+// runSteps returns every `run:` step in the release-path workflows, with the
+// step, job and workflow `env` blocks merged into one visible set.
+func runSteps(t *testing.T) []runStep {
+	t.Helper()
+
+	var out []runStep
+	for _, path := range workflowFiles(t) {
+		base := filepath.Base(path)
+		if !onReleasePath(base) {
+			continue
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		var doc struct {
+			Env  map[string]string `json:"env"`
+			Jobs map[string]struct {
+				Env   map[string]string `json:"env"`
+				Steps []struct {
+					Name string            `json:"name"`
+					Run  string            `json:"run"`
+					Env  map[string]string `json:"env"`
+				} `json:"steps"`
+			} `json:"jobs"`
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for jobName, job := range doc.Jobs {
+			for _, s := range job.Steps {
+				if strings.TrimSpace(s.Run) == "" {
+					continue
+				}
+				env := map[string]bool{}
+				for _, m := range []map[string]string{doc.Env, job.Env, s.Env} {
+					for k := range m {
+						env[k] = true
+					}
+				}
+				out = append(out, runStep{
+					workflow: base, job: jobName, name: s.Name, run: s.Run, env: env,
+				})
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no run steps found in the release-path workflows")
+	}
+	return out
+}
+
+// retryCall matches an invocation of the retry helper, not curl's --retry flag.
+var retryCall = regexp.MustCompile(`(?m)(^|\||&|;|\$\()\s*retry\s+\S`)
+
+// TestRetryHelperIsInScope catches a defect that shipped in this gate's first
+// draft and would have failed every release.
+//
+// Each `run:` block executes in its own shell, so a function defined in one step
+// does not exist in the next. `retry` was defined in the asset-verification step
+// and called in the image-verification step, where it resolved to
+// `retry: command not found`. Every call took the failure branch, the
+// tag-to-digest comparison saw an empty value, and the step exited 1 on a
+// perfectly good release — with error text blaming the signatures.
+//
+// The shell would not complain at lint time and actionlint does not model
+// cross-step scope, so nothing else catches this.
+func TestRetryHelperIsInScope(t *testing.T) {
+	for _, s := range runSteps(t) {
+		if !retryCall.MatchString(s.run) {
+			continue
+		}
+		if !strings.Contains(s.run, "retry()") {
+			t.Errorf("%s: job %q step %q calls `retry` but does not define it; "+
+				"each run block is its own shell, so a helper from an earlier step is not in scope",
+				s.workflow, s.job, s.name)
+		}
+	}
+}
+
+// varRef matches a ${NAME} expansion of an upper-case shell variable.
+var varRef = regexp.MustCompile(`\$\{([A-Z][A-Z0-9_]*)\}`)
+
+// assigned matches the forms that bring a name into scope within one script.
+var assigned = regexp.MustCompile(`(?m)^\s*(?:export\s+|local\s+|declare\s+)?([A-Z][A-Z0-9_]*)=`)
+
+// forLoopVar matches `for NAME in ...`, which also binds a name.
+var forLoopVar = regexp.MustCompile(`(?m)\bfor\s+([A-Z][A-Z0-9_]*)\s+in\b`)
+
+// runnerProvided are always in scope: shell built-ins the interpreter maintains,
+// plus the variables the Actions runner exports into every step.
+var runnerProvided = map[string]bool{
+	// Shell built-ins.
+	"PWD": true, "OLDPWD": true, "IFS": true, "UID": true, "EUID": true,
+	"PPID": true, "SHLVL": true, "RANDOM": true, "SECONDS": true, "HOSTNAME": true,
+	"BASH_VERSION": true, "LINENO": true, "FUNCNAME": true, "OSTYPE": true,
+	// Runner-provided.
+	"HOME": true, "PATH": true, "CI": true, "RUNNER_OS": true, "RUNNER_ARCH": true,
+	"RUNNER_TEMP": true, "RUNNER_DEBUG": true, "TMPDIR": true, "LD_LIBRARY_PATH": true,
+}
+
+// TestNoUnboundVariablesInRunBlocks pins the other half of the same defect
+// class. Every release-path script runs under `set -u`, so a name that reaches
+// the shell without an `env:` entry is not an empty string — it aborts the step.
+//
+// The draft-state guard shipped exactly this way: it read `${TAG}` with only
+// `GH_TOKEN` in its `env`, so it would have failed the job immediately after
+// creating the release, skipping the gate entirely.
+func TestNoUnboundVariablesInRunBlocks(t *testing.T) {
+	for _, s := range runSteps(t) {
+		if !strings.Contains(s.run, "set -u") && !strings.Contains(s.run, "set -euo") {
+			continue
+		}
+
+		inScope := map[string]bool{}
+		for _, m := range assigned.FindAllStringSubmatch(s.run, -1) {
+			inScope[m[1]] = true
+		}
+		for _, m := range forLoopVar.FindAllStringSubmatch(s.run, -1) {
+			inScope[m[1]] = true
+		}
+
+		for _, m := range varRef.FindAllStringSubmatch(s.run, -1) {
+			name := m[1]
+			switch {
+			case s.env[name], inScope[name], runnerProvided[name]:
+				continue
+			case strings.HasPrefix(name, "GITHUB_"):
+				continue
+			}
+			t.Errorf("%s: job %q step %q reads ${%s} under `set -u`, but nothing puts it in scope; "+
+				"add it to the step's env: or assign it in the script, or the step aborts rather than "+
+				"reading an empty value", s.workflow, s.job, s.name, name)
+		}
+	}
+}

--- a/test/releasepolicy/shell_scope_test.go
+++ b/test/releasepolicy/shell_scope_test.go
@@ -111,8 +111,32 @@ func runSteps(t *testing.T) []runStep {
 	return out
 }
 
+// commandPosition matches the places a bare word can start a command: the
+// beginning of a line, after a list or pipeline operator, inside a substitution,
+// after `!`, or after a keyword that introduces one. Anchoring on it is what
+// keeps `curl --retry 5` and `--retry-delay` out of the match -- a flag is
+// preceded by `-`, which is not a command position.
+//
+// The first version of this pattern accepted only line start, `|`, `&`, `;` and
+// `$(`. Every call in `Verify every release asset and its bundle` reads
+// `if retry cosign ...`, which matched none of them, so the one step this test
+// was written about was skipped entirely: deleting its `retry()` definition
+// still passed.
+const commandPosition = "(?:^|[|&;(){\x60]|!|\\b(?:if|then|else|elif|do|while|until|time)\\b)"
+
 // retryCall matches an invocation of the retry helper, not curl's --retry flag.
-var retryCall = regexp.MustCompile(`(?m)(^|\||&|;|\$\()\s*retry\s+\S`)
+var retryCall = regexp.MustCompile(`(?m)` + commandPosition + `\s*retry\s+\S`)
+
+// firstRealMatch returns the offset of the first match that is not inside a
+// comment, or -1. A comment naming a command runs nothing.
+func firstRealMatch(re *regexp.Regexp, body string) int {
+	for _, m := range re.FindAllStringIndex(body, -1) {
+		if !inComment(body, m[0]) {
+			return m[0]
+		}
+	}
+	return -1
+}
 
 // TestRetryHelperIsInScope catches a defect that shipped in this gate's first
 // draft and would have failed every release.
@@ -128,20 +152,14 @@ var retryCall = regexp.MustCompile(`(?m)(^|\||&|;|\$\()\s*retry\s+\S`)
 // cross-step scope, so nothing else catches this.
 func TestRetryHelperIsInScope(t *testing.T) {
 	for _, s := range runSteps(t) {
-		call := retryCall.FindStringIndex(s.run)
-		if call == nil {
+		call := firstRealMatch(retryCall, s.run)
+		if call < 0 {
 			continue
 		}
 		// A definition inside a comment defines nothing, and one that appears
 		// after the first call is not in scope at that call.
-		def := -1
-		for _, m := range retryDefine.FindAllStringIndex(s.run, -1) {
-			if !inComment(s.run, m[0]) {
-				def = m[0]
-				break
-			}
-		}
-		if def == -1 || def > call[0] {
+		def := firstRealMatch(retryDefine, s.run)
+		if def == -1 || def > call {
 			t.Errorf("%s: job %q step %q calls `retry` with no definition in scope before the call; "+
 				"each run block is its own shell, so a helper from an earlier step does not carry over",
 				s.workflow, s.job, s.name)
@@ -151,6 +169,57 @@ func TestRetryHelperIsInScope(t *testing.T) {
 
 // retryDefine matches a real function definition, not a mention of one.
 var retryDefine = regexp.MustCompile(`(?m)^\s*retry\s*\(\)\s*\{`)
+
+// cosignCall matches a cosign invocation, capturing whether it went through the
+// retry helper and which subcommand it runs.
+var cosignCall = regexp.MustCompile(`(?m)` + commandPosition + `\s*(retry\s+)?cosign\s+(\S+)`)
+
+// cosignLocal are the subcommands that reach no network, so a retry would buy
+// nothing. Everything else -- including an indirect `cosign "$@"` -- talks to
+// Rekor or the registry and must be retried.
+var cosignLocal = map[string]bool{
+	"version": true, "--version": true, "help": true, "--help": true,
+	"generate": true, "public-key": true, "env": true,
+}
+
+// TestCosignCallsAreRetried pins the coverage half of the defect class
+// TestRetryHelperIsInScope pins the scope half of. A helper that is in scope
+// still protects nothing if a call is written without it.
+//
+// Every cosign call reaches Rekor and GHCR, so a bare one fails on a single
+// 502. Inside the release gate that is worse than a wasted run: the calls after
+// `gh release edit --draft=false` execute with the release already public, so a
+// transient failure fires the retraction handler and pulls back a release that
+// passed every signature, SBOM, digest and provenance check -- reporting a
+// network blip as though the artifacts had been tampered with. That is how a
+// gate earns a reputation for crying wolf and starts getting overridden.
+//
+// The gate shipped five unretried calls: the provenance predicate, both chart
+// checks, and both public-channel checks.
+func TestCosignCallsAreRetried(t *testing.T) {
+	for _, s := range runSteps(t) {
+		for _, m := range cosignCall.FindAllStringSubmatchIndex(s.run, -1) {
+			// m[2] is the start of the optional `retry ` group; -1 means the
+			// call is bare. m[4]:m[5] is the subcommand.
+			if m[2] >= 0 || inComment(s.run, m[0]) || cosignLocal[s.run[m[4]:m[5]]] {
+				continue
+			}
+			t.Errorf("%s: job %q step %q invokes cosign without the retry helper: %q. "+
+				"cosign talks to Rekor and GHCR on every call, so an unretried one reports a "+
+				"transient outage as a verification failure",
+				s.workflow, s.job, s.name, snippet(s.run, m[0]))
+		}
+	}
+}
+
+// snippet returns a one-line excerpt starting at offset, for error messages.
+func snippet(body string, offset int) string {
+	end := strings.IndexByte(body[offset:], '\n')
+	if end < 0 {
+		end = len(body) - offset
+	}
+	return strings.TrimSpace(body[offset : offset+end])
+}
 
 // inComment reports whether the offset falls on a line whose first
 // non-whitespace character is `#`.

--- a/test/releasepolicy/shell_scope_test.go
+++ b/test/releasepolicy/shell_scope_test.go
@@ -174,12 +174,18 @@ var retryDefine = regexp.MustCompile(`(?m)^\s*retry\s*\(\)\s*\{`)
 // retry helper and which subcommand it runs.
 var cosignCall = regexp.MustCompile(`(?m)` + commandPosition + `\s*(retry\s+)?cosign\s+(\S+)`)
 
-// cosignLocal are the subcommands that reach no network, so a retry would buy
-// nothing. Everything else -- including an indirect `cosign "$@"` -- talks to
-// Rekor or the registry and must be retried.
+// cosignLocal are the subcommands that cannot reach a network under any flag,
+// so a retry would buy nothing. Everything else -- including an indirect
+// `cosign "$@"` -- can talk to Rekor, a registry or a KMS and must be retried.
+//
+// Kept to what is provably local rather than what merely looks local. An
+// earlier version also exempted `public-key`, which takes `--key` and will
+// fetch from a KMS provider, and `generate`, whose neighbours in the CLI do the
+// same. Nothing in this repository runs either; exempting them bought no
+// coverage and gave away the property the list exists to protect. A subcommand
+// earns a place here by being unable to make a request, not by being unused.
 var cosignLocal = map[string]bool{
 	"version": true, "--version": true, "help": true, "--help": true,
-	"generate": true, "public-key": true, "env": true,
 }
 
 // TestCosignCallsAreRetried pins the coverage half of the defect class

--- a/test/releasepolicy/shell_scope_test.go
+++ b/test/releasepolicy/shell_scope_test.go
@@ -128,19 +128,45 @@ var retryCall = regexp.MustCompile(`(?m)(^|\||&|;|\$\()\s*retry\s+\S`)
 // cross-step scope, so nothing else catches this.
 func TestRetryHelperIsInScope(t *testing.T) {
 	for _, s := range runSteps(t) {
-		if !retryCall.MatchString(s.run) {
+		call := retryCall.FindStringIndex(s.run)
+		if call == nil {
 			continue
 		}
-		if !strings.Contains(s.run, "retry()") {
-			t.Errorf("%s: job %q step %q calls `retry` but does not define it; "+
-				"each run block is its own shell, so a helper from an earlier step is not in scope",
+		// A definition inside a comment defines nothing, and one that appears
+		// after the first call is not in scope at that call.
+		def := -1
+		for _, m := range retryDefine.FindAllStringIndex(s.run, -1) {
+			if !inComment(s.run, m[0]) {
+				def = m[0]
+				break
+			}
+		}
+		if def == -1 || def > call[0] {
+			t.Errorf("%s: job %q step %q calls `retry` with no definition in scope before the call; "+
+				"each run block is its own shell, so a helper from an earlier step does not carry over",
 				s.workflow, s.job, s.name)
 		}
 	}
 }
 
-// varRef matches a ${NAME} expansion of an upper-case shell variable.
+// retryDefine matches a real function definition, not a mention of one.
+var retryDefine = regexp.MustCompile(`(?m)^\s*retry\s*\(\)\s*\{`)
+
+// inComment reports whether the offset falls on a line whose first
+// non-whitespace character is `#`.
+func inComment(body string, offset int) bool {
+	start := strings.LastIndexByte(body[:offset], '\n') + 1
+	return strings.HasPrefix(strings.TrimSpace(body[start:offset]), "#")
+}
+
+// varRef matches ${NAME}; bareVarRef matches the unbraced $NAME form, which
+// aborts under nounset exactly the same way.
 var varRef = regexp.MustCompile(`\$\{([A-Z][A-Z0-9_]*)\}`)
+var bareVarRef = regexp.MustCompile(`\$([A-Z][A-Z0-9_]*)`)
+
+// nounset matches the spellings that turn an unset name into an abort:
+// `set -u`, `set -eu`, `set -euo pipefail`, `set -o nounset`.
+var nounset = regexp.MustCompile(`set\s+(-[a-zA-Z]*u|-o\s+nounset)`)
 
 // assigned matches the forms that bring a name into scope within one script.
 var assigned = regexp.MustCompile(`(?m)^\s*(?:export\s+|local\s+|declare\s+)?([A-Z][A-Z0-9_]*)=`)
@@ -169,7 +195,7 @@ var runnerProvided = map[string]bool{
 // creating the release, skipping the gate entirely.
 func TestNoUnboundVariablesInRunBlocks(t *testing.T) {
 	for _, s := range runSteps(t) {
-		if !strings.Contains(s.run, "set -u") && !strings.Contains(s.run, "set -euo") {
+		if !nounset.MatchString(s.run) {
 			continue
 		}
 
@@ -181,7 +207,9 @@ func TestNoUnboundVariablesInRunBlocks(t *testing.T) {
 			inScope[m[1]] = true
 		}
 
-		for _, m := range varRef.FindAllStringSubmatch(s.run, -1) {
+		refs := varRef.FindAllStringSubmatch(s.run, -1)
+		refs = append(refs, bareVarRef.FindAllStringSubmatch(s.run, -1)...)
+		for _, m := range refs {
 			name := m[1]
 			switch {
 			case s.env[name], inScope[name], runnerProvided[name]:
@@ -189,7 +217,7 @@ func TestNoUnboundVariablesInRunBlocks(t *testing.T) {
 			case strings.HasPrefix(name, "GITHUB_"):
 				continue
 			}
-			t.Errorf("%s: job %q step %q reads ${%s} under `set -u`, but nothing puts it in scope; "+
+			t.Errorf("%s: job %q step %q reads variable %s under `set -u`, but nothing puts it in scope; "+
 				"add it to the step's env: or assign it in the script, or the step aborts rather than "+
 				"reading an empty value", s.workflow, s.job, s.name, name)
 		}
@@ -236,13 +264,15 @@ func TestFailureHandlersRunLast(t *testing.T) {
 				if !strings.Contains(s.If, "failure()") {
 					continue
 				}
+				// Any later step at all is a problem, not only an unconditional
+				// one: `if: always()` runs after a prior failure, so a later
+				// always() step that fails is equally beyond this handler's
+				// reach. The only safe position is last.
 				for _, later := range job.Steps[i+1:] {
-					if later.If == "" {
-						t.Errorf("%s: job %q step %q handles failure() but step %q runs after it "+
-							"unconditionally; a failure there is evaluated too late for this handler "+
-							"to fire, so it can never clean up after it",
-							base, jobName, s.Name, later.Name)
-					}
+					t.Errorf("%s: job %q step %q handles failure() but step %q runs after it; "+
+						"if:failure() is evaluated in declaration order, so a failure below this "+
+						"step comes too late for it to fire. A failure handler must be last.",
+						base, jobName, s.Name, later.Name)
 				}
 			}
 		}

--- a/test/releasepolicy/shell_scope_test.go
+++ b/test/releasepolicy/shell_scope_test.go
@@ -195,3 +195,56 @@ func TestNoUnboundVariablesInRunBlocks(t *testing.T) {
 		}
 	}
 }
+
+// TestFailureHandlersRunLast catches a cleanup step that cannot see the failure
+// it exists to clean up after.
+//
+// Steps run in declaration order, and `if: failure()` is evaluated in that
+// order too. A retract-on-failure step placed before the last verification step
+// has already been evaluated -- and skipped, because nothing had failed yet --
+// by the time that verification fails. It never fires, and the release stays
+// published with the run red: the exact state the draft exists to prevent.
+//
+// A failure handler is therefore only meaningful if every step after it is
+// itself conditional; an unconditional step below it is a failure it cannot
+// catch.
+func TestFailureHandlersRunLast(t *testing.T) {
+	for _, path := range workflowFiles(t) {
+		base := filepath.Base(path)
+		if !onReleasePath(base) {
+			continue
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		var doc struct {
+			Jobs map[string]struct {
+				Steps []struct {
+					Name string `json:"name"`
+					If   string `json:"if"`
+				} `json:"steps"`
+			} `json:"jobs"`
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for jobName, job := range doc.Jobs {
+			for i, s := range job.Steps {
+				if !strings.Contains(s.If, "failure()") {
+					continue
+				}
+				for _, later := range job.Steps[i+1:] {
+					if later.If == "" {
+						t.Errorf("%s: job %q step %q handles failure() but step %q runs after it "+
+							"unconditionally; a failure there is evaluated too late for this handler "+
+							"to fire, so it can never clean up after it",
+							base, jobName, s.Name, later.Name)
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/releasepolicy/workflow_graph_test.go
+++ b/test/releasepolicy/workflow_graph_test.go
@@ -166,13 +166,6 @@ func TestJobOutputReferencesResolve(t *testing.T) {
 // `|`, so an interpolated value is executed rather than read. Values must cross
 // into a shell through `env:`.
 func TestNoExpressionInterpolationInRunBlocks(t *testing.T) {
-	releasePath := map[string]bool{
-		"release.yml":     true,
-		"publish.yml":     true,
-		"attest.yml":      true,
-		"build-image.yml": true,
-	}
-
 	paths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
 	if err != nil {
 		t.Fatalf("glob workflows: %v", err)
@@ -189,7 +182,9 @@ func TestNoExpressionInterpolationInRunBlocks(t *testing.T) {
 
 	for _, p := range paths {
 		base := filepath.Base(p)
-		if !releasePath[base] {
+		// attest-selftest.yml has no run blocks worth scanning here, but the
+		// interpolation rule applies to every file that reaches the signer.
+		if !onReleasePath(base) {
 			continue
 		}
 		raw, err := os.ReadFile(p)
@@ -253,9 +248,7 @@ func workflowCallOutputs(raw []byte, t *testing.T) map[string]any {
 // can diverge, so it would pass on an artifact whose registry attestation is
 // gone while a consumer using cosign gets nothing.
 func TestVerificationUsesExactIdentity(t *testing.T) {
-	releasePath := []string{"release.yml", "publish.yml", "attest.yml", "build-image.yml", "attest-selftest.yml"}
-
-	for _, base := range releasePath {
+	for _, base := range releasePathWorkflows {
 		raw, err := os.ReadFile(filepath.Join(workflowDir, base))
 		if err != nil {
 			t.Fatalf("read %s: %v", base, err)

--- a/test/releasepolicy/workflow_graph_test.go
+++ b/test/releasepolicy/workflow_graph_test.go
@@ -237,6 +237,53 @@ func workflowCallOutputs(raw []byte, t *testing.T) map[string]any {
 	return nil
 }
 
+// TestVerificationUsesExactIdentity pins two habits that would each weaken
+// verification silently.
+//
+// `--certificate-identity-regexp` is how the pre-epic SECURITY.md command
+// accepted a main-branch build as a release: a pattern naming no workflow and no
+// ref answers a weaker question than it appears to, and the weakening is
+// invisible to whoever copies it. The command we publish is as much a part of
+// the release path as the workflow that signs, so the published instructions are
+// covered too — see TestPublishedVerifyCommandsAreExact.
+//
+// A bare `gh attestation verify` reads GitHub's Attestations API rather than the
+// registry. `cosign attest` writes only to the registry, so the bare form would
+// verify a copy that does not exist here — and where both copies do exist they
+// can diverge, so it would pass on an artifact whose registry attestation is
+// gone while a consumer using cosign gets nothing.
+func TestVerificationUsesExactIdentity(t *testing.T) {
+	releasePath := []string{"release.yml", "publish.yml", "attest.yml", "build-image.yml", "attest-selftest.yml"}
+
+	for _, base := range releasePath {
+		raw, err := os.ReadFile(filepath.Join(workflowDir, base))
+		if err != nil {
+			t.Fatalf("read %s: %v", base, err)
+		}
+		body := string(raw)
+
+		for i, line := range strings.Split(body, "\n") {
+			trimmed := strings.TrimSpace(line)
+			// Comments may name these forms in order to warn against them.
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if strings.Contains(line, "certificate-identity-regexp") {
+				t.Errorf("%s:%d uses --certificate-identity-regexp; use the exact "+
+					"--certificate-identity, which names the workflow and the ref", base, i+1)
+			}
+			// Scoped to the line, not the file. Searching `body` would let one
+			// compliant usage anywhere -- including inside a comment -- disarm
+			// the check for every other occurrence in that file, so the test
+			// would go green on exactly the silent weakening it exists to catch.
+			if strings.Contains(line, "gh attestation verify") && !strings.Contains(line, "--bundle-from-oci") {
+				t.Errorf("%s:%d uses a bare `gh attestation verify`; add --bundle-from-oci so it "+
+					"reads the registry copy rather than the GitHub Attestations API", base, i+1)
+			}
+		}
+	}
+}
+
 func sortedKeys(m map[string]string) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
@@ -244,4 +291,44 @@ func sortedKeys(m map[string]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// TestPublishedVerifyCommandsAreExact covers the surface the original defect
+// actually shipped on: the instructions users copy.
+//
+// ADR-074 records that the pre-epic SECURITY.md command told users to pass
+// `--certificate-identity-regexp`, which accepts a `main` build as a release.
+// Fixing the workflows does not fix that; the published command is its own
+// contract, and a weakened one converts an unverified install into a falsely
+// verified one.
+//
+// Prose is allowed to name the flag — SECURITY.md warns against it by name, and
+// a test that forbade the warning would be worse than no test. Only fenced
+// command blocks are checked.
+func TestPublishedVerifyCommandsAreExact(t *testing.T) {
+	docs := []string{"../../SECURITY.md", "../../README.md", "../../RELEASE.md"}
+
+	for _, path := range docs {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		inFence := false
+		for i, line := range strings.Split(string(raw), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "```") {
+				inFence = !inFence
+				continue
+			}
+			if inFence && strings.Contains(line, "certificate-identity-regexp") {
+				t.Errorf("%s:%d publishes a command using --certificate-identity-regexp; "+
+					"an identity naming no workflow and no ref also accepts a branch build, "+
+					"so a user following it accepts a development image as a release",
+					filepath.Base(path), i+1)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

The only post-publish check verified SHA-256 sums and a version string. Every signing step this epic added could have silently no-opped — wrong permissions, an expired OIDC token, a renamed cosign flag — and the release would still have gone out green. Producing attestations without checking them means the first party to discover they are broken is a user.

The GitHub Release is now created as a **draft** and made visible only after a gate verifies what it advertises:

- every release asset against its Sigstore bundle, and each binary against the bundle binding its SBOM to it
- `checksums.txt` against the downloaded assets
- the image index signature and provenance, and both per-platform SBOMs
- that `manager:<tag>` still resolves to the index digest that was verified
- the provenance **predicate body** — repository, ref, commit — not just the signature
- the chart's signature and provenance

Registry artifacts are necessarily already pushed by that point; the gate verifies them and fails the run, and `RELEASE.md` now states plainly what the draft does *not* hold back.

Verification runs authenticated because a draft is not reachable otherwise. The release is then published and the assets are re-fetched **anonymously** — the channel a user actually takes — and checked again. If anything fails after publication, the release is returned to draft.

## Related Issue

Part of #270 — deliberately **not** `Closes`. `release.yml` runs only on a tag, so the gate has not executed.

## Type of Change
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation / CI
- [x] CLI (nvcrectl) — installer prerelease resolution

## Testing

- The gate's image block was **rehearsed against a real attested image** (`manager:main-ce70f5f`, published by #269's pipeline): index signature, index provenance and both per-platform SBOMs verify, and the predicate's `repository`, `ref` and `gitCommit` resolve at the paths the gate reads. This is the one part of the gate that could be exercised without a tag, and it is the part that encodes the most assumptions about artifact shape.
- **`TestPredicateCheckToleratesDuplicateAttestations`** (new) extracts the predicate step's shell from `release.yml` and runs it against stub cosign output — one envelope, two identical envelopes, two disagreeing, wrong repo, wrong ref, none. Mutation-tested: reintroducing the single-payload parser fails three cases.
- **`TestPublishedVerifyCommandsAreExact`** (new) covers the surface the original defect actually shipped on — the commands users copy — while still allowing prose to name the flag, since `SECURITY.md` warns against it by name.
- `actionlint` clean on all four release-path workflows, `make verify`, `make lint` (0 issues), `make test` green.

### Self-review findings

Five persona screens. Nineteen raw findings, thirteen after reconciliation. The two worst were each found independently by **three** screens.

**Duplicate attestations would have failed every affected release** (MAJOR). `attest.yml` documents that an attempt killed after its registry push and Rekor entry landed publishes a second valid attestation, and states that any consumer "must tolerate more than one attestation per digest and must not treat a duplicate as tampering." This gate is that consumer and did neither: it read cosign's output into one variable, so the statements concatenated and every scalar comparison saw a multi-line value. A correct release would have failed with a tampering-shaped error and stranded as an invisible draft. Reproduced, fixed, and now covered by a regression test.

**`draft: true` is ignored when the release already exists** (MAJOR). softprops/action-gh-release honours the input only on creation; on the update path it passes `draft: existingRelease.draft` (verified in the pinned source). Re-running against an already-published tag — the recovery path `RELEASE.md` documents — would upload freshly built, unverified assets straight into a live release, and `--draft=false` would be a no-op. Now fails closed unless the release is a draft.

**The release was published before the public re-check, with nothing to retract it** (MAJOR). A failure there left the release visible with the run red — the exact state the draft exists to prevent. Added an `if: failure()` retraction.

**No retry on ~30 network calls, and outages reported as verification failures** (MAJOR). `attest.yml` wraps its cosign calls in a bounded retry and says why; the gate reintroduced the same fan-out with none, and worded every failure as `does not verify`. That is how a gate gets routinely overridden. Bounded retry added.

**`RELEASE.md` described the step this PR deletes** (MAJOR) — and two of the four checks it named were left performed by nothing, including the `checksums.txt` verification. Restored the check and rewrote the section, plus the draft lifecycle and a troubleshooting entry stating that a draft left by a failed gate must never be published by hand.

The rest:

- **The tag was never bound to the verified digest** — every image check was digest-addressed, but the chart deploys `manager:<tag>`, so a repointed tag passed a fully green gate. The gate now resolves the tag and compares.
- **A dead `Record advertised digests` step** whose comment asserted a trust property the job graph did not implement (`create-github-release` declares no `outputs:`). Deleted.
- **The `--bundle-from-oci` guard was scoped to the file, not the line**, so one compliant mention — even in a comment — disarmed it for the whole file. The original mutation test only exercised the case it did handle.
- **The predicate step's own error message was unreachable**: `2>/dev/null` plus `set -e` meant the step exited before it could print, and nothing reached `verify.log`.
- **The public re-check downloaded the binary and never verified it**, so it reported the channel good having checked only the installer.
- **`installer -p` resolved drafts** — `gh release list` includes them, so anyone with repo access would install the build the gate had refused. `--exclude-drafts` added.
- **`SECURITY.md` still presented checksums as the binary verification story**, pointing users at the mechanism the release notes themselves disclaim.

Two things I'd rather record than gloss: the gate's first draft violated two rules this epic established — it interpolated `${{ }}` inside run blocks, caught by the test added in #269, and used `cmd && echo ok || err`, where the error branch also runs when the echo fails. And a gate built to catch silent no-ops shipped, in its first draft, a step whose comment claimed a property the graph did not implement.

## What is not proven

The gate has not executed. `release.yml` runs only on a release tag. **#270 stays open** until a release exercises it.

An `-rc` tag after this merges would exercise the gate together with #267, #268 and #269 in one run. `v0.2.0-rc.N` clears all three tag validators and is marked as a prerelease automatically.

- [x] Tests pass locally
- [x] Manual testing completed — see above
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated — `RELEASE.md`, `SECURITY.md`
- [x] Ready for review
