### PR TITLE
ci: make the installer verify what it installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/
 
 The installer places `nvcrectl` on your `$PATH` and creates a `kubectl-nvcre` symlink so the CLI is also available as `kubectl nvcre`.
 
+It verifies the binary it downloads against that release's Sigstore bundle before installing
+it, using `cosign` if you have it and fetching a digest-pinned copy if you do not. If it
+cannot verify, it stops rather than installing — pass `--skip-verify` to override that
+deliberately. Releases before `v0.2.0` carry no bundles.
+
+Piping to `bash` gets you TLS integrity in transit and nothing more: the script runs before
+anything has checked the script itself. To verify what you are about to run, download it and
+check its bundle first — see [SECURITY.md](SECURITY.md#supply-chain).
+
 **2. Set up the cluster**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The installer places `nvcrectl` on your `$PATH` and creates a `kubectl-nvcre` sy
 It verifies the binary it downloads against that release's Sigstore bundle before installing
 it, using `cosign` if you have it and fetching a digest-pinned copy if you do not. If it
 cannot verify, it stops rather than installing — pass `--skip-verify` to override that
-deliberately. Releases before `v0.2.0` carry no bundles.
+deliberately. Releases before `v0.2.0-rc.1` carry no bundles.
 
 Piping to `bash` gets you TLS integrity in transit and nothing more: the script runs before
 anything has checked the script itself. To verify what you are about to run, download it and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -134,14 +134,27 @@ Only then is the release published, after which the assets are re-fetched anonym
 and re-verified over the channel a user actually takes. If anything fails after
 publication, the release is returned to draft.
 
-To verify manually:
+To verify manually, check the signature — not the checksum:
 
 ```bash
-VERSION=v0.1.0
-curl -fsSLO "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${VERSION}/checksums.txt"
-curl -fsSLO "https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${VERSION}/nvcrectl-linux-amd64"
-sha256sum --check --ignore-missing checksums.txt
+VERSION=v0.2.0-rc.1
+BASE="https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${VERSION}"
+curl -fsSLO "${BASE}/nvcrectl-linux-amd64"
+curl -fsSLO "${BASE}/nvcrectl-linux-amd64.sigstore.json"
+
+cosign verify-blob-attestation \
+  --bundle nvcrectl-linux-amd64.sigstore.json \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  nvcrectl-linux-amd64
 ```
+
+`checksums.txt` is still published and `installer` still checks it, but do not mistake it
+for this. It is served from the same origin as the binary and is itself unsigned, so
+whoever can replace one can replace the other in the same write: it detects corruption,
+not tampering. See [SECURITY.md](SECURITY.md#supply-chain) for the image, chart and
+installer equivalents.
 
 Releases up to and including `v0.1.0-rc.7` predate the checksum step and carry no
 `checksums.txt`.
@@ -186,6 +199,16 @@ fails when the tag already has a *published* release. That is deliberate: the ac
 that creates the release honours `draft:` only on creation, so re-running against a
 published tag would upload freshly built, unverified assets into a live release. Cut the
 next patch version instead.
+
+**`installer` refused: "Signature verification failed".** It checks the binary against
+that release's Sigstore bundle and will not install one it cannot verify. Read the cosign
+output printed above the error — it distinguishes a genuine identity or signature mismatch
+from verification that could not complete, such as Rekor being unreachable. A mismatch on
+a release you cut is worth investigating before anything else.
+
+**`installer` refused: "Could not download &lt;asset&gt;.sigstore.json".** That release
+carries no bundles; anything before `v0.2.0-rc.1` predates them. Install a newer release,
+or pass `--skip-verify` if you accept installing something nothing has vouched for.
 
 **The Helm push failed on `check-clean-version`.** The tag was not clean. Delete the tag
 if nothing published, commit your work, and tag again.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,6 +103,28 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
 
   `checksums.txt` is also published, but it is served from the same origin as the assets and is itself unsigned, so it detects corruption rather than tampering. Verify the bundle, not the checksum.
 
+- **`installer` verifies what it installs, and cannot verify itself.** From `v0.2.0` the installer checks the binary it downloads against that release's `.sigstore.json` under the identity above, using `cosign` if present and otherwise fetching a copy pinned by digest inside the script. If it cannot verify, it stops. `--skip-verify` overrides that, and is never inferred from a missing tool or a failed download — verification is skipped only when someone asks for it by name.
+
+  That hardens what the installer *installs*. It does nothing for the installer itself: under `curl … | bash` the script executes before anything has checked it, and whoever could replace that asset could delete the verification logic and its pinned digest in the same write. The pipe buys TLS integrity in transit and nothing against a compromised release asset.
+
+  The verified path puts the trust anchor outside the script:
+
+  ```bash
+  TAG=v1.2.3
+  BASE="https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${TAG}"
+  curl -fsSLO "${BASE}/installer"
+  curl -fsSLO "${BASE}/installer.sigstore.json"
+
+  cosign verify-blob-attestation \
+    --bundle installer.sigstore.json \
+    --type https://slsa.dev/provenance/v1 \
+    --certificate-identity "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}" \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    installer
+
+  bash installer -v "${TAG}"
+  ```
+
 ## Product Security Resources
 
 For all security-related concerns: https://www.nvidia.com/en-us/security

--- a/installer
+++ b/installer
@@ -509,10 +509,16 @@ fetchReleaseAsset() {
     [[ -n "${url}" ]] || return 1
     curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
       -H "Accept: application/octet-stream" -o "${dest}" "${url}" 2>/dev/null || return 1
+    [[ -s "${dest}" ]] || return 1
     return 0
   fi
 
+  # All three branches report success only for a file that actually arrived. An
+  # empty 200 body would otherwise reach cosign and be reported as a signature
+  # failure, which sends the reader looking for tampering rather than for the
+  # download problem they actually have.
   curl -fsSL -o "${dest}" "${GH_RELEASE_URL}/${VERSION}/${name}" 2>/dev/null || return 1
+  [[ -s "${dest}" ]] || return 1
 }
 
 # resolveCosign prints a usable cosign path on stdout. Progress and diagnostics
@@ -535,7 +541,15 @@ resolveCosign() {
     return 1
   fi
 
-  chmod +x "${dest}"
+  chmod +x "${dest}" || return 1
+
+  # chmod succeeds on a noexec mount -- the kernel blocks exec(), not chmod() --
+  # and TEMP_DIR lives wherever mktemp resolves, which is /tmp on hosts that
+  # commonly mount it noexec. Prove it runs here, so an unrunnable cosign is
+  # reported as a local problem instead of surfacing later as a failed
+  # signature, which reads as tampering.
+  "${dest}" version >/dev/null 2>&1 || return 1
+
   echo "${dest}"
 }
 
@@ -546,20 +560,26 @@ else
 
   BUNDLE="${BINARY_NAME}.sigstore.json"
   if ! fetchReleaseAsset "${BUNDLE}" "${TEMP_DIR}/${BUNDLE}"; then
-    err "Could not download ${BUNDLE} for ${VERSION}, so the download cannot be verified. Releases before v0.2.0 carry no bundles — install one of those with --skip-verify if you accept that, or pick a newer release."
+    err "Could not download ${BUNDLE} for ${VERSION}, so the download cannot be verified. Releases before v0.2.0-rc.1 carry no bundles — install one of those with --skip-verify if you accept that, or pick a newer release."
   fi
 
   if ! COSIGN_BIN="$(resolveCosign)"; then
-    err "cosign is required to verify the download and could not be obtained for ${OS}-${ARCH}. Install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or re-run with --skip-verify to install without verification."
+    err "cosign is required to verify the download and could not be obtained or run for ${OS}-${ARCH} (a noexec temp directory will also land here). Install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or re-run with --skip-verify to install without verification."
   fi
 
+  # cosign's own output is kept and printed on failure. Every failure otherwise
+  # reads identically -- bad signature, expired certificate, Rekor being
+  # unreachable, a malformed bundle -- and an outage that looks like tampering
+  # is how people learn to ignore this check.
+  VERIFY_LOG="${TEMP_DIR}/cosign-verify.log"
   if ! "${COSIGN_BIN}" verify-blob-attestation \
       --bundle "${TEMP_DIR}/${BUNDLE}" \
       --type "https://slsa.dev/provenance/v1" \
       --certificate-identity "${SIGSTORE_IDENTITY_PREFIX}/${VERSION}" \
       --certificate-oidc-issuer "${SIGSTORE_ISSUER}" \
-      "${TEMP_DIR}/${BINARY_NAME}" >/dev/null 2>&1; then
-    err "Signature verification failed for ${BINARY_NAME} ${VERSION}. This binary is not what ${GH_REPO} published for that tag — not installing it."
+      "${TEMP_DIR}/${BINARY_NAME}" >"${VERIFY_LOG}" 2>&1; then
+    sed 's/^/    /' "${VERIFY_LOG}" >&2 || true
+    err "Signature verification failed for ${BINARY_NAME} ${VERSION}. Either this is not what ${GH_REPO} published for that tag, or verification could not complete — the cosign output above says which. Not installing it."
   fi
 
   ok "Signature verified."

--- a/installer
+++ b/installer
@@ -25,6 +25,32 @@ GH_RELEASE_URL="https://github.com/${GH_REPO}/releases/download"
 BIN_NAME="nvcrectl"
 INSTALL_DIR="/usr/local/bin"
 
+# Signature verification. Every release asset ships a detached Sigstore bundle,
+# signed by one reusable workflow, so there is exactly one identity to pin. It
+# names the workflow AND the tag: an identity that names neither also accepts a
+# branch build, which is how an unreleased image could pass for a release.
+SIGSTORE_ISSUER="https://token.actions.githubusercontent.com"
+SIGSTORE_IDENTITY_PREFIX="https://github.com/${GH_REPO}/.github/workflows/attest.yml@refs/tags"
+
+# cosign is bootstrapped when absent, and the download is checked against a
+# digest pinned here. Pinning the version alone would leave the bytes to
+# whatever that tag currently serves, which is the same trust gap this script
+# exists to close -- verifying a release with an unverified verifier proves
+# nothing. Refresh both together; the digests are cosign's own
+# cosign_checksums.txt for the release.
+COSIGN_VERSION="v3.1.3"
+COSIGN_BASE_URL="https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}"
+
+cosignDigest() {
+  case "$1" in
+    linux-amd64)  echo "4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71" ;;
+    linux-arm64)  echo "c5d324e091826b0d7a78eb16fef316450b4eb9aaec045611c08ba06f5e73220a" ;;
+    darwin-amd64) echo "2347488e5d5b25336644024dfeca5601b190e91197a71a917bda44744aff106c" ;;
+    darwin-arm64) echo "5cf948c2f4dfe59687bdd0b8523709067383e03982cc543475c8a7dc70e92a76" ;;
+    *) return 1 ;;
+  esac
+}
+
 # Colors
 COLOR_RED='\033[0;31m'
 COLOR_GREEN='\033[0;32m'
@@ -38,14 +64,31 @@ usage() {
   cat <<EOF
 Install / upgrade ${BIN_NAME}
 
-Usage: $0 [-d install_dir] [-p] [-v version]
+Usage: $0 [-d install_dir] [-p] [-v version] [--skip-verify]
 
 Options:
-  -d DIR    Installation directory (default: /usr/local/bin)
-  -p        Include pre-release versions
-  -v TAG    Install this exact release tag (e.g. v0.1.0)
+  -d DIR         Installation directory (default: /usr/local/bin)
+  -p             Include pre-release versions
+  -v TAG         Install this exact release tag (e.g. v0.1.0)
+  --skip-verify  Install without verifying the release signature.
+                 Not a fallback: verification is skipped only when you ask.
+
+The download is verified against its Sigstore bundle. cosign is used if present
+and downloaded against a pinned digest if not. If neither is possible the
+install stops rather than continuing unverified.
 EOF
   exit 1
+}
+
+# sha256Of prints the SHA-256 of a file, using whichever tool this OS ships.
+sha256Of() {
+  if command -v sha256sum &>/dev/null; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum &>/dev/null; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
 }
 
 err() {
@@ -86,6 +129,20 @@ getArch() {
 
 PRERELEASE=false
 VERSION=""
+SKIP_VERIFY=false
+
+# getopts handles short flags only, so --skip-verify is removed from the
+# argument list first. It is spelled long deliberately: turning off signature
+# verification should be something someone typed out, not a letter picked up
+# from a copied command line.
+ARGS=()
+for arg in "$@"; do
+  case "${arg}" in
+    --skip-verify) SKIP_VERIFY=true ;;
+    *) ARGS+=("${arg}") ;;
+  esac
+done
+set -- "${ARGS[@]+"${ARGS[@]}"}"
 
 while getopts "d:pv:" opt; do
   case ${opt} in
@@ -417,6 +474,96 @@ if ! (cd "${TEMP_DIR}" && "${SHA256_CHECK[@]}" checksums.txt); then
 fi
 
 ok "Checksum verified."
+
+# ---------------------------------------------------------------------------
+# Verify the signature
+# ---------------------------------------------------------------------------
+# The checksum above is served from the same origin as the binary and is itself
+# unsigned, so whoever can replace the binary can replace its checksum line in
+# the same write. It catches corruption, not tampering. The signature is the
+# check that means anything, so this fails closed: an unverifiable download is
+# not installed.
+#
+# What this cannot do is authenticate `installer` itself. Under `curl | bash`
+# the script has already executed before anything checked it, and an adversary
+# who can replace this asset can delete these lines and the pinned digest with
+# it. The trust anchor has to sit outside the script -- see SECURITY.md for the
+# download-verify-run path.
+
+fetchReleaseAsset() {
+  local name="$1" dest="$2"
+
+  if [[ "${GH_AVAILABLE}" == "true" ]]; then
+    gh release download "${VERSION}" --repo "${GH_REPO}" \
+      --pattern "${name}" --dir "$(dirname "${dest}")" 2>/dev/null || return 1
+    [[ -s "${dest}" ]] || return 1
+    return 0
+  fi
+
+  if [[ -n "${GH_TOKEN}" ]]; then
+    local url
+    url=$(echo "${RELEASE_JSON:-}" | tr -d '\n' | tr '{' '\n' \
+      | grep "\"name\" *: *\"${name//./\\.}\"" \
+      | grep -o '"url" *: *"https://api\.github\.com[^"]*releases/assets/[0-9]*"' \
+      | head -1 | sed 's/.*"\(https[^"]*\)".*/\1/' || true)
+    [[ -n "${url}" ]] || return 1
+    curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/octet-stream" -o "${dest}" "${url}" 2>/dev/null || return 1
+    return 0
+  fi
+
+  curl -fsSL -o "${dest}" "${GH_RELEASE_URL}/${VERSION}/${name}" 2>/dev/null || return 1
+}
+
+# resolveCosign prints a usable cosign path on stdout. Progress and diagnostics
+# go to stderr so they cannot be captured as the path.
+resolveCosign() {
+  if command -v cosign &>/dev/null; then
+    command -v cosign
+    return 0
+  fi
+
+  local key="${OS}-${ARCH}" want got dest="${TEMP_DIR}/cosign"
+  want="$(cosignDigest "${key}")" || return 1
+
+  msg "cosign not found; fetching pinned ${COSIGN_VERSION} for ${key}..." >&2
+  curl -fsSL -o "${dest}" "${COSIGN_BASE_URL}/cosign-${key}" 2>/dev/null || return 1
+
+  got="$(sha256Of "${dest}")" || return 1
+  if [[ "${got}" != "${want}" ]]; then
+    echo "downloaded cosign digest ${got} does not match the pinned ${want}" >&2
+    return 1
+  fi
+
+  chmod +x "${dest}"
+  echo "${dest}"
+}
+
+if [[ "${SKIP_VERIFY}" == "true" ]]; then
+  printf "${COLOR_RED}!${COLOR_RESET} Signature verification skipped (--skip-verify). Nothing has proven this binary came from %s.\n" "${GH_REPO}"
+else
+  msg "Verifying signature..."
+
+  BUNDLE="${BINARY_NAME}.sigstore.json"
+  if ! fetchReleaseAsset "${BUNDLE}" "${TEMP_DIR}/${BUNDLE}"; then
+    err "Could not download ${BUNDLE} for ${VERSION}, so the download cannot be verified. Releases before v0.2.0 carry no bundles — install one of those with --skip-verify if you accept that, or pick a newer release."
+  fi
+
+  if ! COSIGN_BIN="$(resolveCosign)"; then
+    err "cosign is required to verify the download and could not be obtained for ${OS}-${ARCH}. Install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or re-run with --skip-verify to install without verification."
+  fi
+
+  if ! "${COSIGN_BIN}" verify-blob-attestation \
+      --bundle "${TEMP_DIR}/${BUNDLE}" \
+      --type "https://slsa.dev/provenance/v1" \
+      --certificate-identity "${SIGSTORE_IDENTITY_PREFIX}/${VERSION}" \
+      --certificate-oidc-issuer "${SIGSTORE_ISSUER}" \
+      "${TEMP_DIR}/${BINARY_NAME}" >/dev/null 2>&1; then
+    err "Signature verification failed for ${BINARY_NAME} ${VERSION}. This binary is not what ${GH_REPO} published for that tag — not installing it."
+  fi
+
+  ok "Signature verified."
+fi
 
 # ---------------------------------------------------------------------------
 # Install / upgrade binary + kubectl plugin symlink

--- a/test/releasepolicy/installer_verify_test.go
+++ b/test/releasepolicy/installer_verify_test.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// verifyBlock returns the installer's signature-verification decision, from the
+// `--skip-verify` branch to the end of the block.
+//
+// Extracted from the real script rather than copied. This covers the decision --
+// when to verify, when to refuse, when to proceed -- and deliberately not
+// `fetchReleaseAsset` or `resolveCosign`, which are stubbed below because they
+// need the network. Those two are exercised end-to-end against a real release
+// instead; what is pinned here is that no path reaches an install without
+// either a verified signature or someone having typed --skip-verify.
+func verifyBlock(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(installerPath)
+	if err != nil {
+		t.Fatalf("read installer: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, `if [[ "${SKIP_VERIFY}" == "true" ]]; then`) {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatal("could not find the signature-verification block in installer; " +
+			"if it was renamed or removed, update this test rather than deleting it")
+	}
+	for i := start; i < len(lines); i++ {
+		if lines[i] == "fi" {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatal("could not find the end of the signature-verification block")
+	return ""
+}
+
+// verifyHarness supplies the variables and commands the block reads. Every
+// external dependency is a stub whose behaviour the cases control.
+const verifyHarness = `
+set -uo pipefail
+err() { echo "REFUSED: $*"; exit 9; }
+msg() { :; }
+ok()  { echo "VERIFIED"; }
+COLOR_RED='' ; COLOR_RESET=''
+
+SKIP_VERIFY=%s
+VERSION="v0.2.0-rc.1"
+GH_REPO="NVIDIA/cluster-readiness-engine"
+BINARY_NAME="nvcrectl-linux-amd64"
+TEMP_DIR="$(mktemp -d)"
+OS=linux ; ARCH=amd64
+SIGSTORE_ISSUER="https://token.actions.githubusercontent.com"
+SIGSTORE_IDENTITY_PREFIX="https://github.com/${GH_REPO}/.github/workflows/attest.yml@refs/tags"
+
+fetchReleaseAsset() { return %d; }
+resolveCosign()     { [ %d -eq 0 ] && echo "stub-cosign" ; return %d; }
+stub-cosign()       { return %d; }
+
+# The block calls cosign through "${COSIGN_BIN}", so route that to the stub.
+stub_cosign_wrapper() { return %d; }
+
+%s
+
+echo "PROCEEDED"
+`
+
+type verifyCase struct {
+	name       string
+	skipVerify bool
+	fetchRC    int // 0 = bundle downloaded
+	cosignRC   int // 0 = cosign available
+	verifyRC   int // 0 = signature verifies
+	wantRefuse bool
+	wantVerify bool // the ok "Signature verified." path ran
+}
+
+func runVerify(t *testing.T, block string, c verifyCase) (string, bool) {
+	t.Helper()
+
+	skip := "false"
+	if c.skipVerify {
+		skip = "true"
+	}
+	script := fmt.Sprintf(verifyHarness, skip,
+		c.fetchRC, c.cosignRC, c.cosignRC, c.verifyRC, c.verifyRC, block)
+
+	path := filepath.Join(t.TempDir(), "verify.sh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write harness: %v", err)
+	}
+	// A malformed extraction exits non-zero, which is indistinguishable from a
+	// refusal and would pass every refusal case for the wrong reason.
+	if out, err := exec.Command("bash", "-n", path).CombinedOutput(); err != nil {
+		t.Fatalf("extracted block is not valid shell: %v\n%s", err, out)
+	}
+
+	out, err := exec.Command("bash", path).CombinedOutput()
+	return strings.TrimSpace(string(out)), err != nil
+}
+
+// TestInstallerVerifiesOrRefuses pins the property the installer exists to
+// provide: it does not install a binary whose signature it could not check.
+//
+// checksums.txt is served from the same origin as the binary and is itself
+// unsigned, so it detects corruption rather than tampering. The signature is
+// the check that means anything, which is why every failure below refuses
+// rather than falling back to the checksum -- a silent downgrade to a check
+// that proves nothing is worse than no check, because it reads as verified.
+func TestInstallerVerifiesOrRefuses(t *testing.T) {
+	block := verifyBlock(t)
+
+	cases := []verifyCase{
+		{
+			name:       "signature verifies",
+			wantVerify: true,
+		},
+		{
+			// A release older than the attestation work carries no bundle. That
+			// is not a reason to install it unverified.
+			name:       "bundle cannot be downloaded",
+			fetchRC:    1,
+			wantRefuse: true,
+		},
+		{
+			// The bare-machine case. Missing cosign must never be read as
+			// permission to skip -- that is the inference --skip-verify exists
+			// to make explicit.
+			name:       "cosign unavailable and cannot be bootstrapped",
+			cosignRC:   1,
+			wantRefuse: true,
+		},
+		{
+			name:       "signature does not verify",
+			verifyRC:   1,
+			wantRefuse: true,
+		},
+		{
+			name:       "operator asked to skip",
+			skipVerify: true,
+		},
+		{
+			// Skipping is a decision about this run, not a repair of a broken
+			// release: it must not depend on anything being fetchable.
+			name:       "operator asked to skip and nothing is fetchable",
+			skipVerify: true,
+			fetchRC:    1,
+			cosignRC:   1,
+			verifyRC:   1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, failed := runVerify(t, block, c)
+
+			if c.wantRefuse {
+				if !failed {
+					t.Errorf("installer continued to install; it must refuse\noutput: %s", out)
+				}
+				if strings.Contains(out, "VERIFIED") {
+					t.Errorf("installer reported the signature verified on a failure path\noutput: %s", out)
+				}
+				return
+			}
+			if failed {
+				t.Fatalf("installer refused but should have continued\noutput: %s", out)
+			}
+			if !strings.Contains(out, "PROCEEDED") {
+				t.Errorf("installer did not reach the install step\noutput: %s", out)
+			}
+			if got := strings.Contains(out, "VERIFIED"); got != c.wantVerify {
+				t.Errorf("verified-path ran = %v, want %v\noutput: %s", got, c.wantVerify, out)
+			}
+		})
+	}
+}
+
+// TestInstallerSkipVerifyIsExplicit pins that skipping is spelled out rather
+// than inferred. The flag is long on purpose: a single letter is the kind of
+// thing that gets copied out of an unrelated command line.
+func TestInstallerSkipVerifyIsExplicit(t *testing.T) {
+	raw, err := os.ReadFile(installerPath)
+	if err != nil {
+		t.Fatalf("read installer: %v", err)
+	}
+	body := string(raw)
+
+	if !strings.Contains(body, "--skip-verify") {
+		t.Error("installer has no --skip-verify flag; verification must be skippable only on request")
+	}
+	if strings.Contains(body, `SKIP_VERIFY=true`+"\n") && !strings.Contains(body, `--skip-verify) SKIP_VERIFY=true`) {
+		t.Error("SKIP_VERIFY is set somewhere other than the --skip-verify flag; " +
+			"it must never be inferred from a missing tool or a failed download")
+	}
+	// getopts handles short flags only. A single-letter form would mean the
+	// long flag is decorative.
+	if strings.Contains(body, `getopts "d:pv:s"`) || strings.Contains(body, `getopts "d:psv:"`) {
+		t.Error("skip-verify has a short-flag form; it must be long-only")
+	}
+}

--- a/test/releasepolicy/installer_verify_test.go
+++ b/test/releasepolicy/installer_verify_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -18,9 +19,18 @@ import (
 // Extracted from the real script rather than copied. This covers the decision --
 // when to verify, when to refuse, when to proceed -- and deliberately not
 // `fetchReleaseAsset` or `resolveCosign`, which are stubbed below because they
-// need the network. Those two are exercised end-to-end against a real release
-// instead; what is pinned here is that no path reaches an install without
-// either a verified signature or someone having typed --skip-verify.
+// need the network.
+//
+// Those two have **no automated coverage**. They were exercised by hand against
+// v0.2.0-rc.1 when this landed, which is not the same thing and will not catch a
+// regression: a change to the asset-name escaping, to `gh release download
+// --pattern`, or to the bootstrap digest check would ship without failing a
+// test. Adding that coverage needs either a local asset server or a live
+// release, and is worth doing.
+//
+// What is pinned here is narrower and still worth having: no path reaches an
+// install without either a verified signature or someone having typed
+// --skip-verify.
 func verifyBlock(t *testing.T) string {
 	t.Helper()
 
@@ -70,13 +80,16 @@ SIGSTORE_IDENTITY_PREFIX="https://github.com/${GH_REPO}/.github/workflows/attest
 
 fetchReleaseAsset() { return %d; }
 resolveCosign()     { [ %d -eq 0 ] && echo "stub-cosign" ; return %d; }
-stub-cosign()       { return %d; }
 
-# The block calls cosign through "${COSIGN_BIN}", so route that to the stub.
-stub_cosign_wrapper() { return %d; }
+# The block invokes cosign through "${COSIGN_BIN}", which resolveCosign sets to
+# this function. It records its arguments so the cases can assert on the flags:
+# a stub that ignores them lets --certificate-identity be swapped for
+# --certificate-identity-regexp, or --type dropped, without any test noticing.
+stub-cosign() { printf '%%s\n' "$*" > "${TEMP_DIR}/cosign-args"; return %d; }
 
 %s
 
+[ -f "${TEMP_DIR}/cosign-args" ] && echo "COSIGN_ARGS: $(cat "${TEMP_DIR}/cosign-args")"
 echo "PROCEEDED"
 `
 
@@ -98,7 +111,7 @@ func runVerify(t *testing.T, block string, c verifyCase) (string, bool) {
 		skip = "true"
 	}
 	script := fmt.Sprintf(verifyHarness, skip,
-		c.fetchRC, c.cosignRC, c.cosignRC, c.verifyRC, c.verifyRC, block)
+		c.fetchRC, c.cosignRC, c.cosignRC, c.verifyRC, block)
 
 	path := filepath.Join(t.TempDir(), "verify.sh")
 	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
@@ -187,30 +200,174 @@ func TestInstallerVerifiesOrRefuses(t *testing.T) {
 			if got := strings.Contains(out, "VERIFIED"); got != c.wantVerify {
 				t.Errorf("verified-path ran = %v, want %v\noutput: %s", got, c.wantVerify, out)
 			}
+			if !c.wantVerify {
+				return
+			}
+			// The flags are the verification. An exact identity that becomes a
+			// regexp, or a missing --type, still "passes" a stub that ignores
+			// its arguments -- and both are real weakenings.
+			identity := "--certificate-identity https://github.com/NVIDIA/cluster-readiness-engine" +
+				"/.github/workflows/attest.yml@refs/tags/v0.2.0-rc.1"
+			for _, want := range []string{
+				identity,
+				"--type https://slsa.dev/provenance/v1",
+				"--certificate-oidc-issuer https://token.actions.githubusercontent.com",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("cosign was not called with %q\noutput: %s", want, out)
+				}
+			}
+			if strings.Contains(out, "--certificate-identity-regexp") {
+				t.Error("cosign was called with --certificate-identity-regexp; " +
+					"an identity naming no workflow and no ref also accepts a branch build")
+			}
 		})
 	}
 }
 
-// TestInstallerSkipVerifyIsExplicit pins that skipping is spelled out rather
-// than inferred. The flag is long on purpose: a single letter is the kind of
-// thing that gets copied out of an unrelated command line.
-func TestInstallerSkipVerifyIsExplicit(t *testing.T) {
+// argParseBlock returns the installer's argument pre-parsing plus the getopts
+// loop -- the code that connects `--skip-verify` on the command line to the
+// SKIP_VERIFY variable the verification block reads.
+func argParseBlock(t *testing.T) string {
+	t.Helper()
+
 	raw, err := os.ReadFile(installerPath)
 	if err != nil {
 		t.Fatalf("read installer: %v", err)
 	}
-	body := string(raw)
+	lines := strings.Split(string(raw), "\n")
 
-	if !strings.Contains(body, "--skip-verify") {
-		t.Error("installer has no --skip-verify flag; verification must be skippable only on request")
+	start, getopts := -1, -1
+	for i, l := range lines {
+		if start == -1 && strings.HasPrefix(l, "ARGS=()") {
+			start = i
+		}
+		if start != -1 && strings.HasPrefix(l, "while getopts") {
+			getopts = i
+			break
+		}
 	}
-	if strings.Contains(body, `SKIP_VERIFY=true`+"\n") && !strings.Contains(body, `--skip-verify) SKIP_VERIFY=true`) {
-		t.Error("SKIP_VERIFY is set somewhere other than the --skip-verify flag; " +
-			"it must never be inferred from a missing tool or a failed download")
+	if start == -1 || getopts == -1 {
+		t.Fatal("could not find the argument parsing in installer")
 	}
-	// getopts handles short flags only. A single-letter form would mean the
-	// long flag is decorative.
-	if strings.Contains(body, `getopts "d:pv:s"`) || strings.Contains(body, `getopts "d:psv:"`) {
-		t.Error("skip-verify has a short-flag form; it must be long-only")
+	for i := getopts; i < len(lines); i++ {
+		if lines[i] == "done" {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatal("could not find the end of the getopts loop")
+	return ""
+}
+
+// TestInstallerSkipVerifyFlagIsWired runs the real argument parsing.
+//
+// Without this, deleting the `--skip-verify)` case arm passes every other test
+// in this file: the verification block is exercised by setting SKIP_VERIFY
+// directly, so the flag can quietly become a no-op while remaining documented
+// in usage text and error messages. A flag that is advertised and does nothing
+// is worse than an absent one.
+func TestInstallerSkipVerifyFlagIsWired(t *testing.T) {
+	block := argParseBlock(t)
+
+	cases := []struct {
+		name string
+		args string
+		want string // "SKIP_VERIFY=<v> VERSION=<v> PRERELEASE=<v> DIR=<v>"
+	}{
+		{
+			name: "no arguments", args: ``,
+			want: "SKIP_VERIFY=false VERSION= PRERELEASE=false DIR=/usr/local/bin",
+		},
+		{
+			name: "skip-verify alone", args: `--skip-verify`,
+			want: "SKIP_VERIFY=true VERSION= PRERELEASE=false DIR=/usr/local/bin",
+		},
+		{
+			name: "short flags still parse", args: `-v v1.2.3 -d /opt/bin -p`,
+			want: "SKIP_VERIFY=false VERSION=v1.2.3 PRERELEASE=true DIR=/opt/bin",
+		},
+		{
+			name: "skip-verify alongside short flags", args: `--skip-verify -v v1.2.3`,
+			want: "SKIP_VERIFY=true VERSION=v1.2.3 PRERELEASE=false DIR=/usr/local/bin",
+		},
+		{
+			name: "skip-verify after short flags", args: `-v v1.2.3 --skip-verify`,
+			want: "SKIP_VERIFY=true VERSION=v1.2.3 PRERELEASE=false DIR=/usr/local/bin",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			script := fmt.Sprintf(`
+set -uo pipefail
+usage() { echo "USAGE"; exit 2; }
+INSTALL_DIR="/usr/local/bin"
+PRERELEASE=false
+VERSION=""
+SKIP_VERIFY=false
+set -- %s
+
+%s
+
+echo "SKIP_VERIFY=${SKIP_VERIFY} VERSION=${VERSION} PRERELEASE=${PRERELEASE} DIR=${INSTALL_DIR}"
+`, c.args, block)
+
+			path := filepath.Join(t.TempDir(), "args.sh")
+			if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+				t.Fatalf("write harness: %v", err)
+			}
+			out, err := exec.Command("bash", path).CombinedOutput()
+			if err != nil {
+				t.Fatalf("argument parsing failed: %v\n%s", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != c.want {
+				t.Errorf("argument parsing produced the wrong state\n got: %s\nwant: %s", got, c.want)
+			}
+		})
+	}
+}
+
+// TestInstallerSkipVerifyIsNeverInferred pins that SKIP_VERIFY is only ever set
+// by the flag.
+//
+// The whole point of the long flag is that verification is skipped when someone
+// asks, and never because a tool was missing or a download failed. An earlier
+// version of this test tried to express that with substring matching and could
+// not fail: it looked for `SKIP_VERIFY=true` followed by a newline, but the real
+// line ends `SKIP_VERIFY=true ;;`, so the check was dead. Assert on every
+// assignment instead, which is a property rather than a spelling.
+func TestInstallerSkipVerifyIsNeverInferred(t *testing.T) {
+	raw, err := os.ReadFile(installerPath)
+	if err != nil {
+		t.Fatalf("read installer: %v", err)
+	}
+
+	assign := regexp.MustCompile(`SKIP_VERIFY=`)
+	for i, line := range strings.Split(string(raw), "\n") {
+		if !assign.MatchString(line) {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "#"):
+		case trimmed == "SKIP_VERIFY=false":
+		case strings.HasPrefix(trimmed, `--skip-verify) SKIP_VERIFY=true`):
+		case strings.Contains(trimmed, `"${SKIP_VERIFY}"`):
+		default:
+			t.Errorf("installer:%d assigns SKIP_VERIFY outside the --skip-verify flag: %q\n"+
+				"skipping verification must never be inferred from a missing tool or a failed download",
+				i+1, trimmed)
+		}
+	}
+
+	// getopts takes short flags only, so a short spelling would mean the long
+	// flag is decorative. Parse the real optstring rather than matching a few
+	// guessed spellings of it.
+	m := regexp.MustCompile(`getopts\s+"([^"]*)"`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatal("could not find the getopts optstring in installer")
+	}
+	if strings.Contains(string(m[1]), "s") {
+		t.Errorf("getopts optstring %q accepts a short -s flag; skip-verify must be long-only", m[1])
 	}
 }


### PR DESCRIPTION
## Summary

Closes the last unsigned step in the chain. Every release artifact has been signed since #290, but `installer` — the path the README tells people to `curl | bash` — still decided whether to trust a binary using `checksums.txt` alone. That file is served from the same origin as the binary and is itself unsigned, so whoever can replace one can replace the other in the same write. It detects corruption, not tampering, and presenting it as verification is worse than presenting nothing, because it reads as a check.

The installer now verifies the downloaded binary against that release's `.sigstore.json`, pinning the exact identity `attest.yml@refs/tags/<VERSION>` — the workflow *and* the tag, so a branch build cannot satisfy it.

**It fails closed.** A missing bundle, an unobtainable cosign, or a signature that does not verify all stop the install. None falls back to the checksum. `--skip-verify` is the only way past, it is long-form on purpose, and it is never inferred from a missing tool or a failed download.

cosign is used if present and otherwise fetched from a pinned version and checked against a digest embedded in the script. Pinning the version alone would leave the bytes to whatever that tag serves today — verifying a release with an unverified verifier proves nothing.

### What this deliberately does not do

`installer` cannot authenticate its own bytes. Under `curl … | bash` the script executes before anything has checked it, and an adversary who could replace that asset could delete the verification logic and its pinned digest in the same write. `SECURITY.md` and `README.md` now say so plainly and document the download-verify-run path, per ADR-074's Consequences.

## Related Issue

Part of #268 — the "installer's own fail-closed verification, cosign bootstrap and `--skip-verify`" criterion, which the epic deferred until bundles existed to test against. They exist now: `v0.2.0-rc.1`.

## Type of Change
- [x] 🔨 Build/CI
- [x] 📚 Documentation

## Component(s) Affected
- [x] CLI (nvcrectl) — installer
- [x] Documentation / CI

## Testing

Exercised end to end against `v0.2.0-rc.1`, the first release carrying bundles:

| Scenario | Result |
|---|---|
| Signed release | Verified, installed |
| Release with no bundles (`v0.1.0`) | **Refused**, message names `--skip-verify` and why |
| Same release with `--skip-verify` | Installed, with an explicit warning |
| Wrong signing identity | **Refused**, 0 files installed, cosign's SAN mismatch printed |
| No cosign, no `gh`, no token | Bootstrapped cosign, matched the pinned digest, verified |

That last row is the bare-machine case ADR-074 calls for, and it exercises the anonymous download path too.

`TestInstallerVerifiesOrRefuses` extracts the decision from the script and runs it against stubs over all six branches. `TestInstallerSkipVerifyFlagIsWired` runs the real argument parsing. `TestInstallerSkipVerifyIsNeverInferred` asserts over every `SKIP_VERIFY` assignment.

- [x] Tests pass locally
- [x] Manual testing completed — see above
- [x] No breaking changes — installs of releases before `v0.2.0-rc.1` now require `--skip-verify`, which is the intended behaviour change

## Self-review

Five persona screens. The second commit fixes what they found, and two of those findings were that **the tests in the first commit did not protect what they claimed**.

`TestInstallerSkipVerifyIsExplicit` **could not fail**. It searched for `SKIP_VERIFY=true` followed by a newline; the real line ends `SKIP_VERIFY=true ;;`, so the condition was never true. Injecting the exact defect it described — inferring a skip from a missing cosign — passed.

The cosign stub **ignored its arguments**, so the flags that *are* the verification went unchecked. Swapping `--certificate-identity` for `--certificate-identity-regexp`, or dropping `--type`, passed all six cases.

Nothing ran the actual `--skip-verify` parsing, so deleting the case arm left a flag documented everywhere and wired to nothing.

Mutation results, before and after:

| Mutation | Before | After |
|---|---|---|
| `--skip-verify` case arm gutted | passed | **caught** |
| exact identity → regexp | passed | **caught** |
| `--type` dropped | passed | **caught** |
| skip inferred from missing cosign | passed | **caught** |
| short `-s` flag added | passed | **caught** |

Also fixed: `chmod +x` was unguarded and succeeds on a `noexec` mount, so an unrunnable cosign surfaced later as a *failed signature*; cosign's output was discarded, so a Rekor outage and a genuine mismatch read identically; and `fetchReleaseAsset` reported success for an empty 200 body, which then reached cosign and was reported as tampering. All three turned local problems into supply-chain-shaped alarms, which is how a check earns a reputation for crying wolf.

Docs findings: the cutover is `v0.2.0-rc.1`, not `v0.2.0` — rc.1 sorts *before* v0.2.0 under SemVer, so the original wording told users a release that verifies cleanly carries no bundles. `RELEASE.md` still taught checksum-only verification with no caveat, contradicting `SECURITY.md`'s own "verify the bundle, not the checksum".

### Known gap, stated rather than papered over

`fetchReleaseAsset` and `resolveCosign` have **no automated coverage**. They were exercised by hand against a real release, which is not the same thing and will not catch a regression in the asset-name escaping or the bootstrap digest check. The test comment says so. Closing it needs a local asset server or a live-release job, and is worth doing.

## Checklist
- [x] Self-review completed — see above
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated — `README.md`, `SECURITY.md`, `RELEASE.md`
- [x] Ready for review
