### PR TITLE
docs: publish how to verify a release, and test that the commands work

### DIFF
--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs the commands published in docs/operations/verifying-artifacts.md against
+# a real release.
+#
+# Documentation that tells people how to verify a supply chain is itself a
+# supply-chain artifact: a command that silently stops working leaves readers
+# either unable to check what they installed, or -- worse -- running something
+# that reports success without checking what they think it checks. Static tests
+# in test/docspolicy prove the blocks parse and pin an exact identity. Only
+# executing them proves they still work.
+#
+# The published TAG is substituted for the newest release, so this fails when
+# the docs drift from what the pipeline actually produces, not only when the
+# docs change.
+
+name: Docs Verify
+
+on:
+  pull_request:
+    paths:
+      - 'docs/operations/verifying-artifacts.md'
+      - '.github/workflows/docs-verify.yml'
+  schedule:
+    # Weekly. The commands depend on Rekor, GHCR and the release assets, none of
+    # which this repository controls.
+    - cron: '0 7 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  run-published-commands:
+    name: Run the published verification commands
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.3
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9b87d81 # v0.4
+
+      - name: Resolve the newest release
+        id: rel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release list --repo "${GITHUB_REPOSITORY}" --exclude-drafts \
+                   --limit 1 --json tagName --jq '.[0].tagName')"
+          [[ -n "${tag}" ]] || { echo "::error::no published release to verify against"; exit 1; }
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "verifying the documented commands against ${tag}"
+
+      # Blocks run in one shell, in order, so variables carry between them
+      # exactly as they do for a reader working down the page.
+      - name: Extract and run every published command
+        env:
+          TAG: ${{ steps.rel.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 - "${TAG}" <<'PY'
+          import re, sys
+          tag = sys.argv[1]
+          src = open("docs/operations/verifying-artifacts.md").read()
+          blocks = re.findall(r"```bash\n(.*?)```", src, re.S)
+          if not blocks:
+              raise SystemExit("no bash blocks found in the verification page")
+          out = ["set -euo pipefail"]
+          for i, b in enumerate(blocks, 1):
+              # Point every block at the release under test rather than the tag
+              # the page happens to be pinned to.
+              b = re.sub(r"(?m)^TAG=\S+$", f"TAG={tag}", b)
+              # Installing is covered by the installer's own tests; doing it here
+              # would write to /usr/local/bin for no extra signal.
+              b = b.replace('bash installer -v "${TAG}"', 'echo "[skipped: install]"')
+              out.append(f'echo "::group::block {i}"')
+              out.append(b)
+              out.append('echo "::endgroup::"')
+          open("/tmp/published-commands.sh", "w").write("\n".join(out))
+          print(f"extracted {len(blocks)} blocks, pinned to {tag}")
+          PY
+          bash /tmp/published-commands.sh
+
+      - name: Confirm the extracted artifacts are real
+        run: |
+          set -euo pipefail
+          # A command can exit 0 and produce nothing. The page tells readers to
+          # extract an SBOM; check it actually arrived.
+          [[ -s sbom-linux-amd64.json ]] || {
+            echo "::error::the documented SBOM extraction produced no file"; exit 1; }
+          count="$(jq -r '.components | length' sbom-linux-amd64.json)"
+          [[ "${count}" -gt 0 ]] || {
+            echo "::error::the extracted SBOM has no components"; exit 1; }
+          echo "extracted SBOM carries ${count} components"

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -75,6 +75,17 @@ jobs:
           tag="$(gh release list --repo "${GITHUB_REPOSITORY}" --exclude-drafts \
                    --limit 1 --json tagName --jq '.[0].tagName')"
           [[ -n "${tag}" ]] || { echo "::error::no published release to verify against"; exit 1; }
+
+          # This tag is interpolated into a generated shell script below, and
+          # git accepts $( ), backticks, ; and & inside a tag name -- so
+          # `TAG=v1.0$(id)` would execute. release.yml refuses to release from
+          # anything that is not vMAJOR.MINOR.PATCH[-prerelease], but a release
+          # created through the API or the UI never passes through that check,
+          # and this workflow reads whatever exists.
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::refusing to use tag '${tag}': not vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "verifying the documented commands against ${tag}"
 
@@ -96,7 +107,7 @@ jobs:
           for i, b in enumerate(blocks, 1):
               # Point every block at the release under test rather than the tag
               # the page happens to be pinned to.
-              b, n = re.subn(r"(?m)^TAG=\S+$", f"TAG={tag}", b)
+              b, n = re.subn(r"(?m)^TAG=\S+$", lambda _: f"TAG={tag}", b)
               if "TAG=" in blocks[i - 1] and n == 0:
                   raise SystemExit(
                       f"block {i} sets TAG but the substitution did not fire; "

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -47,8 +47,24 @@ jobs:
         with:
           cosign-release: v3.1.3
 
+      # Same pattern as attest.yml: download from the project that publishes it
+      # and check a digest pinned here. A setup action would have installed
+      # whatever crane is newest at run time, unverified, which is the opposite
+      # of what this workflow is checking.
       - name: Install crane
-        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9b87d81 # v0.4
+        env:
+          CRANE_VERSION: v0.20.6
+          CRANE_SHA256: c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
+        run: |
+          set -euo pipefail
+          base="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}"
+          tarball="go-containerregistry_Linux_x86_64.tar.gz"
+          tmp="$(mktemp -d)"
+          curl -fsSL -o "${tmp}/${tarball}" "${base}/${tarball}"
+          echo "${CRANE_SHA256}  ${tmp}/${tarball}" | sha256sum --check --strict -
+          tar -xzf "${tmp}/${tarball}" -C "${tmp}" crane
+          install -m 0755 "${tmp}/crane" /usr/local/bin/crane
+          crane version
 
       - name: Resolve the newest release
         id: rel
@@ -80,10 +96,18 @@ jobs:
           for i, b in enumerate(blocks, 1):
               # Point every block at the release under test rather than the tag
               # the page happens to be pinned to.
-              b = re.sub(r"(?m)^TAG=\S+$", f"TAG={tag}", b)
+              b, n = re.subn(r"(?m)^TAG=\S+$", f"TAG={tag}", b)
+              if "TAG=" in blocks[i - 1] and n == 0:
+                  raise SystemExit(
+                      f"block {i} sets TAG but the substitution did not fire; "
+                      "the workflow would silently verify the pinned tag instead "
+                      "of the release under test")
               # Installing is covered by the installer's own tests; doing it here
               # would write to /usr/local/bin for no extra signal.
-              b = b.replace('bash installer -v "${TAG}"', 'echo "[skipped: install]"')
+              if 'bash installer' in b:
+                  b, n = re.subn(r'(?m)^bash installer .*$', 'echo "[skipped: install]"', b)
+                  if n == 0:
+                      raise SystemExit(f"block {i} runs the installer but the skip did not fire")
               # helm install needs a cluster. The rest of the chart flow --
               # verify, verify-attestation, pull by digest -- still runs, and
               # the chart's own digest handling is covered by test/helm.
@@ -91,8 +115,11 @@ jobs:
               # install is the last thing in a block there is no blank line to
               # match, the substitution silently misses, and CI runs a real
               # helm install against whatever kubeconfig it has.
-              b = re.sub(r"(?m)^helm install nvcre(?:.*\\\n)*.*$",
-                         'echo "[skipped: needs a cluster]"', b)
+              if "helm install" in b:
+                  b, n = re.subn(r"(?m)^helm install nvcre(?:.*\\\n)*.*$",
+                                 'echo "[skipped: needs a cluster]"', b)
+                  if n == 0:
+                      raise SystemExit(f"block {i} runs helm install but the skip did not fire")
               out.append(f'echo "::group::block {i}"')
               out.append(b)
               out.append('echo "::endgroup::"')

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -84,6 +84,15 @@ jobs:
               # Installing is covered by the installer's own tests; doing it here
               # would write to /usr/local/bin for no extra signal.
               b = b.replace('bash installer -v "${TAG}"', 'echo "[skipped: install]"')
+              # helm install needs a cluster. The rest of the chart flow --
+              # verify, verify-attestation, pull by digest -- still runs, and
+              # the chart's own digest handling is covered by test/helm.
+              # Anchored to the command, not to a trailing blank line: when the
+              # install is the last thing in a block there is no blank line to
+              # match, the substitution silently misses, and CI runs a real
+              # helm install against whatever kubeconfig it has.
+              b = re.sub(r"(?m)^helm install nvcre(?:.*\\\n)*.*$",
+                         'echo "[skipped: needs a cluster]"', b)
               out.append(f'echo "::group::block {i}"')
               out.append(b)
               out.append('echo "::endgroup::"')

--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ curl -fsSL https://github.com/NVIDIA/cluster-readiness-engine/releases/download/
 
 The installer places `nvcrectl` on your `$PATH` and creates a `kubectl-nvcre` symlink so the CLI is also available as `kubectl nvcre`.
 
-It verifies the binary it downloads against that release's Sigstore bundle before installing
-it, using `cosign` if you have it and fetching a digest-pinned copy if you do not. If it
-cannot verify, it stops rather than installing — pass `--skip-verify` to override that
-deliberately. Releases before `v0.2.0-rc.1` carry no bundles.
+From the first release cut after this landed, the installer verifies the binary it
+downloads against that release's Sigstore bundle before installing it, using `cosign` if
+you have it and fetching a digest-pinned copy if you do not. If it cannot verify, it stops
+— pass `--skip-verify` to override that deliberately. Releases up to and including
+`v0.2.0-rc.1` ship an installer that checks only `checksums.txt`, and releases before
+`v0.2.0-rc.1` carry no bundles at all.
 
 Piping to `bash` gets you TLS integrity in transit and nothing more: the script runs before
 anything has checked the script itself. To verify what you are about to run, download it and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,7 +103,7 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
 
   `checksums.txt` is also published, but it is served from the same origin as the assets and is itself unsigned, so it detects corruption rather than tampering. Verify the bundle, not the checksum.
 
-- **`installer` verifies what it installs, and cannot verify itself.** From `v0.2.0` the installer checks the binary it downloads against that release's `.sigstore.json` under the identity above, using `cosign` if present and otherwise fetching a copy pinned by digest inside the script. If it cannot verify, it stops. `--skip-verify` overrides that, and is never inferred from a missing tool or a failed download — verification is skipped only when someone asks for it by name.
+- **`installer` verifies what it installs, and cannot verify itself.** From the first release cut after this behaviour landed — later than `v0.2.0-rc.1`, whose installer checks only `checksums.txt` — the installer checks the binary it downloads against that release's `.sigstore.json` under the identity above, using `cosign` if present and otherwise fetching a copy pinned by digest inside the script. If it cannot verify, it stops. `--skip-verify` overrides that, and is never inferred from a missing tool or a failed download — verification is skipped only when someone asks for it by name.
 
   That hardens what the installer *installs*. It does nothing for the installer itself: under `curl … | bash` the script executes before anything has checked it, and whoever could replace that asset could delete the verification logic and its pinned digest in the same write. The pipe buys TLS integrity in transit and nothing against a compromised release asset.
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -96,6 +96,8 @@ navigation:
         path: operations/monitoring.md
       - page: Prometheus Metrics
         path: operations/metrics.md
+      - page: Verifying Release Artifacts
+        path: operations/verifying-artifacts.md
       - page: Troubleshooting
         path: operations/troubleshooting.md
       - page: FAQ

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -76,6 +76,7 @@ Key chart values:
 | `manager.replicas` | `1` | Controller Deployment replicas |
 | `manager.image.repository` | `ghcr.io/nvidia/cluster-readiness-engine/manager` | Controller image |
 | `manager.image.tag` | `""` (uses chart `appVersion`) | Controller image tag |
+| `manager.image.digest` | `""` | Pin the controller image by digest. Wins over `tag`; the only form that names the exact bytes you verified |
 | `manager.imagePullSecrets` | `[]` | Pull secrets for the controller image |
 | `manager.resources` | `10m/500m` CPU, `1Gi/1Gi` memory | Controller resource requests/limits |
 | `manager.affinity` | `{}` | Controller pod affinity |
@@ -302,7 +303,7 @@ Use this checklist before going live. Each item addresses a specific risk surfac
 | **RBAC audit** | Required | Run `kubectl get clusterrole nvcre-manager-role -o yaml` and verify the permissions match your security requirements. |
 | **TLS for metrics** | Recommended | The default ServiceMonitor uses `insecureSkipVerify: true`. Configure cert-manager to issue a serving certificate for the controller's metrics endpoint. |
 | **Controller node affinity** | Recommended | Schedule the controller on infrastructure nodes, not GPU nodes, using the `manager.affinity` chart value to avoid consuming GPU resources. |
-| **Image provenance** | Recommended | Verify the image signature and its SLSA provenance against the exact signing identity before deploying, then pin by the digest you verified rather than by tag. The provenance names the commit, ref and workflow that built it. See [Verifying release artifacts](./verifying-artifacts.md). Scan images with your vulnerability tooling before deployment. |
+| **Image provenance** | Recommended | Verify the image signature and its SLSA provenance against the exact signing identity before deploying, then pin what you verified with `--set manager.image.digest=sha256:...` rather than deploying by tag — a tag can be repointed after you check it. The provenance names the commit, ref and workflow that built it. See [Verifying release artifacts](./verifying-artifacts.md). Scan images with your vulnerability tooling before deployment. |
 | **Pod Security Standards** | Verify | The controller runs as non-root with `seccompProfile: RuntimeDefault`, a read-only root filesystem, and all capabilities dropped. Verify with `kubectl get pod -n nvcre -o yaml`. |
 | **CRD backup** | Recommended | Include the NVCRE CRDs in your cluster backup strategy. Certification resources contain node health state that may be needed for audit. |
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -302,7 +302,7 @@ Use this checklist before going live. Each item addresses a specific risk surfac
 | **RBAC audit** | Required | Run `kubectl get clusterrole nvcre-manager-role -o yaml` and verify the permissions match your security requirements. |
 | **TLS for metrics** | Recommended | The default ServiceMonitor uses `insecureSkipVerify: true`. Configure cert-manager to issue a serving certificate for the controller's metrics endpoint. |
 | **Controller node affinity** | Recommended | Schedule the controller on infrastructure nodes, not GPU nodes, using the `manager.affinity` chart value to avoid consuming GPU resources. |
-| **Image provenance** | Recommended | Pin container images by digest rather than tag. Scan images with your vulnerability tooling before deployment. |
+| **Image provenance** | Recommended | Verify the image signature and its SLSA provenance against the exact signing identity before deploying, then pin by the digest you verified rather than by tag. The provenance names the commit, ref and workflow that built it. See [Verifying release artifacts](./verifying-artifacts.md). Scan images with your vulnerability tooling before deployment. |
 | **Pod Security Standards** | Verify | The controller runs as non-root with `seccompProfile: RuntimeDefault`, a read-only root filesystem, and all capabilities dropped. Verify with `kubectl get pod -n nvcre -o yaml`. |
 | **CRD backup** | Recommended | Include the NVCRE CRDs in your cluster backup strategy. Certification resources contain node health state that may be needed for audit. |
 

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -17,6 +17,11 @@ Start here. The README shows `curl … | bash` because it is short, and it is ho
 what it gives you: TLS integrity in transit, and nothing at all about whether the script
 on the other end is the one we published. The script runs before anything has checked it.
 
+Set `TAG` to the release you actually have. These commands verify the artifact `TAG`
+names and nothing else — pointed at a different release they will happily report success
+while telling you nothing about the file on your disk. `releases/latest` resolves to the
+newest *stable* release, so it is not `v0.2.0-rc.1`.
+
 To know what you are about to run, check it first:
 
 ```bash
@@ -46,16 +51,18 @@ Run the two commands back to back. Verifying a file and then executing it leaves
 in which something with write access could swap it — small, and it requires a compromise
 that is already worse than this, but it is a window and not a proof.
 
-From `v0.2.0-rc.1` onward the installer checks the binary it downloads against that
-release's bundle and refuses to install if it cannot. `--skip-verify` overrides that and
-is never inferred from a missing tool.
+The installer also verifies the binary *it* downloads, refusing to install one whose
+bundle it cannot check, with `--skip-verify` as the only override. That landed after
+`v0.2.0-rc.1` was cut, so the installer published with the release pinned above does not
+yet do it — it checks only `checksums.txt`. Verify `installer` yourself, as above, until
+a release carries the newer one.
 
 ## Prerequisites
 
 | Tool | Used for | Version this page was checked with |
 |---|---|---|
 | [`cosign`](https://docs.sigstore.dev/cosign/installation/) | every verification below | `v3.1.3` |
-| [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane) | resolving per-platform image digests | `v0.21.1` |
+| [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane) | resolving per-platform image digests | `v0.20.6` (the version the release pipeline pins) |
 | `jq` | reading provenance and SBOM predicates | any |
 | `helm` | pulling the chart by digest | `v3.x` |
 
@@ -162,8 +169,14 @@ jq -r '{
 Confirm the commit is the one the tag points at:
 
 ```bash
-git ls-remote https://github.com/NVIDIA/cluster-readiness-engine "refs/tags/${TAG}"
+git ls-remote --exit-code https://github.com/NVIDIA/cluster-readiness-engine "refs/tags/${TAG}^{}"
 ```
+
+The `^{}` is required and easy to miss. Release tags here are signed, so
+`refs/tags/<TAG>` resolves to the *tag object*, not the commit — comparing that against
+the provenance would mismatch on every correct release. `^{}` peels it to the commit the
+provenance actually names. `--exit-code` makes a tag that does not exist fail rather than
+print nothing and succeed.
 
 `head -1` above is deliberate, and it is also why the `git ls-remote` check is **not
 optional**. A retried signing attempt can leave more than one valid attestation on a
@@ -290,15 +303,19 @@ cosign verify-attestation --type cyclonedx \
   --certificate-identity "${ID}" \
   --certificate-oidc-issuer "${ISSUER}" \
   "${IMAGE}@${AMD64}" 2>/dev/null \
-  | jq -r '.payload' | head -1 | base64 -d | jq '.predicate' > "${tmp}" \
-  && mv "${tmp}" sbom-linux-amd64.json
+  | jq -r '.payload' | head -1 | base64 -d | jq '.predicate' > "${tmp}"
+mv "${tmp}" sbom-linux-amd64.json
 jq -r '.components | length' sbom-linux-amd64.json
 ```
 
 Do not write straight to the final path. `>` truncates the target before the pipeline
 runs and `jq` exits 0 on empty input, so a failed verification leaves a zero-length file
-and a zero exit status — a broken result that reads as success. `set -o pipefail` plus a
-deferred `mv` is what makes the failure visible.
+and a zero exit status — a broken result that reads as success.
+
+The `mv` is a separate statement on purpose. Chaining it with `&&` would put the pipeline
+on the left of an `&&`, where `set -e` does not apply, so the failure would not abort
+there either. Written as two statements, `set -euo pipefail` aborts on the pipeline
+itself.
 
 ## Air-gapped verification
 
@@ -366,12 +383,15 @@ in issue #272.
 prints the SAN it expected and the SAN it found; compare them. The usual cause is a `TAG`
 that does not match the artifact, since the identity embeds the tag.
 
-**`no matching attestations`** — right identity, wrong subject or predicate type. Check
-you are using the index digest for provenance and a per-platform digest for an SBOM, and
-that `--type` matches (`slsaprovenance1` for provenance, `cyclonedx` for an SBOM).
+**`none of the attestations matched the predicate type: <type>, found: <types>`** — right
+identity and subject, wrong `--type`. Provenance is `slsaprovenance1` on the index digest;
+an SBOM is `cyclonedx` on a per-platform digest. The message lists what the subject
+actually carries, which tells you which of the two you got wrong.
 
-**`Error: fetching signatures: reading layout ...`** on a release before `v0.2.0-rc.1` —
-those releases carry no bundles. Nothing was signed; there is nothing to verify.
+**`reading <file>: no such file or directory`** — the bundle is not on disk. Usually the
+`curl` for it failed: releases before `v0.2.0-rc.1` carry no bundles at all, so
+`curl -fsSLO .../installer.sigstore.json` returns `curl: (56) ... error 404` and cosign
+never runs. Nothing was signed there; there is nothing to verify.
 
 **`exec: "docker-credential-osxkeychain"`** from `helm pull` — a local Docker credential
 helper is declared in `~/.docker/config.json` but not installed. It has nothing to do

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -42,6 +42,10 @@ The trust anchor is the `cosign` you already have, not anything inside the scrip
 is the point: `installer` verifies what it *installs*, but it cannot verify itself, and
 neither can any other single-file installer.
 
+Run the two commands back to back. Verifying a file and then executing it leaves a window
+in which something with write access could swap it — small, and it requires a compromise
+that is already worse than this, but it is a window and not a proof.
+
 From `v0.2.0-rc.1` onward the installer checks the binary it downloads against that
 release's bundle and refuses to install if it cannot. `--skip-verify` overrides that and
 is never inferred from a missing tool.
@@ -136,6 +140,10 @@ STATEMENT="$(cosign verify-attestation --type slsaprovenance1 \
   --certificate-oidc-issuer "${ISSUER}" \
   "${IMAGE}:${TAG}" 2>/dev/null | jq -r '.payload' | head -1 | base64 -d)"
 
+# An empty STATEMENT means verification failed, not that there is nothing to say.
+# Without this the jq below prints nothing and exits 0.
+[[ -n "${STATEMENT}" ]] || { echo "provenance verification failed" >&2; exit 1; }
+
 jq -r '{
   repository: .predicate.buildDefinition.externalParameters.repository,
   ref:        .predicate.buildDefinition.externalParameters.ref,
@@ -157,10 +165,13 @@ Confirm the commit is the one the tag points at:
 git ls-remote https://github.com/NVIDIA/cluster-readiness-engine "refs/tags/${TAG}"
 ```
 
-`head -1` above is deliberate. A retried signing attempt can leave more than one valid
-attestation on a digest, which is expected and is not tampering — but it means `.payload`
-can return several lines, and feeding all of them to `base64 -d` produces nonsense. Take
-one, or loop and require every statement to agree.
+`head -1` above is deliberate, and it is also why the `git ls-remote` check is **not
+optional**. A retried signing attempt can leave more than one valid attestation on a
+digest — expected, and not tampering — so `.payload` can return several lines, and feeding
+all of them to `base64 -d` produces nonsense. Taking the first is what makes the command
+runnable; comparing the commit it reports against the tag is what makes taking the first
+safe. Do both, or loop over every line and require each statement to agree before
+trusting any of them.
 
 ## Verifying the Helm chart before installing it
 
@@ -183,12 +194,33 @@ cosign verify-attestation --type slsaprovenance1 \
 helm pull "oci://${CHART}@${DIGEST}"
 ```
 
-Pulling by digest is what closes the loop. Content addressing means you receive those
-exact bytes or an error, so there is no window between verifying and installing.
+Pulling by digest is what makes the download match what you verified: content addressing
+means you receive those exact bytes or an error.
+
+Then install **the file you pulled**, not the tag:
+
+```bash
+IMAGE_DIGEST="$(crane digest "${IMAGE}:${TAG}")"
+
+helm install nvcre ./cluster-readiness-engine*.tgz \
+  --namespace nvcre --create-namespace \
+  --set manager.image.digest="${IMAGE_DIGEST}"
+```
+
+Two things there are doing work.
+
+Installing from the local `.tgz` rather than `oci://…/cluster-readiness-engine --version
+<tag>` matters because the second form re-resolves the tag at install time, which throws
+away everything you just checked.
+
+`manager.image.digest` matters for the same reason one level down. The chart otherwise
+deploys `manager:<tag>`, and a tag can be repointed after you verified it. Setting the
+digest pins the image to the bytes whose signature you checked. Leave it unset and you
+get the tag, which is fine for a development cluster and not what you did this work for.
 
 ## Verifying a downloaded binary and its SBOM
 
-Each `nvcrectl-*` binary ships **two** bundles whose names differ by one segment, and
+Each `nvcrectl-*` binary ships **three** bundles whose names differ by one segment, and
 they prove different things:
 
 | Bundle | Verify against | Proves |
@@ -206,6 +238,7 @@ curl -fsSLO "${BASE}/${ASSET}"
 curl -fsSLO "${BASE}/${ASSET}.sigstore.json"
 curl -fsSLO "${BASE}/${ASSET}.cyclonedx.json"
 curl -fsSLO "${BASE}/${ASSET}.cyclonedx.sigstore.json"
+curl -fsSLO "${BASE}/${ASSET}.cyclonedx.json.sigstore.json"
 
 # 1. the binary is from this release
 cosign verify-blob-attestation \
@@ -222,11 +255,26 @@ cosign verify-blob-attestation \
   --certificate-identity "${ID}" \
   --certificate-oidc-issuer "${ISSUER}" \
   "${ASSET}"
+
+# 3. the SBOM FILE on your disk has not been altered -- subject is the FILE
+cosign verify-blob-attestation \
+  --bundle "${ASSET}.cyclonedx.json.sigstore.json" \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${ASSET}.cyclonedx.json"
 ```
+
+Step 3 is the one that is easy to skip and the one that protects the file you are about
+to read. Steps 1 and 2 both take the **binary** as their subject, so neither of them looks
+at `${ASSET}.cyclonedx.json` at all: replace that file with a doctored SBOM and both still
+report `Verified OK`. Only step 3 fails, with `provided artifact digests do not match
+digests in statement`.
 
 ### Reading the SBOM
 
-The SBOM is published as a plain asset, so no extraction is needed for binaries:
+Read it only after step 3 above. The SBOM is published as a plain asset, so no extraction
+is needed for binaries:
 
 ```bash
 jq -r '.metadata.component.name, (.components | length)' "${ASSET}.cyclonedx.json"
@@ -254,21 +302,63 @@ deferred `mv` is what makes the failure visible.
 
 ## Air-gapped verification
 
-`cosign verify` needs the Sigstore trust root and, by default, fetches it. On a machine
-with no egress, fetch it once somewhere with network:
+`cosign verify` needs the Sigstore trust root. Copying `~/.sigstore` across is **not
+enough**: cosign v3.1.3 attempts a TUF refresh on every verification and fails with
+`tuf refresh failed: ... connection refused` rather than falling back to that cache. It
+fails closed, which is the right direction, but it does not verify.
+
+Export the trust root as a file instead, on a machine with network:
 
 ```bash
 cosign initialize
-tar -czf sigstore-root.tgz -C "${HOME}" .sigstore
+cp ~/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json .
 ```
 
-Move `sigstore-root.tgz` and the artifacts across, then unpack it into `$HOME` on the
-target. Verification is otherwise unchanged and needs no network, because the bundle
-carries the signature, the certificate and the inclusion proof.
+Move `trusted_root.json` across with the artifacts, and pass it explicitly. That path
+takes no network at all:
+
+```bash
+cosign verify-blob-attestation \
+  --trusted-root ./trusted_root.json \
+  --bundle "${ASSET}.sigstore.json" \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${ASSET}"
+```
+
+`--trusted-root` works on every `cosign verify*` command. The bundle already carries the
+signature, the certificate and the inclusion proof, so with the trust root on disk there
+is nothing left to fetch.
+
+Refresh `trusted_root.json` periodically. It pins the Sigstore keys, and a stale copy
+will eventually reject signatures made with newer ones.
 
 Blob bundles are the easy case: an asset and its `.sigstore.json` are two files, and
 `cosign verify-blob-attestation` reads both from disk. Registry attestations need the
 registry, so mirror the image and chart with `crane copy` before disconnecting.
+
+Mirroring the bytes is half the job. The cluster still has to pull from the mirror, so
+point the chart at it — see [Air-gapped and disconnected
+environments](./deployment.md#air-gapped-and-disconnected-environments) for the
+`manager.image.repository` override. Verifying artifacts and then deploying a reference
+the cluster cannot reach leaves you with a correct signature and a pod that never starts.
+
+## Enforcing this automatically
+
+Everything above is something a person runs. Tools that sync from the registry — Flux
+`OCIRepository`, Argo CD, Argo CD Image Updater — do not wait for the GitHub Release, so
+the release gate does not protect them; they see the image and chart as soon as those are
+pushed. They are the consumers who most need the identity contract enforced
+declaratively rather than typed.
+
+Flux supports this natively with [`spec.verify`](https://fluxcd.io/flux/components/source/ocirepositories/#verification)
+using the `cosign` provider, matching the same OIDC issuer and identity used above.
+Whether that path works end to end against a real Flux version is still being confirmed
+(issue #267), so this page does not yet publish a manifest for it — an untested
+verification config is exactly the kind of false assurance the rest of this page exists to
+avoid. Admission-policy samples for Kyverno and the Sigstore policy-controller are tracked
+in issue #272.
 
 ## Troubleshooting
 

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -1,0 +1,311 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Verifying release artifacts
+
+Every artifact a NVCRE release publishes is signed, and each one carries a statement
+saying which commit, workflow and tag produced it. This page is how you check that
+yourself.
+
+You do not have to trust this page, the release notes, or the installer. Everything below
+can be run from a machine with only `cosign` on it, against artifacts fetched over their
+public URLs.
+
+## Install the CLI, verified
+
+Start here. The README shows `curl … | bash` because it is short, and it is honest about
+what it gives you: TLS integrity in transit, and nothing at all about whether the script
+on the other end is the one we published. The script runs before anything has checked it.
+
+To know what you are about to run, check it first:
+
+```bash
+TAG=v0.2.0-rc.1
+BASE="https://github.com/NVIDIA/cluster-readiness-engine/releases/download/${TAG}"
+ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
+ISSUER='https://token.actions.githubusercontent.com'
+
+curl -fsSLO "${BASE}/installer"
+curl -fsSLO "${BASE}/installer.sigstore.json"
+
+cosign verify-blob-attestation \
+  --bundle installer.sigstore.json \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  installer
+
+bash installer -v "${TAG}"
+```
+
+The trust anchor is the `cosign` you already have, not anything inside the script. That
+is the point: `installer` verifies what it *installs*, but it cannot verify itself, and
+neither can any other single-file installer.
+
+From `v0.2.0-rc.1` onward the installer checks the binary it downloads against that
+release's bundle and refuses to install if it cannot. `--skip-verify` overrides that and
+is never inferred from a missing tool.
+
+## Prerequisites
+
+| Tool | Used for | Version this page was checked with |
+|---|---|---|
+| [`cosign`](https://docs.sigstore.dev/cosign/installation/) | every verification below | `v3.1.3` |
+| [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane) | resolving per-platform image digests | `v0.21.1` |
+| `jq` | reading provenance and SBOM predicates | any |
+| `helm` | pulling the chart by digest | `v3.x` |
+
+`cosign` is the only one that is strictly required. Pin the version you use: the bundle
+format is governed by the cosign version that produced it, and the release pipeline pins
+`v3.1.3` for exactly that reason.
+
+## The identity contract
+
+Every attestation in a NVCRE release is produced by one reusable workflow, so there is
+exactly one identity to pin:
+
+```
+--certificate-identity   https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/<TAG>
+--certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Use `--certificate-identity`. Do not use `--certificate-identity-regexp`.
+
+This is not style. An identity that names no workflow and no ref also accepts builds from
+branches, and this project publishes `main-<sha>` development images. A pattern like
+`https://github.com/NVIDIA/cluster-readiness-engine` accepts those too — so a command
+built on it reports success for an artifact that was never released. The exact form names
+the workflow **and** the tag, so a signature from `v0.1.0` cannot pass as `v0.2.0`, and a
+branch build cannot pass as either.
+
+## Verifying the container image
+
+The image is a multi-platform index. Two different things are attested, to two different
+subjects, and the distinction matters:
+
+| Subject | Carries |
+|---|---|
+| the **index** digest | signature + SLSA Build Provenance v1 |
+| each **per-platform** manifest digest | signature + a CycloneDX SBOM for that platform |
+
+An SBOM describes the contents of one root filesystem, and an index has more than one. A
+single SBOM attached to the index would be silently wrong for whichever platform it did
+not describe, so each platform gets its own.
+
+Signature and provenance, against the tag:
+
+```bash
+TAG=v0.2.0-rc.1
+IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
+ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
+ISSUER='https://token.actions.githubusercontent.com'
+
+cosign verify \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${IMAGE}:${TAG}"
+
+cosign verify-attestation --type slsaprovenance1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${IMAGE}:${TAG}"
+```
+
+The SBOM lives on the platform manifest, so resolve that digest first rather than reusing
+the tag:
+
+```bash
+AMD64="$(crane digest --platform linux/amd64 "${IMAGE}:${TAG}")"
+echo "linux/amd64 -> ${AMD64}"
+
+cosign verify-attestation --type cyclonedx \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${IMAGE}@${AMD64}"
+```
+
+## What the provenance actually proves
+
+A signature says who signed and under which ref. Only the provenance predicate says what
+was built. Read it:
+
+```bash
+set -o pipefail
+STATEMENT="$(cosign verify-attestation --type slsaprovenance1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${IMAGE}:${TAG}" 2>/dev/null | jq -r '.payload' | head -1 | base64 -d)"
+
+jq -r '{
+  repository: .predicate.buildDefinition.externalParameters.repository,
+  ref:        .predicate.buildDefinition.externalParameters.ref,
+  commit:     .predicate.buildDefinition.resolvedDependencies[0].digest.gitCommit,
+  builder:    .predicate.runDetails.builder.id
+}' <<<"${STATEMENT}"
+```
+
+| Field | What it proves |
+|---|---|
+| `externalParameters.repository` | which repository the build ran in |
+| `externalParameters.ref` | the exact ref — `refs/tags/<TAG>` for a release |
+| `resolvedDependencies[0].digest.gitCommit` | the source commit, which you can compare against the tag |
+| `runDetails.builder.id` | the workflow that performed the build |
+
+Confirm the commit is the one the tag points at:
+
+```bash
+git ls-remote https://github.com/NVIDIA/cluster-readiness-engine "refs/tags/${TAG}"
+```
+
+`head -1` above is deliberate. A retried signing attempt can leave more than one valid
+attestation on a digest, which is expected and is not tampering — but it means `.payload`
+can return several lines, and feeding all of them to `base64 -d` produces nonsense. Take
+one, or loop and require every statement to agree.
+
+## Verifying the Helm chart before installing it
+
+Verify the digest, then install *that digest* — not the tag you verified a moment ago:
+
+```bash
+CHART=ghcr.io/nvidia/cluster-readiness-engine
+DIGEST="$(crane digest "${CHART}:${TAG}")"
+
+cosign verify \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${CHART}@${DIGEST}"
+
+cosign verify-attestation --type slsaprovenance1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${CHART}@${DIGEST}"
+
+helm pull "oci://${CHART}@${DIGEST}"
+```
+
+Pulling by digest is what closes the loop. Content addressing means you receive those
+exact bytes or an error, so there is no window between verifying and installing.
+
+## Verifying a downloaded binary and its SBOM
+
+Each `nvcrectl-*` binary ships **two** bundles whose names differ by one segment, and
+they prove different things:
+
+| Bundle | Verify against | Proves |
+|---|---|---|
+| `<binary>.sigstore.json` | the **binary** | the binary came from this release |
+| `<binary>.cyclonedx.sigstore.json` | the **binary** | this SBOM describes that binary |
+| `<binary>.cyclonedx.json.sigstore.json` | the **SBOM file** | the SBOM document is unaltered |
+
+The middle one is the one people miss. It binds the SBOM to the binary, so a real SBOM
+for a *different* build cannot be presented alongside this one.
+
+```bash
+ASSET=nvcrectl-linux-amd64
+curl -fsSLO "${BASE}/${ASSET}"
+curl -fsSLO "${BASE}/${ASSET}.sigstore.json"
+curl -fsSLO "${BASE}/${ASSET}.cyclonedx.json"
+curl -fsSLO "${BASE}/${ASSET}.cyclonedx.sigstore.json"
+
+# 1. the binary is from this release
+cosign verify-blob-attestation \
+  --bundle "${ASSET}.sigstore.json" \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${ASSET}"
+
+# 2. the SBOM beside it describes that binary -- note the subject is the BINARY
+cosign verify-blob-attestation \
+  --bundle "${ASSET}.cyclonedx.sigstore.json" \
+  --type cyclonedx \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${ASSET}"
+```
+
+### Reading the SBOM
+
+The SBOM is published as a plain asset, so no extraction is needed for binaries:
+
+```bash
+jq -r '.metadata.component.name, (.components | length)' "${ASSET}.cyclonedx.json"
+```
+
+For the **image**, the SBOM is inside an attestation and has to be extracted. Write it
+through a temporary file:
+
+```bash
+set -o pipefail
+tmp="$(mktemp)"
+cosign verify-attestation --type cyclonedx \
+  --certificate-identity "${ID}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${IMAGE}@${AMD64}" 2>/dev/null \
+  | jq -r '.payload' | head -1 | base64 -d | jq '.predicate' > "${tmp}" \
+  && mv "${tmp}" sbom-linux-amd64.json
+jq -r '.components | length' sbom-linux-amd64.json
+```
+
+Do not write straight to the final path. `>` truncates the target before the pipeline
+runs and `jq` exits 0 on empty input, so a failed verification leaves a zero-length file
+and a zero exit status — a broken result that reads as success. `set -o pipefail` plus a
+deferred `mv` is what makes the failure visible.
+
+## Air-gapped verification
+
+`cosign verify` needs the Sigstore trust root and, by default, fetches it. On a machine
+with no egress, fetch it once somewhere with network:
+
+```bash
+cosign initialize
+tar -czf sigstore-root.tgz -C "${HOME}" .sigstore
+```
+
+Move `sigstore-root.tgz` and the artifacts across, then unpack it into `$HOME` on the
+target. Verification is otherwise unchanged and needs no network, because the bundle
+carries the signature, the certificate and the inclusion proof.
+
+Blob bundles are the easy case: an asset and its `.sigstore.json` are two files, and
+`cosign verify-blob-attestation` reads both from disk. Registry attestations need the
+registry, so mirror the image and chart with `crane copy` before disconnecting.
+
+## Troubleshooting
+
+**`no matching CertificateIdentity found`** — the identity did not match. The message
+prints the SAN it expected and the SAN it found; compare them. The usual cause is a `TAG`
+that does not match the artifact, since the identity embeds the tag.
+
+**`no matching attestations`** — right identity, wrong subject or predicate type. Check
+you are using the index digest for provenance and a per-platform digest for an SBOM, and
+that `--type` matches (`slsaprovenance1` for provenance, `cyclonedx` for an SBOM).
+
+**`Error: fetching signatures: reading layout ...`** on a release before `v0.2.0-rc.1` —
+those releases carry no bundles. Nothing was signed; there is nothing to verify.
+
+**`exec: "docker-credential-osxkeychain"`** from `helm pull` — a local Docker credential
+helper is declared in `~/.docker/config.json` but not installed. It has nothing to do
+with the chart, which is public and needs no credentials. Point helm at an empty registry
+config to bypass it:
+
+```bash
+echo '{}' > /tmp/helm-reg.json
+HELM_REGISTRY_CONFIG=/tmp/helm-reg.json helm pull "oci://${CHART}@${DIGEST}"
+```
+
+**Verification fails intermittently** — Rekor and the registry are network services.
+`cosign` has no retry flag; run the command again before concluding anything. A transient
+failure and a real mismatch produce different messages, and the first one is far more
+common.
+
+**A checksum passed but you want more** — `checksums.txt` is served from the same origin
+as the assets and is itself unsigned, so whoever can replace an asset can replace its
+checksum line in the same write. It detects corruption, not tampering. This is not
+theoretical: a release built with a binary deliberately modified after signing produced
+`ok checksums.txt` and was caught only by the signature check. Verify the bundle.
+
+## See also
+
+- [SECURITY.md](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/SECURITY.md) — reporting policy and the supply chain summary
+- [RELEASE.md](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/RELEASE.md) — what a release publishes and how it verifies itself
+- [ADR-074](https://github.com/NVIDIA/cluster-readiness-engine/blob/main/docs/designs/074-supply-chain-attestation.md) — the artifact and verification contract, and why each choice was made

--- a/helm/cluster-readiness-engine/templates/deployment.yaml
+++ b/helm/cluster-readiness-engine/templates/deployment.yaml
@@ -36,7 +36,17 @@ spec:
         - --measurement-max-concurrent-reconciles={{ required "manager.measurementMaxConcurrentReconciles is required" .Values.manager.measurementMaxConcurrentReconciles }}
         command:
         - /manager
+        {{- /*
+          A digest wins over a tag. Verification is digest-addressed, so an
+          operator who checked a signature and then deployed by tag deployed
+          something the tag happened to resolve to at pull time, not the bytes
+          they verified.
+        */ -}}
+        {{- if .Values.manager.image.digest }}
+        image: {{ .Values.manager.image.repository }}@{{ .Values.manager.image.digest }}
+        {{- else }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/cluster-readiness-engine/values.yaml
+++ b/helm/cluster-readiness-engine/values.yaml
@@ -15,6 +15,11 @@ manager:
   image:
     repository: ghcr.io/nvidia/cluster-readiness-engine/manager
     tag: ""
+    # Pin by digest instead of tag. When set, this wins over `tag` and the image
+    # is referenced as repository@digest -- the only form that names the exact
+    # bytes you verified, since a tag can be repointed after verification.
+    # Example: sha256:735ad1e142a378b0919510bd1fc113cd53ab754bc79b7f0980d647d50a914523
+    digest: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: []
   resources:

--- a/test/docspolicy/verification_page_test.go
+++ b/test/docspolicy/verification_page_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package docspolicy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// verificationPage is the page that tells users how to check what we shipped.
+// A wrong command here is worse than no page: it converts an unverified install
+// into one the user believes was verified.
+const verificationPage = "../../docs/operations/verifying-artifacts.md"
+
+// bashFence matches a ```bash fenced block and captures its body.
+var bashFence = regexp.MustCompile("(?s)```bash\\n(.*?)```")
+
+func pageBlocks(t *testing.T) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(verificationPage)
+	if err != nil {
+		t.Fatalf("read %s: %v", verificationPage, err)
+	}
+	matches := bashFence.FindAllStringSubmatch(string(raw), -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s has no ```bash blocks; the page is meant to be copy-pasteable", verificationPage)
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// TestVerificationPageBlocksAreValidShell parses every published command.
+//
+// These are copy-pasted by people verifying a supply chain, often onto a
+// machine they are being careful about. A block that does not parse wastes
+// their time; worse, a block that parses but was never run can fail halfway and
+// leave them believing the part that did run proved something. The executable
+// half of this lives in .github/workflows/docs-verify.yml, which runs the same
+// blocks against a real release.
+func TestVerificationPageBlocksAreValidShell(t *testing.T) {
+	for i, block := range pageBlocks(t) {
+		path := filepath.Join(t.TempDir(), "block.sh")
+		if err := os.WriteFile(path, []byte(block), 0o600); err != nil {
+			t.Fatalf("write block: %v", err)
+		}
+		if out, err := exec.Command("bash", "-n", path).CombinedOutput(); err != nil {
+			t.Errorf("block %d in %s is not valid shell: %v\n%s\n--- block ---\n%s",
+				i+1, verificationPage, err, out, block)
+		}
+	}
+}
+
+// TestVerificationPagePinsAnExactIdentity is the specific mistake this page
+// exists to stop people making.
+//
+// SECURITY.md previously published `--certificate-identity-regexp` with a
+// pattern naming no workflow and no ref. This repository also publishes
+// `main-<sha>` development images signed under the same repository, so that
+// pattern accepts an unreleased branch build as a release. Anyone following the
+// documentation exactly would have accepted one.
+func TestVerificationPagePinsAnExactIdentity(t *testing.T) {
+	blocks := pageBlocks(t)
+	joined := strings.Join(blocks, "\n")
+
+	if strings.Contains(joined, "--certificate-identity-regexp") {
+		t.Error("the verification page publishes --certificate-identity-regexp; " +
+			"an identity naming no workflow and no ref also accepts a branch build")
+	}
+
+	// The identity must name attest.yml and a tag ref. Anything looser is the
+	// defect above wearing a different spelling.
+	wantIdentity := "/.github/workflows/attest.yml@refs/tags/"
+	if !strings.Contains(joined, wantIdentity) {
+		t.Errorf("no published command pins an identity containing %q; "+
+			"the identity must name the signing workflow and the tag", wantIdentity)
+	}
+
+	if !strings.Contains(joined, "https://token.actions.githubusercontent.com") {
+		t.Error("no published command pins --certificate-oidc-issuer; " +
+			"without it any issuer that can mint a matching SAN is accepted")
+	}
+}
+
+// TestVerificationPageIsInTheNav keeps the page reachable.
+//
+// A verification page nobody can find is the same as not having one, and the
+// Fern site is built from docs/index.yml rather than by directory scan, so a
+// new page is invisible until it is listed.
+func TestVerificationPageIsInTheNav(t *testing.T) {
+	raw, err := os.ReadFile("../../docs/index.yml")
+	if err != nil {
+		t.Fatalf("read docs/index.yml: %v", err)
+	}
+	if !strings.Contains(string(raw), "operations/verifying-artifacts.md") {
+		t.Error("docs/index.yml does not list operations/verifying-artifacts.md, " +
+			"so the page does not appear in the published navigation")
+	}
+}

--- a/test/docspolicy/verification_page_test.go
+++ b/test/docspolicy/verification_page_test.go
@@ -78,22 +78,68 @@ func TestVerificationPagePinsAnExactIdentity(t *testing.T) {
 			"an identity naming no workflow and no ref also accepts a branch build")
 	}
 
+	// Per command, not across the page. A global substring check passes as soon
+	// as one command somewhere pins the identity, so a page could grow a second
+	// `cosign verify` with no constraints at all and still look compliant --
+	// and that unconstrained command is the one a reader would copy.
+	cmds := cosignVerifyCommands(joined)
+	if len(cmds) == 0 {
+		t.Fatal("the verification page publishes no cosign verify commands")
+	}
+
 	// The whole identity, repository included. Checking only the
 	// `/.github/workflows/attest.yml@refs/tags/` suffix would accept a page
 	// that pinned some other repository's workflow -- an identity under which
 	// cosign would happily verify an artifact NVIDIA never built. The suffix is
 	// the part that looks security-relevant; the origin is the part that is.
-	wantIdentity := "https://github.com/NVIDIA/cluster-readiness-engine" +
+	const wantIdentity = "https://github.com/NVIDIA/cluster-readiness-engine" +
 		"/.github/workflows/attest.yml@refs/tags/"
-	if !strings.Contains(joined, wantIdentity) {
-		t.Errorf("no published command pins the identity %q; "+
-			"it must name this repository, the signing workflow and the tag", wantIdentity)
+
+	for _, c := range cmds {
+		flat := strings.Join(strings.Fields(c), " ")
+		if !strings.Contains(flat, "--certificate-identity") {
+			t.Errorf("published command pins no --certificate-identity: %s", flat)
+			continue
+		}
+		// The identity may be inlined or passed via ${ID}; accept the variable
+		// only because the block that sets it is checked below.
+		if !strings.Contains(flat, wantIdentity) && !strings.Contains(flat, "${ID}") {
+			t.Errorf("published command does not pin this repository's identity: %s", flat)
+		}
+		if !strings.Contains(flat, "--certificate-oidc-issuer") {
+			t.Errorf("published command pins no --certificate-oidc-issuer, so any "+
+				"issuer that can mint a matching SAN is accepted: %s", flat)
+		}
 	}
 
-	if !strings.Contains(joined, "https://token.actions.githubusercontent.com") {
-		t.Error("no published command pins --certificate-oidc-issuer; " +
-			"without it any issuer that can mint a matching SAN is accepted")
+	// Whatever ${ID} and ${ISSUER} are set to must themselves be right.
+	if !strings.Contains(joined, wantIdentity) {
+		t.Errorf("no block defines the identity %q", wantIdentity)
 	}
+	if !strings.Contains(joined, "https://token.actions.githubusercontent.com") {
+		t.Error("no block defines the Sigstore OIDC issuer")
+	}
+}
+
+// cosignVerifyCommands returns each `cosign verify*` invocation, joined across
+// its backslash continuations.
+func cosignVerifyCommands(text string) []string {
+	var out []string
+	lines := strings.Split(text, "\n")
+	for i := 0; i < len(lines); i++ {
+		t := strings.TrimSpace(lines[i])
+		// Skip the retry-wrapper form and comments; match a real invocation.
+		if !strings.HasPrefix(t, "cosign verify") {
+			continue
+		}
+		cmd := t
+		for strings.HasSuffix(strings.TrimSpace(cmd), "\\") && i+1 < len(lines) {
+			i++
+			cmd = strings.TrimSuffix(strings.TrimSpace(cmd), "\\") + " " + strings.TrimSpace(lines[i])
+		}
+		out = append(out, cmd)
+	}
+	return out
 }
 
 // TestVerificationPageIsInTheNav keeps the page reachable.

--- a/test/docspolicy/verification_page_test.go
+++ b/test/docspolicy/verification_page_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/yaml"
 )
 
 // verificationPage is the page that tells users how to check what we shipped.
@@ -76,12 +78,16 @@ func TestVerificationPagePinsAnExactIdentity(t *testing.T) {
 			"an identity naming no workflow and no ref also accepts a branch build")
 	}
 
-	// The identity must name attest.yml and a tag ref. Anything looser is the
-	// defect above wearing a different spelling.
-	wantIdentity := "/.github/workflows/attest.yml@refs/tags/"
+	// The whole identity, repository included. Checking only the
+	// `/.github/workflows/attest.yml@refs/tags/` suffix would accept a page
+	// that pinned some other repository's workflow -- an identity under which
+	// cosign would happily verify an artifact NVIDIA never built. The suffix is
+	// the part that looks security-relevant; the origin is the part that is.
+	wantIdentity := "https://github.com/NVIDIA/cluster-readiness-engine" +
+		"/.github/workflows/attest.yml@refs/tags/"
 	if !strings.Contains(joined, wantIdentity) {
-		t.Errorf("no published command pins an identity containing %q; "+
-			"the identity must name the signing workflow and the tag", wantIdentity)
+		t.Errorf("no published command pins the identity %q; "+
+			"it must name this repository, the signing workflow and the tag", wantIdentity)
 	}
 
 	if !strings.Contains(joined, "https://token.actions.githubusercontent.com") {
@@ -100,8 +106,40 @@ func TestVerificationPageIsInTheNav(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read docs/index.yml: %v", err)
 	}
-	if !strings.Contains(string(raw), "operations/verifying-artifacts.md") {
-		t.Error("docs/index.yml does not list operations/verifying-artifacts.md, " +
-			"so the page does not appear in the published navigation")
+
+	// Parsed, not string-matched. A commented-out entry still contains the
+	// path, so containment would report a page as navigable while the site
+	// renders without it -- which is the exact state this test exists to catch.
+	var nav any
+	if err := yaml.Unmarshal(raw, &nav); err != nil {
+		t.Fatalf("parse docs/index.yml: %v", err)
 	}
+	if !navHasPath(nav, "operations/verifying-artifacts.md") {
+		t.Error("docs/index.yml has no navigation entry with " +
+			"path: operations/verifying-artifacts.md, so the page does not appear " +
+			"in the published navigation")
+	}
+}
+
+// navHasPath reports whether the parsed navigation contains an entry whose
+// `path` is want, at any depth.
+func navHasPath(node any, want string) bool {
+	switch v := node.(type) {
+	case map[string]any:
+		if p, ok := v["path"].(string); ok && p == want {
+			return true
+		}
+		for _, child := range v {
+			if navHasPath(child, want) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if navHasPath(child, want) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/test/helm/render_test.go
+++ b/test/helm/render_test.go
@@ -149,3 +149,89 @@ func managerArgs(rendered []byte) ([]string, error) {
 	}
 	return nil, fmt.Errorf("rendered chart has no manager Deployment container")
 }
+
+// managerImage returns the manager container's image reference.
+func managerImage(rendered []byte) (string, error) {
+	dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(rendered), 4096)
+	for {
+		var obj unstructured.Unstructured
+		err := dec.Decode(&obj)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("decode helm template output: %w", err)
+		}
+		if obj.GetKind() != "Deployment" {
+			continue
+		}
+		var dep appsv1.Deployment
+		if err := kruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep); err != nil {
+			return "", fmt.Errorf("convert manager Deployment: %w", err)
+		}
+		for i := range dep.Spec.Template.Spec.Containers {
+			if dep.Spec.Template.Spec.Containers[i].Name == "manager" {
+				return dep.Spec.Template.Spec.Containers[i].Image, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("rendered chart has no manager Deployment container")
+}
+
+// TestHelmTemplatePinsImageByDigest covers the only image reference that names
+// what an operator actually verified.
+//
+// Verification is digest-addressed. Deploying by tag afterwards deploys
+// whatever the tag resolves to at pull time, which is not necessarily what was
+// checked -- a tag can be repointed after the signature was verified. The
+// documented guidance in docs/operations/deployment.md tells operators to pin
+// by the digest they verified, and before this the chart offered no way to do
+// it: `image:` was a hardcoded `repository:tag` join, and no value could
+// produce `repository@sha256:...`.
+func TestHelmTemplatePinsImageByDigest(t *testing.T) {
+	requireHelm(t)
+	dir := chartDir(t)
+	requireChartInputs(t, dir)
+
+	const digest = "sha256:735ad1e142a378b0919510bd1fc113cd53ab754bc79b7f0980d647d50a914523"
+
+	cases := []struct {
+		name string
+		set  []string
+		want string
+	}{
+		{
+			name: "digest pins the exact bytes",
+			set:  []string{"manager.image.digest=" + digest},
+			want: "ghcr.io/nvidia/cluster-readiness-engine/manager@" + digest,
+		},
+		{
+			// A digest is more specific than a tag, so it must win rather than
+			// producing repository:tag@digest or silently ignoring one of them.
+			name: "digest wins over an explicit tag",
+			set:  []string{"manager.image.digest=" + digest, "manager.image.tag=v9.9.9"},
+			want: "ghcr.io/nvidia/cluster-readiness-engine/manager@" + digest,
+		},
+		{
+			name: "tag is still used when no digest is set",
+			set:  []string{"manager.image.tag=v9.9.9"},
+			want: "ghcr.io/nvidia/cluster-readiness-engine/manager:v9.9.9",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rendered, err := helmTemplate(dir, tc.set)
+			if err != nil {
+				t.Fatalf("helm template: %v", err)
+			}
+			got, err := managerImage(rendered)
+			if err != nil {
+				t.Fatalf("read manager image: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("manager image = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/releasepolicy/workflow_graph_test.go
+++ b/test/releasepolicy/workflow_graph_test.go
@@ -4,6 +4,7 @@
 package releasepolicy
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -300,6 +301,21 @@ func sortedKeys(m map[string]string) []string {
 // command blocks are checked.
 func TestPublishedVerifyCommandsAreExact(t *testing.T) {
 	docs := []string{"../../SECURITY.md", "../../README.md", "../../RELEASE.md"}
+
+	// Everything under docs/ too. The published verification page lives there,
+	// and a regexp identity in a docs page is worth exactly as much to a user as
+	// one in SECURITY.md -- both are commands we tell them to run.
+	if err := filepath.WalkDir("../../docs", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".md") {
+			docs = append(docs, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk docs: %v", err)
+	}
 
 	for _, path := range docs {
 		raw, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Everything this epic produces is invisible to users unless we tell them the commands. Until now the only guidance was `SECURITY.md`, and the version that shipped before #286 told people to pass `--certificate-identity-regexp='https://github.com/NVIDIA/cluster-readiness-engine'` — a pattern naming no workflow and no ref, which this repository's own `main-<sha>` development images satisfy. **Following our documentation exactly accepted an unreleased branch build as a release.**

Adds `docs/operations/verifying-artifacts.md`, in the Fern nav under Operations. It leads with the verified install path — download `installer`, check its bundle with a cosign you already trust, then run it — because the script cannot authenticate its own bytes and `curl | bash` buys TLS integrity and nothing else. Then the identity contract, the image (index carries provenance, per-platform manifests carry SBOMs, and why that asymmetry is not stylistic), the chart verified by digest and installed by digest, binaries and their three differently-named bundles, reading the provenance predicate field by field, air-gapped verification, and troubleshooting.

**Every command was executed verbatim against `v0.2.0-rc.1`**, in sequence, in one shell, as a reader would work down the page. 13 blocks, no failures.

## Related Issue

Part of #271. Also closes a gap #267 depends on (chart digest pinning) — see below.

## Type of Change
- [x] 📚 Documentation
- [x] 🔨 Build/CI

## Enforcement

Docs that drift are the failure mode here, so this ships with both halves:

- **`test/docspolicy`** — parses every published block, requires the full exact identity (repository included), a pinned issuer, and a real nav entry. Runs in `make test`.
- **`.github/workflows/docs-verify.yml`** — extracts the same blocks and runs them against the **newest** release, weekly and on change, substituting the published tag. So it fails when the *pipeline* drifts from the docs, not only when the docs change.
- `TestPublishedVerifyCommandsAreExact` now walks `docs/` too.

## Chart change

Review found that `deployment.md` told operators to "pin by the digest you verified" and the chart could not do it: `image:` was a hardcoded `repository:tag` join, so no value could produce `repository@sha256:...`. Adds `manager.image.digest`, which wins over `tag`, covered by `TestHelmTemplatePinsImageByDigest` across all three combinations.

- [x] Tests pass locally
- [x] Manual testing completed — all 13 blocks against a live release
- [x] No breaking changes

## Checklist
- [x] Self-review completed — see above
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run — n/a
- [x] Golden files updated — n/a
- [x] Documentation updated — this is the documentation
- [x] Ready for review
