### PR TITLE
docs: add H200 and B200 to GPU architecture detection list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NVCRE is for platform and infrastructure teams that bring up, validate, or resel
 ## Features
 
 - A certification catalog with NCCL communication tests and multi-node training workloads
-- Platform detection (AWS, GCP, Azure, OCI, nscale, TogetherAI, Mistral, Forge, on-prem) and GPU architecture detection (GB200, GB300, H100, A100, L40S, L40)
+- Platform detection (AWS, GCP, Azure, OCI, nscale, TogetherAI, Mistral, Forge, on-prem) and GPU architecture detection (GB200, GB300, H100, H200, B200, A100, L40S, L40)
 - Goodput measurement parsed from training logs with configurable LogProfile patterns
 - Per-bus bandwidth measurement parsed from NCCL logs
 - Node health monitoring with CEL expressions while workloads run

--- a/docs/cli-reference/workflow.md
+++ b/docs/cli-reference/workflow.md
@@ -19,7 +19,7 @@ nvcrectl workflow render [flags] <workflow.yaml>
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--platform` | auto | Target platform (`aws`, `gcp`, `azure`, `oci`, `mistral`, `forge`) |
-| `--gpu-arch` | auto | Target GPU architecture (`h100`, `gb200`, `gb300`) |
+| `--gpu-arch` | auto | Target GPU architecture with built-in mock-node templates (`h100`, `gb200`, `gb300`); other architectures are supported via `--nodes-file` or `--dry-run` (auto-detected from the cluster) |
 | `--nodes-file` | — | Path to a YAML file of `corev1.Node` objects for offline rendering (mutually exclusive with `--platform`/`--gpu-arch`) |
 | `--output` | `yaml` | Output format: `yaml` or `json` |
 | `--dry-run` | `false` | Validate against the live API server without creating resources |

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -94,7 +94,7 @@ anything.`,
 	}
 
 	cmd.Flags().StringVar(&platform, "platform", "", "Target platform (aws, gcp, azure, oci, mistral, forge)")
-	cmd.Flags().StringVar(&gpuArch, "gpu-arch", "", "Target GPU architecture (h100, gb200, gb300)")
+	cmd.Flags().StringVar(&gpuArch, "gpu-arch", "", "Target GPU architecture (h100, h200, b200, gb200, gb300, a100, l40s, l40; mock templates: h100, gb200, gb300)")
 	cmd.Flags().StringVar(&nodesFile, "nodes-file", "",
 		"Custom nodes YAML file (mutually exclusive with --platform/--gpu-arch)")
 	cmd.Flags().StringVar(&outputFormat, "output", "yaml", "Output format: yaml or json")


### PR DESCRIPTION
## Summary

The README's platform/GPU detection feature list omitted H200 and B200, even though both are supported: both have entries in the GPU defaults table (`pkg/catalog/entries/_lib/gpu-defaults.yaml`), and `docs/concepts/catalog.md` already states "Supported GPU architectures include GB200, GB300, H100, H200, and B200". The stale list made an on-prem HGX H200 cluster look unsupported at first glance — it is not (verified there).

## Related Issue

Trivial docs fix, exempt per the template.

## Type of Change
- [x] 📚 Documentation

## Component(s) Affected
- [x] Documentation / CI

## Testing
- [x] Tests pass locally (docs-only change; no code paths affected)
- [x] Manual testing completed — verified against a live 3-node on-prem HGX H200 cluster: nodes labeled `nvidia.com/gpu.product: NVIDIA-H200` are detected, and `nvcrectl certification render --platform onprem` for `communication/nccl-all-reduce` renders a valid 3-node × 8-GPU Workflow
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Commits are signed off for the DCO (`git commit -s`)
- [x] `make manifests generate` run (if `*_types.go` was modified) — n/a
- [x] Golden files updated (if integration test output changed) — n/a
- [x] Documentation updated (if needed) — this is the documentation
- [x] Ready for review