### PR TITLE
ci: scan the images we ship, weekly, for CVEs published after we shipped them

### DIFF
--- a/.github/workflows/vuln-scan-images.yml
+++ b/.github/workflows/vuln-scan-images.yml
@@ -40,6 +40,33 @@ env:
   CRANE_SHA256: c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
 
 jobs:
+  # An expired suppression must fail the run that would otherwise apply it.
+  #
+  # grype has no notion of the `# expires:` comment, so it applies every rule in
+  # .grype.yaml unconditionally. The only thing that enforces expiry is a Go
+  # test, and until this job existed that test ran solely on push and pull
+  # request -- so a rule whose date passed during a release freeze or a quiet
+  # week would be applied by the Monday scan, suppress a real finding, and
+  # report clean, with nothing red anywhere because the build that would have
+  # gone red was not running. The expiry was coupled to commit cadence rather
+  # than to the scan it protects.
+  #
+  # The same test is run, not a copy of it, so the two cannot drift.
+  validate-suppressions:
+    name: Validate .grype.yaml suppressions
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Every suppression is still in date
+        run: go test ./test/releasepolicy/ -run TestGrypeIgnoreRulesAreTriageable -count=1 -v
+
   # Resolves what to scan. Two targets, each a multi-platform index, each
   # expanded to its per-platform manifests.
   resolve:
@@ -70,10 +97,49 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The newest published release: what operators are actually running.
+          # Same bounded retry, and for the same reason, as attest.yml's
+          # crane_digest(). This step makes up to 21 anonymous GHCR calls in a
+          # burst, and a rate limit or 5xx on any of them must not be able to
+          # decide what gets scanned. Each `run:` is its own shell, so the
+          # helper is defined where it is used rather than shared.
+          crane_err="$(mktemp)"
+          crane_digest() {
+            local n out
+            for n in 1 2 3; do
+              if out="$(timeout --foreground 120s crane digest "$@" 2>"${crane_err}")"; then
+                printf '%s' "${out}"
+                return 0
+              fi
+              echo "::warning::crane digest attempt ${n} failed: $(cat "${crane_err}")" >&2
+              if [[ "${n}" -lt 3 ]]; then sleep $((n * 5)); fi
+            done
+            return 1
+          }
+
+          # A missing manifest is a real answer; anything else is the registry
+          # failing to answer. Collapsing the two lets a 5xx read as "no image
+          # here", which is how the walk-back below would silently select a
+          # stale commit -- or exhaust and blame publish.yml for a GHCR outage.
+          crane_missing() {
+            local err
+            if err="$(timeout --foreground 120s crane digest "$@" 2>&1 >/dev/null)"; then
+              return 1
+            fi
+            if grep -qiE 'MANIFEST_UNKNOWN|NAME_UNKNOWN|not found|404' <<<"${err}"; then
+              return 0
+            fi
+            echo "::error::registry error resolving $*: ${err}"
+            exit 1
+          }
+
+          # --exclude-pre-releases, deliberately. RELEASE.md states that
+          # `releases/latest` resolves to the newest stable release and never a
+          # pre-release, so that is what operators are running. Without this the
+          # scan swaps in the RC for the whole release-candidate window and the
+          # GA image -- the one actually deployed -- goes unscanned.
           release_tag="$(gh release list --repo "${GITHUB_REPOSITORY}" --exclude-drafts \
-                          --limit 1 --json tagName --jq '.[0].tagName')"
-          [[ -n "${release_tag}" ]] || { echo "::error::no published release to scan"; exit 1; }
+                          --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"
+          [[ -n "${release_tag}" ]] || { echo "::error::no published stable release to scan"; exit 1; }
 
           # The newest PUBLISHED main image: what the next release will look
           # like. Deliberately not the tip of main -- publish.yml builds on push
@@ -83,7 +149,7 @@ jobs:
           # walk back until an image is found and fail if none is.
           main_sha=""
           while read -r sha; do
-            if crane digest "${IMAGE}:main-${sha}" >/dev/null 2>&1; then
+            if ! crane_missing "${IMAGE}:main-${sha}"; then
               main_sha="${sha}"; break
             fi
           done < <(gh api "repos/${GITHUB_REPOSITORY}/commits?sha=main&per_page=15" --jq '.[].sha[0:7]')
@@ -93,18 +159,36 @@ jobs:
           fi
           echo "newest published main image: main-${main_sha}"
 
+          # Counted before the registry is consulted, so the expectation cannot
+          # be shaped by what the registry happened to answer.
+          #
+          # Belt and braces, and honestly labelled as such: every failure branch
+          # in the loop below is terminal, so nothing can currently reach the end
+          # with a short list, and no test constrains this assertion (removing it
+          # leaves the suite green). It is here to fail loudly if a later edit
+          # reintroduces a non-terminal path -- which is exactly what the
+          # original `continue` was.
+          expected=0
           targets='[]'
           for pair in "release:${release_tag}" "main:main-${main_sha}"; do
             name="${pair%%:*}"; tag="${pair#*:}"
+            expected=$((expected + 2))
 
-            if ! index="$(crane digest "${IMAGE}:${tag}" 2>/dev/null)"; then
-              echo "::warning::${IMAGE}:${tag} does not resolve; skipping the ${name} target"
-              continue
+            # Terminal, not skippable. Every sibling check in this loop exits 1;
+            # this one used to warn and continue, which let the release target --
+            # the primary subject -- vanish from a green run.
+            if ! index="$(crane_digest "${IMAGE}:${tag}")"; then
+              echo "::error::${IMAGE}:${tag} does not resolve; refusing to scan a subset"
+              exit 1
             fi
 
             amd64=""; arm64=""
             for arch in amd64 arm64; do
-              digest="$(crane digest --platform "linux/${arch}" "${IMAGE}:${tag}" 2>/dev/null || true)"
+              # From the pinned index, not the tag. Re-resolving the tag per
+              # platform allows a republish between calls to pair an amd64
+              # manifest from one index with an arm64 from another, and makes
+              # the index-equality check below compare against a stale value.
+              digest="$(crane_digest --platform "linux/${arch}" "${IMAGE}@${index}" || true)"
               if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
                 echo "::error::${name}: linux/${arch} digest is missing or malformed: '${digest}'"
                 exit 1
@@ -128,18 +212,21 @@ jobs:
             for arch in amd64 arm64; do
               case "${arch}" in amd64) d="${amd64}" ;; arm64) d="${arm64}" ;; esac
               targets="$(jq -c --arg n "${name}" --arg t "${tag}" --arg a "${arch}" --arg d "${d}" \
-                '. + [{name: ($n + "-" + $a), tag: $t, arch: $a, ref: ($n + "-" + $a), digest: $d}]' <<<"${targets}")"
+                '. + [{name: ($n + "-" + $a), tag: $t, arch: $a, digest: $d}]' <<<"${targets}")"
             done
             echo "${name} (${tag}) -> amd64 ${amd64} / arm64 ${arm64}"
           done
 
-          [[ "$(jq 'length' <<<"${targets}")" -gt 0 ]] || {
-            echo "::error::no scannable targets resolved"; exit 1; }
+          resolved="$(jq 'length' <<<"${targets}")"
+          if [[ "${resolved}" -ne "${expected}" ]]; then
+            echo "::error::resolved ${resolved} targets but set out to scan ${expected}"
+            exit 1
+          fi
           echo "value=${targets}" >> "$GITHUB_OUTPUT"
 
   scan:
     name: Scan ${{ matrix.target.name }}
-    needs: resolve
+    needs: [validate-suppressions, resolve]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -174,18 +261,38 @@ jobs:
 
       - name: Stage the report
         env:
-          SARIF: ${{ steps.scan.outputs.json }}
+          # Named for what it is. scan-action returns a path, and the output key
+          # tracks output-format above. Calling it SARIF invited switching the
+          # format to sarif, which has no top-level .matches -- and with a `//
+          # []` default that would have read as "every image is clean" on a
+          # green run rather than failing.
+          REPORT: ${{ steps.scan.outputs.json }}
           NAME: ${{ matrix.target.name }}
           DIGEST: ${{ matrix.target.digest }}
           TAG: ${{ matrix.target.tag }}
         run: |
           set -euo pipefail
           mkdir -p reports
-          # Carry the subject alongside the findings; the raw grype document
-          # does not record which reference we asked it to scan.
+
+          # Assert the shape rather than defaulting it. An absent .matches means
+          # the document is not what this step parses, and a report of zero
+          # findings is the one wrong answer that looks like good news.
+          jq -e 'has("matches")' "${REPORT}" >/dev/null || {
+            echo "::error::${REPORT} has no .matches key; grype output format changed"; exit 1; }
+
+          # severity-cutoff is passed to grype as --fail-on, which sets the exit
+          # code and does not filter the document; only --only-fixed filters. So
+          # the raw report carries every fixable match at every severity, and
+          # counting it as "high+" overstates by whatever Low and Medium the base
+          # image happens to carry. Filter here, once, so every downstream count
+          # and listing means what its label says -- including the Slack body,
+          # where sub-high rows would otherwise pad the message and could push a
+          # Critical past the truncation limit.
           jq --arg name "${NAME}" --arg digest "${DIGEST}" --arg tag "${TAG}" \
-            '{target: $name, tag: $tag, digest: $digest, matches: (.matches // [])}' \
-            "${SARIF}" > "reports/${NAME}.json"
+            '{target: $name, tag: $tag, digest: $digest,
+              matches: [.matches[] | select(.vulnerability.severity == "Critical"
+                                         or .vulnerability.severity == "High")]}' \
+            "${REPORT}" > "reports/${NAME}.json"
           jq -r '"\(.target): \(.matches | length) fixable high+ findings"' "reports/${NAME}.json"
 
       - name: Upload the raw report
@@ -215,8 +322,12 @@ jobs:
       # the ones that did not. Three green targets and a missing fourth reads
       # exactly like four clean ones.
       #
-      # resolve/ is the only place that knows what was supposed to be scanned, so
-      # the expected set is taken from there rather than from the artifacts.
+      # The expected set comes from resolve rather than from the artifacts. That
+      # is only sound because resolve now fails when it cannot resolve every
+      # target it set out to scan -- when it was allowed to warn and drop one,
+      # the dropped target was missing from this expectation too, so this check
+      # verified the survivors and reported clean. Deriving an expectation from
+      # the thing under test is the defect, wherever it is done.
       - name: Confirm every resolved target produced a report
         env:
           TARGETS: ${{ needs.resolve.outputs.targets }}
@@ -340,10 +451,66 @@ jobs:
 
           # shellcheck disable=SC2016  # $t is a jq variable, not a shell one
           jq -n --arg t "${text}" '{text: $t}' > payload.json
+          # Retried and time-bounded. This step runs only on a week that found
+          # something, so a single 429 or 5xx would discard the alert precisely
+          # when it matters, and the next attempt is seven days later.
           code="$(curl -sS -o resp.txt -w '%{http_code}' -X POST -H 'Content-type: application/json' \
+                    --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
                     --data @payload.json "${url}" || echo 000)"
           if [[ "${code}" != "200" ]]; then
             echo "::error::Slack returned ${code}: $(cat resp.txt)"
             exit 1
           fi
           echo "posted to Slack"
+
+  # A run that did not finish must reach the same people as a run that found
+  # something.
+  #
+  # Every other path here is Slack-silent on failure: if resolve fails the
+  # report job is skipped by its own `needs.resolve.result == 'success'` gate,
+  # and if a scan job fails the completeness step exits before Notify Slack is
+  # reached. The only state that reached the channel was a fully successful run
+  # with findings -- so a scan that had been failing every Monday for a month
+  # was indistinguishable, to the people the webhook exists to serve, from a
+  # clean month. The failures this workflow is built around were loud only
+  # inside the Actions tab.
+  notify-failure:
+    name: Report a run that did not complete
+    needs: [validate-suppressions, resolve, scan, report]
+    if: >-
+      always() && github.repository == 'NVIDIA/cluster-readiness-engine' &&
+      (github.event_name == 'schedule' || inputs.notify_slack) &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Notify Slack that the scan did not complete
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_PATH }}
+          VALIDATE: ${{ needs.validate-suppressions.result }}
+          RESOLVE: ${{ needs.resolve.result }}
+          SCAN: ${{ needs.scan.result }}
+          REPORT: ${{ needs.report.result }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${WEBHOOK}" ]]; then
+            echo "::notice::SLACK_WEBHOOK_PATH is not set; skipping the failure notification."
+            exit 0
+          fi
+          url="${WEBHOOK}"
+          [[ "${url}" == https://* ]] || url="https://hooks.slack.com/${WEBHOOK#/}"
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          text="$(printf '*NVCRE image vulnerability scan did not complete* — this week the images were not fully scanned.\n\nsuppressions: %s\nresolve: %s\nscan: %s\nreport: %s\n\n<%s|Full run>' \
+                   "${VALIDATE}" "${RESOLVE}" "${SCAN}" "${REPORT}" "${run_url}")"
+
+          # shellcheck disable=SC2016  # $t is a jq variable, not a shell one
+          jq -n --arg t "${text}" '{text: $t}' > payload.json
+          code="$(curl -sS -o resp.txt -w '%{http_code}' -X POST -H 'Content-type: application/json' \
+                    --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
+                    --data @payload.json "${url}" || echo 000)"
+          if [[ "${code}" != "200" ]]; then
+            echo "::error::Slack returned ${code}: $(cat resp.txt)"
+            exit 1
+          fi
+          echo "posted the failure notice to Slack"

--- a/.github/workflows/vuln-scan-images.yml
+++ b/.github/workflows/vuln-scan-images.yml
@@ -147,6 +147,14 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.resolve.outputs.targets) }}
     steps:
+      # Load-bearing, and not for the reason it looks like. The scan targets a
+      # registry digest and needs nothing from the source tree -- except
+      # .grype.yaml. scan-action passes no --config and no cwd, so grype runs in
+      # GITHUB_WORKSPACE and picks up ./.grype.yaml by its default config search.
+      # Delete this step as "we scan by digest, we don't need the repo" and every
+      # suppression stops applying, with nothing failing to say so: the scan just
+      # reports more, which reads like a worse week rather than a broken config.
+      # TestVulnScanChecksOutBeforeScanning holds this.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -200,6 +208,31 @@ jobs:
           merge-multiple: true
           path: reports
 
+      # A scan job that fails uploads no artifact, so its target does not appear
+      # in reports/ at all -- not as a failure, not as an empty result, not at
+      # all. Every summary below is built from reports/, so without this the run
+      # reports on the targets that happened to succeed and says nothing about
+      # the ones that did not. Three green targets and a missing fourth reads
+      # exactly like four clean ones.
+      #
+      # resolve/ is the only place that knows what was supposed to be scanned, so
+      # the expected set is taken from there rather than from the artifacts.
+      - name: Confirm every resolved target produced a report
+        env:
+          TARGETS: ${{ needs.resolve.outputs.targets }}
+        run: |
+          set -euo pipefail
+          missing=0
+          while read -r name; do
+            if [[ ! -s "reports/${name}.json" ]]; then
+              echo "::error::target ${name} was resolved for scanning but produced no report; its scan job failed or was skipped"
+              missing=1
+            fi
+          done < <(jq -r '.[].name' <<<"${TARGETS}")
+          [[ "${missing}" -eq 0 ]] || {
+            echo "::error::refusing to summarise a partial scan"; exit 1; }
+          echo "all $(jq 'length' <<<"${TARGETS}") resolved targets reported"
+
       # The full set every run, carried-over findings included. Diffing against
       # the previous run would stop reporting anything that had merely been seen
       # before, and a finding that disappears because it is no longer new is a
@@ -230,10 +263,13 @@ jobs:
           echo "critical=${crit}" >> "$GITHUB_OUTPUT"
           echo "high=${high}" >> "$GITHUB_OUTPUT"
 
-          # Every scanned target is listed, including the clean ones. Without
-          # this a target that failed to scan is indistinguishable from one with
-          # no findings -- both simply absent -- which is the quiet way a scan
-          # stops covering something.
+          # Every scanned target is listed, including the clean ones, so a
+          # reader can see the coverage rather than infer it from which findings
+          # happen to be present. This is presentation only -- what actually
+          # guarantees the set is complete is the step above, which fails the job
+          # when a resolved target produced no report. Listing alone cannot: a
+          # target that never scanned is absent from reports/ and so absent from
+          # this list too.
           jq -s -r '.[] | "  \(.target)  \(.tag)  \(.digest)  \(.matches | length) finding(s)"' \
             reports/*.json > scanned.txt
 
@@ -285,8 +321,22 @@ jobs:
           [[ "${url}" == https://* ]] || url="https://hooks.slack.com/${WEBHOOK#/}"
 
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # Slack rejects a message body over ~40KB. The week that overflows it
+          # is the week with the most findings -- so left alone, the alert fails
+          # exactly when it matters most. Truncate and point at the run, which
+          # has the full summary in its step output either way.
+          # Deliberately not `cut ... | head -c`: head exits at its limit, cut
+          # takes SIGPIPE, and pipefail turns that into a failed step -- on the
+          # large summary this exists to handle, and only on that one.
+          body="$(head -c 12000 summary.txt)"
+          if [[ "$(wc -c < summary.txt)" -gt 12000 ]]; then
+            body="${body}"$'\n\n[truncated -- see the full run]'
+          fi
+
+          # shellcheck disable=SC2016  # the backticks are Slack code-fence markup, not a substitution
           text="$(printf '*NVCRE image vulnerability scan* — %s critical, %s high (fixable)\n\n```%s```\n<%s|Full run>' \
-                   "${CRIT}" "${HIGH}" "$(cat summary.txt)" "${run_url}")"
+                   "${CRIT}" "${HIGH}" "${body}" "${run_url}")"
 
           # shellcheck disable=SC2016  # $t is a jq variable, not a shell one
           jq -n --arg t "${text}" '{text: $t}' > payload.json

--- a/.github/workflows/vuln-scan-images.yml
+++ b/.github/workflows/vuln-scan-images.yml
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Weekly vulnerability scan of the container images this project publishes.
+#
+# govulncheck covers Go module advisories in the source tree and codeql covers
+# the Go code. Neither sees the image: not the base layer, not an OS package,
+# not anything the Dockerfile adds. release.yml runs ClamAV over the release
+# binaries, which is malware detection, not vulnerability detection.
+#
+# The gap is time. Scanning at build time answers "was this clean when we
+# shipped it". A CVE published against a base-image package the day after a
+# release affects every operator running that release, and nothing here would
+# otherwise notice. This answers "is it clean now".
+#
+# It does not build anything. Both targets already exist in the registry, so
+# they are scanned by digest where they are.
+
+name: Vulnerability Scan (images)
+
+on:
+  schedule:
+    # Monday 08:00 UTC. Offset from codeql (06:00), govulncheck (06:30) and
+    # docs-verify (07:00) so a Monday morning does not land four scheduled
+    # jobs on the same runners at once.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      notify_slack:
+        description: 'Post the summary to Slack even on a manual run'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: ghcr.io/nvidia/cluster-readiness-engine/manager
+  CRANE_VERSION: v0.20.6
+  CRANE_SHA256: c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
+
+jobs:
+  # Resolves what to scan. Two targets, each a multi-platform index, each
+  # expanded to its per-platform manifests.
+  resolve:
+    name: Resolve scan targets
+    if: github.repository == 'NVIDIA/cluster-readiness-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      targets: ${{ steps.targets.outputs.value }}
+    steps:
+      # Same pattern as attest.yml: from the project that publishes it, checked
+      # on arrival, rather than a setup action that installs whatever is newest.
+      - name: Install crane
+        run: |
+          set -euo pipefail
+          base="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}"
+          tarball="go-containerregistry_Linux_x86_64.tar.gz"
+          tmp="$(mktemp -d)"
+          curl -fsSL -o "${tmp}/${tarball}" "${base}/${tarball}"
+          echo "${CRANE_SHA256}  ${tmp}/${tarball}" | sha256sum --check --strict -
+          tar -xzf "${tmp}/${tarball}" -C "${tmp}" crane
+          install -m 0755 "${tmp}/crane" /usr/local/bin/crane
+
+      - name: Resolve per-platform digests
+        id: targets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # The newest published release: what operators are actually running.
+          release_tag="$(gh release list --repo "${GITHUB_REPOSITORY}" --exclude-drafts \
+                          --limit 1 --json tagName --jq '.[0].tagName')"
+          [[ -n "${release_tag}" ]] || { echo "::error::no published release to scan"; exit 1; }
+
+          # The newest PUBLISHED main image: what the next release will look
+          # like. Deliberately not the tip of main -- publish.yml builds on push
+          # and the tip frequently has no image yet, so computing the tag from
+          # HEAD skips this target most of the time. A scan that silently covers
+          # half of what it claims is worse than one that covers less loudly, so
+          # walk back until an image is found and fail if none is.
+          main_sha=""
+          while read -r sha; do
+            if crane digest "${IMAGE}:main-${sha}" >/dev/null 2>&1; then
+              main_sha="${sha}"; break
+            fi
+          done < <(gh api "repos/${GITHUB_REPOSITORY}/commits?sha=main&per_page=15" --jq '.[].sha[0:7]')
+          if [[ -z "${main_sha}" ]]; then
+            echo "::error::no main-<sha> image found in the last 15 commits on main; publish.yml may be failing"
+            exit 1
+          fi
+          echo "newest published main image: main-${main_sha}"
+
+          targets='[]'
+          for pair in "release:${release_tag}" "main:main-${main_sha}"; do
+            name="${pair%%:*}"; tag="${pair#*:}"
+
+            if ! index="$(crane digest "${IMAGE}:${tag}" 2>/dev/null)"; then
+              echo "::warning::${IMAGE}:${tag} does not resolve; skipping the ${name} target"
+              continue
+            fi
+
+            amd64=""; arm64=""
+            for arch in amd64 arm64; do
+              digest="$(crane digest --platform "linux/${arch}" "${IMAGE}:${tag}" 2>/dev/null || true)"
+              if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "::error::${name}: linux/${arch} digest is missing or malformed: '${digest}'"
+                exit 1
+              fi
+              # Equal to the index means this is a plain manifest, not an index,
+              # so a "per-platform" scan would silently cover one architecture.
+              if [[ "${digest}" == "${index}" ]]; then
+                echo "::error::${name}: linux/${arch} resolved to the index digest; ${tag} is not multi-platform"
+                exit 1
+              fi
+              case "${arch}" in amd64) amd64="${digest}" ;; arm64) arm64="${digest}" ;; esac
+            done
+
+            # Identical platform digests mean the index lost an architecture and
+            # advertises one manifest twice.
+            if [[ "${amd64}" == "${arm64}" ]]; then
+              echo "::error::${name}: linux/amd64 and linux/arm64 resolved to the same digest ${amd64}"
+              exit 1
+            fi
+
+            for arch in amd64 arm64; do
+              case "${arch}" in amd64) d="${amd64}" ;; arm64) d="${arm64}" ;; esac
+              targets="$(jq -c --arg n "${name}" --arg t "${tag}" --arg a "${arch}" --arg d "${d}" \
+                '. + [{name: ($n + "-" + $a), tag: $t, arch: $a, ref: ($n + "-" + $a), digest: $d}]' <<<"${targets}")"
+            done
+            echo "${name} (${tag}) -> amd64 ${amd64} / arm64 ${arm64}"
+          done
+
+          [[ "$(jq 'length' <<<"${targets}")" -gt 0 ]] || {
+            echo "::error::no scannable targets resolved"; exit 1; }
+          echo "value=${targets}" >> "$GITHUB_OUTPUT"
+
+  scan:
+    name: Scan ${{ matrix.target.name }}
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.resolve.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # fail-build is false on purpose. This workflow reports; it does not gate.
+      # A red scheduled job caused by an upstream base-image CVE we cannot fix
+      # is how people learn to ignore red jobs.
+      - name: Scan
+        id: scan
+        uses: anchore/scan-action@27805bf3b4e84b4a5c980df22ed233c00390a439 # v7.4.2
+        with:
+          image: ${{ env.IMAGE }}@${{ matrix.target.digest }}
+          severity-cutoff: high
+          only-fixed: true
+          fail-build: false
+          output-format: json
+
+      - name: Stage the report
+        env:
+          SARIF: ${{ steps.scan.outputs.json }}
+          NAME: ${{ matrix.target.name }}
+          DIGEST: ${{ matrix.target.digest }}
+          TAG: ${{ matrix.target.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          # Carry the subject alongside the findings; the raw grype document
+          # does not record which reference we asked it to scan.
+          jq --arg name "${NAME}" --arg digest "${DIGEST}" --arg tag "${TAG}" \
+            '{target: $name, tag: $tag, digest: $digest, matches: (.matches // [])}' \
+            "${SARIF}" > "reports/${NAME}.json"
+          jq -r '"\(.target): \(.matches | length) fixable high+ findings"' "reports/${NAME}.json"
+
+      - name: Upload the raw report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vuln-report-${{ matrix.target.name }}
+          path: reports/${{ matrix.target.name }}.json
+          retention-days: 30
+
+  report:
+    name: Summarise and notify
+    needs: [resolve, scan]
+    if: always() && needs.resolve.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vuln-report-*
+          merge-multiple: true
+          path: reports
+
+      # The full set every run, carried-over findings included. Diffing against
+      # the previous run would stop reporting anything that had merely been seen
+      # before, and a finding that disappears because it is no longer new is a
+      # finding nobody fixed.
+      - name: Assemble the summary
+        id: summary
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(reports/*.json)
+          [[ ${#files[@]} -gt 0 ]] || { echo "::error::no scan reports were produced"; exit 1; }
+
+          jq -s '
+            [ .[] | . as $r
+              | ($r.matches // [])
+              | map({
+                  target: $r.target, digest: $r.digest,
+                  severity: (.vulnerability.severity // "Unknown"),
+                  id: (.vulnerability.id // "?"),
+                  package: ((.artifact.name // "?") + "@" + (.artifact.version // "?")),
+                  fix: ((.vulnerability.fix.versions // []) | join(", ")),
+                  aliases: ((.relatedVulnerabilities // []) | map(.id) | join(", "))
+                })
+            ] | flatten' "${files[@]}" > all.json
+
+          crit=$(jq '[.[] | select(.severity == "Critical")] | length' all.json)
+          high=$(jq '[.[] | select(.severity == "High")] | length' all.json)
+          echo "critical=${crit}" >> "$GITHUB_OUTPUT"
+          echo "high=${high}" >> "$GITHUB_OUTPUT"
+
+          # Every scanned target is listed, including the clean ones. Without
+          # this a target that failed to scan is indistinguishable from one with
+          # no findings -- both simply absent -- which is the quiet way a scan
+          # stops covering something.
+          jq -s -r '.[] | "  \(.target)  \(.tag)  \(.digest)  \(.matches | length) finding(s)"' \
+            reports/*.json > scanned.txt
+
+          {
+            echo "Image vulnerability scan — ${crit} critical, ${high} high (fixable)"
+            echo
+            echo "Scanned:"
+            cat scanned.txt
+            echo
+            if [[ "${crit}" -eq 0 && "${high}" -eq 0 ]]; then
+              echo "No fixable high or critical findings."
+            else
+              jq -r 'group_by(.target)[] |
+                "  \(.[0].target)  (\(.[0].digest[0:19])…)",
+                (.[] | "    [\(.severity)] \(.id)  \(.package)  fix: \(if .fix == "" then "none" else .fix end)\(if .aliases == "" then "" else "  aka \(.aliases)" end)"),
+                ""' all.json
+            fi
+          } > summary.txt
+
+          # Always echoed, so a manual run is useful with no Slack involved.
+          cat summary.txt
+          {
+            echo '### Image vulnerability scan'
+            echo '```'
+            cat summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only when there is something to act on. A weekly "0 findings" message
+      # trains people to skim past it, and then past the one that matters.
+      - name: Notify Slack
+        if: >-
+          (github.event_name == 'schedule' || inputs.notify_slack) &&
+          (steps.summary.outputs.critical != '0' || steps.summary.outputs.high != '0')
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_PATH }}
+          CRIT: ${{ steps.summary.outputs.critical }}
+          HIGH: ${{ steps.summary.outputs.high }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${WEBHOOK}" ]]; then
+            echo "::notice::SLACK_WEBHOOK_PATH is not set; skipping the notification. The summary above is complete."
+            exit 0
+          fi
+          # The secret is named PATH, so it may hold either a bare
+          # services/T.../B.../xxx path or a full URL. Accept both rather than
+          # fail on a reasonable reading of the name.
+          url="${WEBHOOK}"
+          [[ "${url}" == https://* ]] || url="https://hooks.slack.com/${WEBHOOK#/}"
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          text="$(printf '*NVCRE image vulnerability scan* — %s critical, %s high (fixable)\n\n```%s```\n<%s|Full run>' \
+                   "${CRIT}" "${HIGH}" "$(cat summary.txt)" "${run_url}")"
+
+          # shellcheck disable=SC2016  # $t is a jq variable, not a shell one
+          jq -n --arg t "${text}" '{text: $t}' > payload.json
+          code="$(curl -sS -o resp.txt -w '%{http_code}' -X POST -H 'Content-type: application/json' \
+                    --data @payload.json "${url}" || echo 000)"
+          if [[ "${code}" != "200" ]]; then
+            echo "::error::Slack returned ${code}: $(cat resp.txt)"
+            exit 1
+          fi
+          echo "posted to Slack"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Suppressions for the weekly image vulnerability scan
+# (.github/workflows/vuln-scan-images.yml).
+#
+# Without a suppression path, one unfixable CVE re-alerts every week forever and
+# the channel gets muted -- at which point the scan has negative value, because
+# it looks like coverage and nobody reads it. Without an EXPIRY, a suppression
+# outlives the reason for it and the finding never comes back.
+#
+# Every rule must carry four things, and TestGrypeIgnoreRulesAreTriageable
+# fails the build if any is missing:
+#
+#   vulnerability   the CVE or GHSA id
+#   package.name    the affected package -- never suppress an id globally
+#   justification   why it does not apply HERE, in prose, in the comment block
+#   expires         YYYY-MM-DD, after which the rule stops applying
+#
+# An expired rule is not an error in grype -- grype does not know about the
+# field. The test fails instead, which is the point: the finding re-surfaces as
+# a red build that someone has to look at, rather than staying silently muted.
+#
+# Format:
+#
+#   ignore:
+#     # justification: <why this does not apply to NVCRE>
+#     # expires: 2026-12-31
+#     - vulnerability: CVE-2026-12345
+#       package:
+#         name: some-package
+#
+# Deliberately not OpenVEX yet. OpenVEX needs a triage process to exist first,
+# and this file is where that process starts. Revisit publishing these as a
+# signed OpenVEX attestation once the ruleset has been exercised for a few
+# cycles and we know what the real justifications look like.
+
+ignore: []

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -17,9 +17,20 @@
 #   justification   why it does not apply HERE, in prose, in the comment block
 #   expires         YYYY-MM-DD, after which the rule stops applying
 #
+# The justification and expires comments must sit in the contiguous comment
+# block DIRECTLY ABOVE the rule they describe. A block parked above the
+# `ignore:` key, or separated from its rule by another rule, documents nothing
+# anyone can re-triage: there is no way to tell which justification belongs to
+# which id.
+#
+# An expiry may not be more than 180 days out. A date nobody will live to see is
+# the same as no date, and the whole mechanism is the coming-back.
+#
 # An expired rule is not an error in grype -- grype does not know about the
 # field. The test fails instead, which is the point: the finding re-surfaces as
 # a red build that someone has to look at, rather than staying silently muted.
+# The weekly scan runs that same test before it scans, so a rule cannot expire
+# during a quiet week and still be applied.
 #
 # Format:
 #

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,6 +125,12 @@ We credit reporters of confirmed vulnerabilities in the release notes of the fix
   bash installer -v "${TAG}"
   ```
 
+- **The published images are re-scanned weekly, after release.** Signing and SBOMs answer "was this what we built"; they say nothing about a CVE published after we shipped. `.github/workflows/vuln-scan-images.yml` runs every Monday at 08:00 UTC against the newest **stable** release and the newest published `main` image, both per platform, by digest. Fixable High and Critical findings are posted to Slack; a run that does not complete is posted too, so a broken scan cannot look like a clean week.
+
+  The scan reports, it does not gate — an unfixable upstream base-image CVE must not turn releases red. Findings feed the timelines in [Vulnerability Fix Timelines](#vulnerability-fix-timelines) above.
+
+  Suppressions live in [`.grype.yaml`](.grype.yaml). Every rule must name a CVE **and** a package, carry a prose justification, and expire within 180 days, with the justification and expiry in the comment block directly above the rule. `TestGrypeIgnoreRulesAreTriageable` enforces all of that and fails the build once a rule lapses — including in the weekly run itself, so a rule cannot expire during a quiet week and go on suppressing a finding. Renew a lapsed rule only after re-confirming it still applies; do not simply extend the date.
+
 ## Product Security Resources
 
 For all security-related concerns: https://www.nvidia.com/en-us/security

--- a/test/releasepolicy/grype_suppressions_test.go
+++ b/test/releasepolicy/grype_suppressions_test.go
@@ -4,6 +4,7 @@
 package releasepolicy
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -24,6 +25,82 @@ var expiryComment = regexp.MustCompile(`(?m)^\s*#\s*expires:\s*(\d{4}-\d{2}-\d{2
 // justificationComment matches the prose that says why a rule applies.
 var justificationComment = regexp.MustCompile(`(?m)^\s*#\s*justification:\s*(\S.*)$`)
 
+// checkGrypeConfig returns one message per problem found, empty if the config
+// is triageable.
+//
+// Split out from the test that reads the real file so the rules can be run
+// against configs that are deliberately wrong. With `ignore: []` -- the
+// committed state, and the state this file will be in most of the time -- every
+// assertion below is vacuously true: zero rules match zero comments and neither
+// loop executes. A test that only ever sees that input passes with both regexes
+// broken, which is indistinguishable from a test that works.
+//
+// `now` is a parameter rather than time.Now() so expiry can be tested at all.
+func checkGrypeConfig(raw []byte, now time.Time) []string {
+	var problems []string
+	report := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	var doc struct {
+		Ignore []struct {
+			Vulnerability string `json:"vulnerability"`
+			Package       struct {
+				Name string `json:"name"`
+			} `json:"package"`
+		} `json:"ignore"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return []string{fmt.Sprintf("parse: %v", err)}
+	}
+
+	body := string(raw)
+	expiries := expiryComment.FindAllStringSubmatch(body, -1)
+	justifications := justificationComment.FindAllStringSubmatch(body, -1)
+
+	// One of each per rule. Counting rather than associating keeps this simple,
+	// and a mismatch is exactly the case worth failing on: a rule added without
+	// its comment block, or a comment block left behind by a deleted rule.
+	if len(expiries) != len(doc.Ignore) {
+		report("%d ignore rules but %d `# expires:` comments; "+
+			"every suppression needs a date after which it stops applying",
+			len(doc.Ignore), len(expiries))
+	}
+	if len(justifications) != len(doc.Ignore) {
+		report("%d ignore rules but %d `# justification:` comments; "+
+			"a suppression without a stated reason cannot be re-triaged by anyone else",
+			len(doc.Ignore), len(justifications))
+	}
+
+	for i, rule := range doc.Ignore {
+		if strings.TrimSpace(rule.Vulnerability) == "" {
+			report("ignore rule %d names no vulnerability", i+1)
+		}
+		// A rule with no package suppresses the id everywhere, including in a
+		// package that really is affected.
+		if strings.TrimSpace(rule.Package.Name) == "" {
+			report("ignore rule %d (%s) names no package; "+
+				"suppressing an id globally hides it in packages that are affected",
+				i+1, rule.Vulnerability)
+		}
+	}
+
+	for _, m := range expiries {
+		expiry, err := time.Parse("2006-01-02", m[1])
+		if err != nil {
+			report("`# expires: %s` is not a YYYY-MM-DD date", m[1])
+			continue
+		}
+		if now.After(expiry) {
+			report("a suppression expired on %s. Re-triage it: confirm whether the "+
+				"finding still applies, then either fix it, or renew the rule with a new "+
+				"date and an updated justification. Do not simply extend the date.", m[1])
+		}
+	}
+
+	return problems
+}
+
 // TestGrypeIgnoreRulesAreTriageable is what keeps the weekly scan worth reading.
 //
 // A suppression with no expiry outlives its reason. The CVE stops being
@@ -40,62 +117,176 @@ func TestGrypeIgnoreRulesAreTriageable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read %s: %v", grypeConfig, err)
 	}
+	for _, p := range checkGrypeConfig(raw, time.Now().UTC()) {
+		t.Errorf("%s: %s", grypeConfig, p)
+	}
+}
+
+// TestGrypeConfigCheckRejects is the half that proves the check above does
+// anything. Each case is a config that must be refused, and the reason it must
+// be refused is the reason the suppression mechanism is safe to have at all.
+//
+// Without these, the committed `ignore: []` means the rules are never once
+// exercised against a rule -- so the first suppression anyone adds would be the
+// first time the check runs, which is the worst moment to discover it does not.
+func TestGrypeConfigCheckRejects(t *testing.T) {
+	// Fixed so an expiry case cannot start or stop failing with the calendar.
+	now := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
+
+	const justified = "# justification: not reachable in this image\n# expires: 2099-01-01\n"
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "rule with no expires comment",
+			body: "# justification: not reachable\nignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "`# expires:` comments",
+		},
+		{
+			name: "rule with no justification comment",
+			body: "# expires: 2099-01-01\nignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "`# justification:` comments",
+		},
+		{
+			name: "expired rule",
+			body: "# justification: not reachable\n# expires: 2026-09-03\n" +
+				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "expired on 2026-09-03",
+		},
+		{
+			name: "rule naming no package suppresses the id everywhere",
+			body: justified + "ignore:\n  - vulnerability: CVE-2026-1\n",
+			want: "names no package",
+		},
+		{
+			name: "rule naming no vulnerability",
+			body: justified + "ignore:\n  - package:\n      name: libfoo\n",
+			want: "names no vulnerability",
+		},
+		{
+			// The regex matches the shape, so the counts agree and only the
+			// parse catches it. A month of 13 is the case a shape-only check
+			// would wave through.
+			name: "expiry that has the shape of a date but is not one",
+			body: "# justification: not reachable\n# expires: 2026-13-99\n" +
+				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "is not a YYYY-MM-DD date",
+		},
+		{
+			name: "comment block left behind by a deleted rule",
+			body: justified + "ignore: []\n",
+			want: "`# expires:` comments",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := checkGrypeConfig([]byte(tc.body), now)
+			if len(problems) == 0 {
+				t.Fatalf("config was accepted but must be rejected:\n%s", tc.body)
+			}
+			if !strings.Contains(strings.Join(problems, "\n"), tc.want) {
+				t.Errorf("rejected for the wrong reason\n got: %s\nwant substring: %s",
+					strings.Join(problems, "\n"), tc.want)
+			}
+		})
+	}
+}
+
+// vulnScanWorkflow is the weekly image scan that consumes .grype.yaml.
+const vulnScanWorkflow = "../../.github/workflows/vuln-scan-images.yml"
+
+// TestVulnScanChecksOutBeforeScanning holds the only thing that makes every
+// rule in .grype.yaml -- and every test above -- have any effect.
+//
+// scan-action passes neither --config nor a cwd to grype, so grype finds
+// ./.grype.yaml through its default config search, relative to GITHUB_WORKSPACE.
+// That works solely because the job checks the repository out first. Nothing
+// else in the scan job needs the source: it scans a registry digest.
+//
+// So the checkout reads as removable, and removing it disarms every suppression
+// without failing anything. The scan simply starts reporting findings that were
+// triaged, which looks like a bad week upstream rather than a broken config --
+// and the fix people reach for is another suppression that also does nothing.
+func TestVulnScanChecksOutBeforeScanning(t *testing.T) {
+	raw, err := os.ReadFile(vulnScanWorkflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", vulnScanWorkflow, err)
+	}
 
 	var doc struct {
-		Ignore []struct {
-			Vulnerability string `json:"vulnerability"`
-			Package       struct {
+		Jobs map[string]struct {
+			Steps []struct {
 				Name string `json:"name"`
-			} `json:"package"`
-		} `json:"ignore"`
+				Uses string `json:"uses"`
+			} `json:"steps"`
+		} `json:"jobs"`
 	}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parse %s: %v", grypeConfig, err)
+		t.Fatalf("parse %s: %v", vulnScanWorkflow, err)
 	}
 
-	body := string(raw)
-	expiries := expiryComment.FindAllStringSubmatch(body, -1)
-	justifications := justificationComment.FindAllStringSubmatch(body, -1)
-
-	// One of each per rule. Counting rather than associating keeps this simple,
-	// and a mismatch is exactly the case worth failing on: a rule added without
-	// its comment block, or a comment block left behind by a deleted rule.
-	if len(expiries) != len(doc.Ignore) {
-		t.Errorf("%s has %d ignore rules but %d `# expires:` comments; "+
-			"every suppression needs a date after which it stops applying",
-			grypeConfig, len(doc.Ignore), len(expiries))
-	}
-	if len(justifications) != len(doc.Ignore) {
-		t.Errorf("%s has %d ignore rules but %d `# justification:` comments; "+
-			"a suppression without a stated reason cannot be re-triaged by anyone else",
-			grypeConfig, len(doc.Ignore), len(justifications))
-	}
-
-	for i, rule := range doc.Ignore {
-		if strings.TrimSpace(rule.Vulnerability) == "" {
-			t.Errorf("%s: ignore rule %d names no vulnerability", grypeConfig, i+1)
-		}
-		// A rule with no package suppresses the id everywhere, including in a
-		// package that really is affected.
-		if strings.TrimSpace(rule.Package.Name) == "" {
-			t.Errorf("%s: ignore rule %d (%s) names no package; "+
-				"suppressing an id globally hides it in packages that are affected",
-				grypeConfig, i+1, rule.Vulnerability)
+	scanned := false
+	for jobName, j := range doc.Jobs {
+		checkedOut := false
+		for _, s := range j.Steps {
+			if strings.HasPrefix(s.Uses, "actions/checkout@") {
+				checkedOut = true
+			}
+			if !strings.HasPrefix(s.Uses, "anchore/scan-action@") {
+				continue
+			}
+			scanned = true
+			if !checkedOut {
+				t.Errorf("%s: job %q runs anchore/scan-action with no preceding actions/checkout; "+
+					"grype resolves ./.grype.yaml from the workspace, so every suppression "+
+					"silently stops applying", vulnScanWorkflow, jobName)
+			}
 		}
 	}
 
-	today := time.Now().UTC()
-	for _, m := range expiries {
-		expiry, err := time.Parse("2006-01-02", m[1])
-		if err != nil {
-			t.Errorf("%s: `# expires: %s` is not a YYYY-MM-DD date", grypeConfig, m[1])
-			continue
-		}
-		if today.After(expiry) {
-			t.Errorf("%s: a suppression expired on %s. Re-triage it: confirm whether the "+
-				"finding still applies, then either fix it, or renew the rule with a new "+
-				"date and an updated justification. Do not simply extend the date.",
-				grypeConfig, m[1])
-		}
+	// Guards the guard. If the action is ever renamed or replaced, the loop
+	// above matches nothing and passes without having checked anything.
+	if !scanned {
+		t.Fatalf("%s: found no anchore/scan-action step; this test no longer covers "+
+			"what it claims and needs updating to match the scanner in use", vulnScanWorkflow)
+	}
+}
+
+// TestGrypeConfigCheckAccepts guards the other direction: a correctly formed
+// suppression must not be refused, or the mechanism is unusable and the next
+// person deletes the check instead of the rule.
+func TestGrypeConfigCheckAccepts(t *testing.T) {
+	now := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "no suppressions at all",
+			body: "ignore: []\n",
+		},
+		{
+			name: "one fully triageable rule",
+			body: "# justification: the vulnerable code path is not compiled in\n" +
+				"# expires: 2026-12-31\n" +
+				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+		},
+		{
+			name: "two rules each with their own block",
+			body: "# justification: not reachable\n# expires: 2026-12-31\n" +
+				"# justification: fixed upstream, waiting on a base image bump\n# expires: 2026-11-30\n" +
+				"ignore:\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n" +
+				"  - vulnerability: GHSA-aaaa-bbbb-cccc\n    package:\n      name: libbar\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if problems := checkGrypeConfig([]byte(tc.body), now); len(problems) > 0 {
+				t.Errorf("valid config was rejected: %s", strings.Join(problems, "\n"))
+			}
+		})
 	}
 }

--- a/test/releasepolicy/grype_suppressions_test.go
+++ b/test/releasepolicy/grype_suppressions_test.go
@@ -25,15 +25,38 @@ var expiryComment = regexp.MustCompile(`(?m)^\s*#\s*expires:\s*(\d{4}-\d{2}-\d{2
 // justificationComment matches the prose that says why a rule applies.
 var justificationComment = regexp.MustCompile(`(?m)^\s*#\s*justification:\s*(\S.*)$`)
 
+// maxExpiryHorizon bounds how far ahead a suppression may be dated.
+//
+// Rejecting only past dates leaves `# expires: 2099-01-01`, which satisfies
+// every other rule here while producing exactly the outcome .grype.yaml says
+// the expiry exists to prevent: a finding that never comes back. An expiry
+// nobody will live to see is the same as no expiry, so the horizon is what
+// makes the field mean anything.
+const maxExpiryHorizon = 180 * 24 * time.Hour
+
+// ruleStart matches the line that begins one ignore rule. Comment lines cannot
+// match, so the documented example block in .grype.yaml is not counted.
+var ruleStart = regexp.MustCompile(`^\s*-\s+\S`)
+
+// commentLine matches any comment, used to walk the contiguous block above a
+// rule.
+var commentLine = regexp.MustCompile(`^\s*#`)
+
 // checkGrypeConfig returns one message per problem found, empty if the config
 // is triageable.
 //
 // Split out from the test that reads the real file so the rules can be run
 // against configs that are deliberately wrong. With `ignore: []` -- the
-// committed state, and the state this file will be in most of the time -- every
-// assertion below is vacuously true: zero rules match zero comments and neither
-// loop executes. A test that only ever sees that input passes with both regexes
+// committed state, and the state this file will be in most of the time -- a
+// count-based check is vacuously true: zero rules match zero comments and no
+// loop executes. A test that only ever sees that input passes with every regex
 // broken, which is indistinguishable from a test that works.
+//
+// Comments are associated with the rule they sit above rather than counted
+// against the file total. .grype.yaml tells contributors that "every rule must
+// carry four things"; counting cannot enforce that, and accepts a file whose
+// justifications and expiries sit anywhere so long as the totals agree -- which
+// makes re-triage a guess about which justification belongs to which CVE.
 //
 // `now` is a parameter rather than time.Now() so expiry can be tested at all.
 func checkGrypeConfig(raw []byte, now time.Time) []string {
@@ -54,51 +77,90 @@ func checkGrypeConfig(raw []byte, now time.Time) []string {
 		return []string{fmt.Sprintf("parse: %v", err)}
 	}
 
-	body := string(raw)
-	expiries := expiryComment.FindAllStringSubmatch(body, -1)
-	justifications := justificationComment.FindAllStringSubmatch(body, -1)
-
-	// One of each per rule. Counting rather than associating keeps this simple,
-	// and a mismatch is exactly the case worth failing on: a rule added without
-	// its comment block, or a comment block left behind by a deleted rule.
-	if len(expiries) != len(doc.Ignore) {
-		report("%d ignore rules but %d `# expires:` comments; "+
-			"every suppression needs a date after which it stops applying",
-			len(doc.Ignore), len(expiries))
-	}
-	if len(justifications) != len(doc.Ignore) {
-		report("%d ignore rules but %d `# justification:` comments; "+
-			"a suppression without a stated reason cannot be re-triaged by anyone else",
-			len(doc.Ignore), len(justifications))
+	blocks := ruleCommentBlocks(string(raw))
+	if len(blocks) != len(doc.Ignore) {
+		report("found %d ignore rules but %d rule lines; the file's shape is not "+
+			"what this check can reason about", len(doc.Ignore), len(blocks))
+		return problems
 	}
 
 	for i, rule := range doc.Ignore {
+		label := fmt.Sprintf("ignore rule %d (%s)", i+1, rule.Vulnerability)
+
 		if strings.TrimSpace(rule.Vulnerability) == "" {
 			report("ignore rule %d names no vulnerability", i+1)
 		}
 		// A rule with no package suppresses the id everywhere, including in a
 		// package that really is affected.
 		if strings.TrimSpace(rule.Package.Name) == "" {
-			report("ignore rule %d (%s) names no package; "+
-				"suppressing an id globally hides it in packages that are affected",
-				i+1, rule.Vulnerability)
+			report("%s names no package; "+
+				"suppressing an id globally hides it in packages that are affected", label)
 		}
-	}
 
-	for _, m := range expiries {
-		expiry, err := time.Parse("2006-01-02", m[1])
+		b := blocks[i]
+		if b.justification == "" {
+			report("%s has no `# justification:` in the comment block directly above it; "+
+				"a suppression without a stated reason cannot be re-triaged by anyone else", label)
+		}
+		if b.expires == "" {
+			report("%s has no `# expires:` in the comment block directly above it; "+
+				"every suppression needs a date after which it stops applying", label)
+			continue
+		}
+
+		expiry, err := time.Parse("2006-01-02", b.expires)
 		if err != nil {
-			report("`# expires: %s` is not a YYYY-MM-DD date", m[1])
+			report("%s: `# expires: %s` is not a YYYY-MM-DD date", label, b.expires)
 			continue
 		}
 		if now.After(expiry) {
-			report("a suppression expired on %s. Re-triage it: confirm whether the "+
-				"finding still applies, then either fix it, or renew the rule with a new "+
-				"date and an updated justification. Do not simply extend the date.", m[1])
+			report("%s expired on %s. Re-triage it: confirm whether the finding still "+
+				"applies, then either fix it, or renew the rule with a new date and an "+
+				"updated justification. Do not simply extend the date.", label, b.expires)
+		}
+		if expiry.After(now.Add(maxExpiryHorizon)) {
+			report("%s expires on %s, more than %d days out. A suppression dated that far "+
+				"ahead never comes back for re-triage, which is what an expiry is for.",
+				label, b.expires, int(maxExpiryHorizon.Hours()/24))
 		}
 	}
 
 	return problems
+}
+
+// ruleBlock is the justification and expiry found in the contiguous comment
+// block immediately above one ignore rule.
+type ruleBlock struct {
+	justification string
+	expires       string
+}
+
+// ruleCommentBlocks returns one entry per ignore rule, in file order, carrying
+// whatever the contiguous comment block directly above that rule declared.
+//
+// "Directly above" is the whole point: a block separated from its rule by
+// another rule, or parked above the `ignore:` key, documents nothing a reader
+// can act on.
+func ruleCommentBlocks(body string) []ruleBlock {
+	lines := strings.Split(body, "\n")
+	var out []ruleBlock
+
+	for i, line := range lines {
+		if !ruleStart.MatchString(line) {
+			continue
+		}
+		var b ruleBlock
+		for j := i - 1; j >= 0 && commentLine.MatchString(lines[j]); j-- {
+			if m := justificationComment.FindStringSubmatch(lines[j]); m != nil && b.justification == "" {
+				b.justification = strings.TrimSpace(m[1])
+			}
+			if m := expiryComment.FindStringSubmatch(lines[j]); m != nil && b.expires == "" {
+				b.expires = m[1]
+			}
+		}
+		out = append(out, b)
+	}
+	return out
 }
 
 // TestGrypeIgnoreRulesAreTriageable is what keeps the weekly scan worth reading.
@@ -133,7 +195,9 @@ func TestGrypeConfigCheckRejects(t *testing.T) {
 	// Fixed so an expiry case cannot start or stop failing with the calendar.
 	now := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
 
-	const justified = "# justification: not reachable in this image\n# expires: 2099-01-01\n"
+	// A well-formed block, directly above its rule, well inside the horizon.
+	const ok = "ignore:\n  # justification: not reachable in this image\n" +
+		"  # expires: 2026-12-31\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n"
 
 	for _, tc := range []struct {
 		name string
@@ -142,43 +206,67 @@ func TestGrypeConfigCheckRejects(t *testing.T) {
 	}{
 		{
 			name: "rule with no expires comment",
-			body: "# justification: not reachable\nignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
-			want: "`# expires:` comments",
+			body: "ignore:\n  # justification: not reachable\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "no `# expires:`",
 		},
 		{
 			name: "rule with no justification comment",
-			body: "# expires: 2099-01-01\nignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
-			want: "`# justification:` comments",
+			body: "ignore:\n  # expires: 2026-12-31\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "no `# justification:`",
 		},
 		{
 			name: "expired rule",
-			body: "# justification: not reachable\n# expires: 2026-09-03\n" +
-				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2026-09-03\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
 			want: "expired on 2026-09-03",
 		},
 		{
+			// The rule this file exists to prevent. Every other assertion is
+			// satisfied; only the horizon catches it.
+			name: "expiry so far out the finding never returns",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2099-01-01\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			want: "more than 180 days out",
+		},
+		{
 			name: "rule naming no package suppresses the id everywhere",
-			body: justified + "ignore:\n  - vulnerability: CVE-2026-1\n",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2026-12-31\n" +
+				"  - vulnerability: CVE-2026-1\n",
 			want: "names no package",
 		},
 		{
 			name: "rule naming no vulnerability",
-			body: justified + "ignore:\n  - package:\n      name: libfoo\n",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2026-12-31\n" +
+				"  - package:\n      name: libfoo\n",
 			want: "names no vulnerability",
 		},
 		{
-			// The regex matches the shape, so the counts agree and only the
-			// parse catches it. A month of 13 is the case a shape-only check
-			// would wave through.
+			// The regex matches the shape, so only the parse catches it. A month
+			// of 13 is the case a shape-only check would wave through.
 			name: "expiry that has the shape of a date but is not one",
-			body: "# justification: not reachable\n# expires: 2026-13-99\n" +
-				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2026-13-99\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
 			want: "is not a YYYY-MM-DD date",
 		},
 		{
-			name: "comment block left behind by a deleted rule",
-			body: justified + "ignore: []\n",
-			want: "`# expires:` comments",
+			// Both blocks parked above the `ignore:` key rather than above the
+			// rules they justify. Totals agree, so a counting check accepts this
+			// -- and nobody can tell which justification belongs to which CVE.
+			name: "comment blocks not attached to the rules they describe",
+			body: "# justification: not reachable\n# expires: 2026-12-31\n" +
+				"# justification: fixed upstream\n# expires: 2026-11-30\n" +
+				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n" +
+				"  - vulnerability: CVE-2026-2\n    package:\n      name: libbar\n",
+			want: "no `# justification:` in the comment block directly above it",
+		},
+		{
+			// The second rule borrows nothing: the block above it belongs to the
+			// first rule, and there is no contiguous comment run of its own.
+			name: "second rule with no block of its own",
+			body: ok + "  - vulnerability: CVE-2026-2\n    package:\n      name: libbar\n",
+			want: "no `# justification:`",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -270,17 +358,28 @@ func TestGrypeConfigCheckAccepts(t *testing.T) {
 		},
 		{
 			name: "one fully triageable rule",
-			body: "# justification: the vulnerable code path is not compiled in\n" +
-				"# expires: 2026-12-31\n" +
-				"ignore:\n  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
+			body: "ignore:\n" +
+				"  # justification: the vulnerable code path is not compiled in\n" +
+				"  # expires: 2026-12-31\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
 		},
 		{
+			// Each block sits directly above the rule it describes, which is the
+			// layout .grype.yaml documents and the only one a re-triager can
+			// read. The earlier version of this case put both blocks above the
+			// `ignore:` key and still called itself "each with their own block".
 			name: "two rules each with their own block",
-			body: "# justification: not reachable\n# expires: 2026-12-31\n" +
-				"# justification: fixed upstream, waiting on a base image bump\n# expires: 2026-11-30\n" +
-				"ignore:\n" +
+			body: "ignore:\n" +
+				"  # justification: not reachable\n  # expires: 2026-12-31\n" +
 				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n" +
+				"  # justification: fixed upstream, waiting on a base image bump\n" +
+				"  # expires: 2026-11-30\n" +
 				"  - vulnerability: GHSA-aaaa-bbbb-cccc\n    package:\n      name: libbar\n",
+		},
+		{
+			name: "expiry exactly at the horizon",
+			body: "ignore:\n  # justification: not reachable\n  # expires: 2027-03-03\n" +
+				"  - vulnerability: CVE-2026-1\n    package:\n      name: libfoo\n",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/releasepolicy/grype_suppressions_test.go
+++ b/test/releasepolicy/grype_suppressions_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+// grypeConfig holds the suppressions the weekly image scan applies.
+const grypeConfig = "../../.grype.yaml"
+
+// expiryComment matches the `# expires: YYYY-MM-DD` line a rule must carry.
+// The date lives in a comment because grype has no such field -- it would
+// reject an unknown key -- so the deadline is enforced here instead.
+var expiryComment = regexp.MustCompile(`(?m)^\s*#\s*expires:\s*(\d{4}-\d{2}-\d{2})\s*$`)
+
+// justificationComment matches the prose that says why a rule applies.
+var justificationComment = regexp.MustCompile(`(?m)^\s*#\s*justification:\s*(\S.*)$`)
+
+// TestGrypeIgnoreRulesAreTriageable is what keeps the weekly scan worth reading.
+//
+// A suppression with no expiry outlives its reason. The CVE stops being
+// reported, the package stays vulnerable, and nothing ever asks again -- the
+// finding is not fixed, it is hidden, and the hiding is permanent. Grype cannot
+// enforce this because it has no notion of an expiring rule, so the deadline is
+// carried in a comment and enforced here.
+//
+// The failure is deliberately loud: an expired rule turns the build red until
+// someone re-triages it. That is the whole mechanism. A quiet expiry would be
+// the same as no expiry.
+func TestGrypeIgnoreRulesAreTriageable(t *testing.T) {
+	raw, err := os.ReadFile(grypeConfig)
+	if err != nil {
+		t.Fatalf("read %s: %v", grypeConfig, err)
+	}
+
+	var doc struct {
+		Ignore []struct {
+			Vulnerability string `json:"vulnerability"`
+			Package       struct {
+				Name string `json:"name"`
+			} `json:"package"`
+		} `json:"ignore"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", grypeConfig, err)
+	}
+
+	body := string(raw)
+	expiries := expiryComment.FindAllStringSubmatch(body, -1)
+	justifications := justificationComment.FindAllStringSubmatch(body, -1)
+
+	// One of each per rule. Counting rather than associating keeps this simple,
+	// and a mismatch is exactly the case worth failing on: a rule added without
+	// its comment block, or a comment block left behind by a deleted rule.
+	if len(expiries) != len(doc.Ignore) {
+		t.Errorf("%s has %d ignore rules but %d `# expires:` comments; "+
+			"every suppression needs a date after which it stops applying",
+			grypeConfig, len(doc.Ignore), len(expiries))
+	}
+	if len(justifications) != len(doc.Ignore) {
+		t.Errorf("%s has %d ignore rules but %d `# justification:` comments; "+
+			"a suppression without a stated reason cannot be re-triaged by anyone else",
+			grypeConfig, len(doc.Ignore), len(justifications))
+	}
+
+	for i, rule := range doc.Ignore {
+		if strings.TrimSpace(rule.Vulnerability) == "" {
+			t.Errorf("%s: ignore rule %d names no vulnerability", grypeConfig, i+1)
+		}
+		// A rule with no package suppresses the id everywhere, including in a
+		// package that really is affected.
+		if strings.TrimSpace(rule.Package.Name) == "" {
+			t.Errorf("%s: ignore rule %d (%s) names no package; "+
+				"suppressing an id globally hides it in packages that are affected",
+				grypeConfig, i+1, rule.Vulnerability)
+		}
+	}
+
+	today := time.Now().UTC()
+	for _, m := range expiries {
+		expiry, err := time.Parse("2006-01-02", m[1])
+		if err != nil {
+			t.Errorf("%s: `# expires: %s` is not a YYYY-MM-DD date", grypeConfig, m[1])
+			continue
+		}
+		if today.After(expiry) {
+			t.Errorf("%s: a suppression expired on %s. Re-triage it: confirm whether the "+
+				"finding still applies, then either fix it, or renew the rule with a new "+
+				"date and an updated justification. Do not simply extend the date.",
+				grypeConfig, m[1])
+		}
+	}
+}

--- a/test/releasepolicy/vuln_scan_resolve_test.go
+++ b/test/releasepolicy/vuln_scan_resolve_test.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package releasepolicy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// The weekly image scan decides what gets scanned in one shell step, and every
+// completeness guarantee downstream is anchored to what that step emits. The
+// report job checks that every resolved target produced a report -- so if this
+// step is allowed to quietly resolve fewer targets than it set out to, the
+// check downstream validates the survivors and the run reports clean.
+//
+// That is not hypothetical: the first version of this step warned and
+// `continue`d when an image did not resolve, which dropped the release target
+// -- the image operators actually run -- from a green weekly run that sent no
+// notification, because the Slack step only fires when findings exist.
+//
+// These tests execute the step's own shell against stubs, extracted from the
+// workflow rather than copied, so they cannot drift from what they cover.
+
+const resolveStepName = "Resolve per-platform digests"
+
+// resolveStep returns the body of the resolve step, by job and step name.
+func resolveStep(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(vulnScanWorkflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", vulnScanWorkflow, err)
+	}
+	var doc struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `json:"name"`
+				Run  string `json:"run"`
+			} `json:"steps"`
+		} `json:"jobs"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", vulnScanWorkflow, err)
+	}
+	for _, s := range doc.Jobs["resolve"].Steps {
+		if s.Name == resolveStepName {
+			return s.Run
+		}
+	}
+	t.Fatalf("%s has no step %q in job \"resolve\"; if it was renamed, update this "+
+		"test rather than deleting it -- the branch it covers is the one that runs "+
+		"when the registry does not answer", vulnScanWorkflow, resolveStepName)
+	return ""
+}
+
+// resolveHarness stubs the three commands the step shells out to.
+//
+// The stubs record their arguments rather than only returning a status. A stub
+// that returns only an exit code cannot tell "the step asked the registry the
+// right question" from "the step asked nothing at all" -- which is how a
+// version of this step that resolved per-platform digests from a mutable tag
+// instead of the pinned index would pass a status-only harness unchanged.
+func resolveHarness(t *testing.T, dir, failTag string) {
+	t.Helper()
+
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	// `timeout` is GNU coreutils and is absent on darwin, where these tests also
+	// run. The step wraps every crane call in it, so it is stubbed to drop the
+	// flag and duration and exec the rest. Nothing here is testing timeout.
+	write(t, filepath.Join(bin, "timeout"), `#!/usr/bin/env bash
+[[ "$1" == "--foreground" ]] && shift
+shift
+exec "$@"
+`)
+
+	// Distinct digests per platform, and neither equal to the index, so the
+	// step's own multi-platform assertions pass on the happy path.
+	write(t, filepath.Join(bin, "crane"), fmt.Sprintf(`#!/usr/bin/env bash
+echo "$*" >> %q
+ref="${!#}"
+if [[ -n %q && "${ref}" == *%q* ]]; then
+  echo "MANIFEST_UNKNOWN: manifest unknown" >&2
+  exit 1
+fi
+if [[ "$*" == *"--platform linux/amd64"* ]]; then
+  echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+elif [[ "$*" == *"--platform linux/arm64"* ]]; then
+  echo "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+else
+  echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+fi
+`, filepath.Join(dir, "crane.log"), failTag, failTag))
+
+	write(t, filepath.Join(bin, "gh"), fmt.Sprintf(`#!/usr/bin/env bash
+echo "$*" >> %q
+if [[ "$1" == "release" ]]; then
+  echo "v1.2.3"
+elif [[ "$1" == "api" ]]; then
+  printf '%%s\n' aaaaaaa bbbbbbb ccccccc
+fi
+`, filepath.Join(dir, "gh.log")))
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil { //nolint:gosec // stub must be executable
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func runResolve(t *testing.T, failTag string) (out string, failed bool, dir string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	resolveHarness(t, dir, failTag)
+	out, failed = runShell(t, dir, resolveStep(t),
+		"PATH="+filepath.Join(dir, "bin")+":"+os.Getenv("PATH"),
+		"IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager",
+		"GITHUB_REPOSITORY=NVIDIA/cluster-readiness-engine",
+		"GH_TOKEN=stub",
+	)
+	return out, failed, dir
+}
+
+// TestResolveRefusesAPartialTargetSet is the regression test for the defect
+// that made every downstream completeness check unable to see a missing target.
+func TestResolveRefusesAPartialTargetSet(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		failTag string
+		want    string
+	}{
+		{
+			// The image operators are actually running.
+			name:    "release image does not resolve",
+			failTag: "v1.2.3",
+			want:    "refusing to scan a subset",
+		},
+		{
+			// The other half of the claimed coverage.
+			name:    "main image does not resolve",
+			failTag: "main-",
+			want:    "no main-<sha> image found",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, failed, dir := runResolve(t, tc.failTag)
+			if !failed {
+				t.Fatalf("resolve accepted a partial target set and exited 0:\n%s", out)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("failed for the wrong reason\n got: %s\nwant substring: %s", out, tc.want)
+			}
+			// Exiting non-zero is not enough: a step that emitted a short target
+			// list and then failed for an unrelated reason would still hand the
+			// report job a set it would happily call complete.
+			if got := readLog(t, filepath.Join(dir, "github_output")); strings.Contains(got, "value=") {
+				t.Errorf("resolve published a target set on a failed run: %s", got)
+			}
+		})
+	}
+}
+
+// TestResolveScansTheStableRelease pins the target selection itself.
+//
+// `gh release list --exclude-drafts --limit 1` returns the newest release
+// including pre-releases, so during any RC window the scan would substitute the
+// RC for the GA image and never scan what operators are running -- green, and
+// silent, because Slack only fires on findings.
+func TestResolveScansTheStableRelease(t *testing.T) {
+	_, failed, dir := runResolve(t, "")
+	if failed {
+		t.Fatalf("resolve failed on the happy path")
+	}
+
+	gh := readLog(t, filepath.Join(dir, "gh.log"))
+	if !strings.Contains(gh, "--exclude-pre-releases") {
+		t.Errorf("resolve asked for the newest release without --exclude-pre-releases, "+
+			"so an RC displaces the GA image operators run; gh calls were:\n%s", gh)
+	}
+}
+
+// TestResolvePinsPlatformsToTheIndex holds the digest handoff.
+//
+// Re-resolving the tag for each platform lets a republish between calls pair an
+// amd64 manifest from one index with an arm64 from another, under one target
+// name -- and makes the step's own "equal to the index" assertion compare
+// against a value that is no longer current. attest.yml resolves the index once
+// and descends from it for exactly this reason.
+func TestResolvePinsPlatformsToTheIndex(t *testing.T) {
+	_, failed, dir := runResolve(t, "")
+	if failed {
+		t.Fatalf("resolve failed on the happy path")
+	}
+
+	for line := range strings.SplitSeq(readLog(t, filepath.Join(dir, "crane.log")), "\n") {
+		if !strings.Contains(line, "--platform") {
+			continue
+		}
+		if !strings.Contains(line, "@sha256:") {
+			t.Errorf("per-platform digest resolved from a mutable tag rather than the "+
+				"pinned index: %q", line)
+		}
+	}
+}
+
+// TestResolveEmitsEveryTarget is the accept side. Without it, a step that
+// failed unconditionally would satisfy every rejection case above.
+func TestResolveEmitsEveryTarget(t *testing.T) {
+	out, failed, dir := runResolve(t, "")
+	if failed {
+		t.Fatalf("resolve rejected a fully resolvable set:\n%s", out)
+	}
+
+	got := readLog(t, filepath.Join(dir, "github_output"))
+	if !strings.Contains(got, "value=") {
+		t.Fatalf("resolve published no target set:\n%s", got)
+	}
+	// Two targets, two platforms each. The step asserts this itself; this
+	// confirms the assertion is reachable and passes on a good run.
+	for _, want := range []string{"release-amd64", "release-arm64", "main-amd64", "main-arm64"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("target %q missing from the published set: %s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #276. Part of #262, Phase 4 — Assure.

## Why

`govulncheck` covers Go module advisories in the source tree and CodeQL covers the Go code. Neither sees the image — not the base layer, not an OS package, not anything the Dockerfile adds. `release.yml` runs ClamAV over the release binaries, which is malware detection, not vulnerability detection.

The gap is time. Scanning at build time answers *"was this clean when we shipped it."* A CVE published against a base-image package the day after a release affects every operator running that release, and nothing in this repository would otherwise notice. This answers *"is it clean now."*

## What

A scheduled workflow (Mondays 08:00 UTC, offset from the three other scheduled jobs) that scans two published multi-platform images by digest — the newest **stable** release and the newest published `main-<sha>` — each expanded to its per-platform manifests. It builds nothing; both targets already exist in the registry.

`fail-build: false` on purpose. This reports, it does not gate: a red scheduled job caused by an upstream base-image CVE we cannot fix is how people learn to ignore red jobs. Slack fires on fixable High/Critical findings, and separately when a run does not complete.

`.grype.yaml` carries the suppressions. Every rule must name a CVE **and** a package, carry a prose justification, and expire within 180 days, with justification and expiry in the comment block directly above the rule it describes. Deliberately not OpenVEX yet — that needs a triage process to exist first, and this file is where it starts.

## Review found two ways this could report green while covering less than it claims

Both are the epic's named recurring failure — a check that reads as protective and is not — and both are fixed here.

**`resolve` fail-opened.** An unresolvable image index warned and `continue`d, dropping that target, while every sibling check in the same loop exits 1. The report job's completeness check reads `needs.resolve.outputs.targets` — the *already-reduced* set — so it could not see the omission; it verified the survivors and reported clean. A week in which the released image was never scanned was indistinguishable from a week in which it was clean, and Slack stayed quiet because it only fires on findings. Resolution is now terminal, and every `crane` call goes through the same bounded-retry helper `attest.yml` already uses, so a registry blip is retried rather than silently narrowing coverage.

**The scan was pointed at the wrong image.** `gh release list --exclude-drafts --limit 1` returns the newest release *including pre-releases*. Verified against the live repo: that query returns `v0.2.0-rc.1` today, while the actual latest stable is `v0.1.0`. For the whole RC window the scan would have covered the candidate and never the GA image operators are running — the exact case the workflow exists for. `RELEASE.md` already states `releases/latest` is stable-only.

## Also corrected

- **Per-platform digests were re-resolved from the mutable tag**, so a republish between calls could pair an `amd64` manifest from one index with an `arm64` from another, and made the index-equality assertion compare against a stale value. Now descends from the pinned index, as `attest.yml` does for the same reason.
- **`severity-cutoff` is grype's `--fail-on`** — it sets the exit code and does not filter the report; only `--only-fixed` filters. Counts labelled "fixable high+" therefore included Low and Medium, padding the Slack body and letting the truncation limit push a Critical out of the alert. Verified against the pinned action's source, not inferred. Filtered once, at staging.
- **Suppression expiry was enforced only on push and PR**, so a rule could lapse during a release freeze or a quiet week and still be applied by the Monday scan with nothing red — the expiry was coupled to commit cadence rather than to the scan it protects. The scheduled run now runs that same test before scanning.
- **An expiry had no upper bound.** `# expires: 2099-01-01` satisfied every check while never coming back, which is precisely what the field exists to prevent. Bounded to 180 days.
- **Justification and expiry are now associated with the rule they sit above**, not counted against file totals. Counting cannot enforce what `.grype.yaml` promises a contributor, and accepted a file where no reader could tell which justification belonged to which CVE.
- **Every failure path was Slack-silent** — if `resolve` failed the report job was skipped by its own gate, and if a scan failed the completeness step exited before the notify step was reached. A scan failing every Monday for a month looked, to the people the webhook serves, like a clean month.
- **The `SARIF` env var held a path to a grype JSON report.** The name invited switching `output-format` to `sarif`, which has no top-level `.matches` — and `// []` would have turned that into "every image is clean" on a green run rather than a failure. Renamed; the document shape is asserted rather than defaulted.

## Tests

`TestResolveRefusesAPartialTargetSet`, `TestResolveScansTheStableRelease` and `TestResolvePinsPlatformsToTheIndex` execute the resolve step's own shell against recording stubs, extracted from the workflow rather than copied so they cannot drift. The stubs record arguments, not just exit status — a status-only stub cannot tell "asked the registry the right question" from "asked nothing at all."

`TestGrypeConfigCheckRejects` / `Accepts` replace what was a vacuous test: with the committed `ignore: []`, the original assertions were all trivially true and passed with both regexes broken.

Mutation-verified. Restoring the `continue`, dropping `--exclude-pre-releases`, re-resolving platforms from the tag, removing the expiry-horizon, ignoring comment-block contiguity, and dropping the justification/expires/package/vulnerability requirements are each caught.

One assertion is **not** covered: the expected-vs-resolved cardinality check. Removing it leaves the suite green, because every earlier branch in that loop is already terminal. It is kept as a guard against a future non-terminal path — which is exactly what the original `continue` was — and its comment says that rather than implying it is load-bearing.

## Verification

`make build`, `make lint` (0 issues), `make test` (unit + 182s integration) green. `actionlint` clean.

## Open items

- **Slack destination unverified.** `SLACK_WEBHOOK_PATH` exists in repo secrets (created 2026-09-02), which resolves epic open question 6 — but I have `maintain`, not `admin`, so I cannot confirm which channel it reaches. Worth checking before the first Monday it fires.
- Epic open question 7 is answered here as **both** targets. Easy to drop the `main` one if that is not wanted.
- `crane` and `gh` calls in `resolve` are anonymous. That matches `docs-verify.yml`, which already does weekly anonymous reads against this image, so it is the existing repo pattern rather than a new exposure — but it is why the retry helper matters.
