### PR TITLE
chore(deps): hold the kubernetes group at 0.36.x until kubeflow/trainer supports 1.37

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,46 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
+    # TEMPORARY: hold the Kubernetes libraries at 0.36.x until
+    # github.com/kubeflow/trainer/v2 ships a 1.37-compatible release.
+    #
+    # Kubernetes 1.37 removed the unused corev1.PodStatusResult type
+    # (kubernetes/kubernetes#136271, listed under API Change in
+    # CHANGELOG-1.37; it had no REST endpoint and had been unused since
+    # 2015). Trainer still references it from its generated openapi, and we
+    # import that package in api/v1alpha1/job_types.go, so bumping these
+    # modules fails the build with "undefined: corev1.PodStatusResult" and
+    # takes every CI job down with it. See the failure on #312.
+    #
+    # Nothing in our dependency graph actually wants 0.37; only Dependabot
+    # proposes it. Trainer master is still on k8s v0.36.4 and the bump is
+    # open in kubeflow/trainer#4005, itself blocked on kubeflow/trainer#4006.
+    # Watch #4005: when it lands and a release follows, bump trainer and
+    # delete this block in the same PR.
+    #
+    # Scoped to minor and major so 0.36.x patch updates keep flowing. Only
+    # the modules that move with the Kubernetes minor are listed. k8s.io/klog
+    # (v2.x), k8s.io/kube-openapi and k8s.io/utils (pseudo-versions), and the
+    # independently versioned sigs.k8s.io modules are deliberately excluded
+    # so they are not frozen by accident. controller-runtime is included
+    # because 0.25.0 requires k8s.io/api v0.37.0.
+    ignore:
+      - dependency-name: "k8s.io/api"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/apimachinery"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/apiserver"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/client-go"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/component-base"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "k8s.io/streaming"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     groups:
       kubernetes:
         patterns:


### PR DESCRIPTION
Stops Dependabot from re-raising the same red Kubernetes bump every Monday, and records why.

#### The problem

The k8s bump in #312 fails to build:

```
../../../go/pkg/mod/github.com/kubeflow/trainer/v2@v2.2.1/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go:279:10: undefined: corev1.PodStatusResult
```

Kubernetes 1.37 removed the unused `corev1.PodStatusResult` type (kubernetes/kubernetes#136271, listed under API Change in CHANGELOG-1.37; no REST endpoint, unused since 2015). It was still baked into generated openapi, so anything shipping a `zz_generated.openapi.go` over core/v1 breaks until it regenerates. `kubeflow/trainer` is one of those, and we import it from `api/v1alpha1/job_types.go`, so the whole module stops type-checking. That single error is what fails Lint, Build, Test, CodeQL, govulncheck, Verify and UAT on #312.

The PR does not bump `k8s.io/api` directly, but `client-go` v0.37.0 requires it, so it arrives transitively.

#### There is nothing to fix on our side

- trainer v2.2.1 (pinned) and v2.3.0 (latest) both still reference `PodStatusResult`
- trainer `master` is still on `k8s.io/api` v0.36.4
- the bump is open and unmerged in kubeflow/trainer#4005, itself blocked on kubeflow/trainer#4006 (envtest 1.37 rejects the CRDs: CEL rule cost budget, and rules referencing an undefined `metadata.namespace`)

Nothing in our graph actually wants 0.37 — our own `require` is already the maximum and trainer holds at 0.36. The only thing proposing it is Dependabot, which is why this is a Dependabot config change rather than a `replace` in `go.mod`. Version skew between `apimachinery`/`client-go` at 0.37 and `api` held at 0.36 is not a supported configuration.

Not unique to us: `sigs.k8s.io/custom-metrics-apiserver` broke identically, and elastic/elasticsearch-k8s-metrics-adapter#296 landed the same remedy.

#### Scope

Scoped to `minor` and `major` only, so 0.36.x patch updates keep flowing automatically — those carry most of the security fixes, which is the same reasoning behind the shorter patch cooldown already in this file.

Only the modules that move with the Kubernetes minor are listed:

`k8s.io/api`, `k8s.io/apiextensions-apiserver`, `k8s.io/apimachinery`, `k8s.io/apiserver`, `k8s.io/client-go`, `k8s.io/component-base`, `k8s.io/streaming`, `sigs.k8s.io/controller-runtime`

`controller-runtime` is included because 0.25.0 requires `k8s.io/api` v0.37.0. `k8s.io/klog` (v2.140.0), `k8s.io/kube-openapi` and `k8s.io/utils` (pseudo-versions), and the independently versioned `sigs.k8s.io` modules are deliberately excluded so a broad `k8s.io/*` match does not freeze them by accident.

#### Config over an `@dependabot ignore` comment

The comment command would also work and self-clears when the dependency is manually bumped. It is not used here because it stores the preference centrally, outside the repo, where it is invisible to everyone who did not read this thread. GitHub's own guidance is that for repositories with more than one contributor it is better to define ignores in the configuration file. The tradeoff is that this one does not self-clear, so the rule carries the reason and the upstream PR to watch in its `description`.

#### Removing this

Watch kubeflow/trainer#4005. When it lands and a trainer release follows, bump trainer and delete the `ignore` block in the same PR.

Validated by parsing the file and checking the resulting ignore entries.
