### PR TITLE
docs: admission-policy samples for Kyverno and Sigstore policy-controller (#272)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,12 @@ people do not tag at the same time.
    made visible only by the `Verify release` job, after it has verified every published
    artifact. If that job fails, the release stays a draft — see Troubleshooting.
 5. Check the published release, then announce it.
+6. If you maintain the admission-policy samples, bump the pinned `subject:` tag in
+   `config/samples/policy/kyverno-verify-images.yaml` and
+   `config/samples/policy/policy-controller-verify-images.yaml` to the new release
+   (or open a follow-up PR). Nothing in CI rewrites those strings; a stale pin is a
+   policy that will deny the next upgrade for anyone who applied the sample as-is.
+   See [Verifying release artifacts](docs/operations/verifying-artifacts.md#admission-policy-samples).
 
 Do not publish a draft release by hand. A draft left behind by a failed `Verify release`
 is a release the pipeline determined it could not verify; publishing it from the UI is

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,7 +35,15 @@ people do not tag at the same time.
 1. Make sure `main` is green. Every required check must pass: Lint, Build, Test, Verify,
    and UAT.
 2. Decide the version. See Versioning above.
-3. Tag the commit on `main` and push the tag.
+3. Bump the pinned `subject:` tag in
+   `config/samples/policy/kyverno-verify-images.yaml` and
+   `config/samples/policy/policy-controller-verify-images.yaml` to the version you are
+   about to cut, and land that change on `main` **before** tagging. Nothing in CI
+   rewrites those strings. Tagging first and bumping later leaves the samples at that
+   tag pinned to the previous release — exactly the stale-pin outage the bump exists to
+   prevent. See [Verifying release artifacts](docs/operations/verifying-artifacts.md#admission-policy-samples).
+4. Tag the commit on `main` (the one that already carries the bumped pins) and push the
+   tag.
 
    ```bash
    git checkout main && git pull --ff-only
@@ -47,16 +55,10 @@ people do not tag at the same time.
    `NVIDIA/cluster-readiness-engine`, which is usually `upstream`.
 
    Sign the tag (`-s`). Pushing the tag is the release trigger.
-4. Watch the `Release` workflow. The GitHub Release is created as a **draft** and is
+5. Watch the `Release` workflow. The GitHub Release is created as a **draft** and is
    made visible only by the `Verify release` job, after it has verified every published
    artifact. If that job fails, the release stays a draft — see Troubleshooting.
-5. Check the published release, then announce it.
-6. If you maintain the admission-policy samples, bump the pinned `subject:` tag in
-   `config/samples/policy/kyverno-verify-images.yaml` and
-   `config/samples/policy/policy-controller-verify-images.yaml` to the new release
-   (or open a follow-up PR). Nothing in CI rewrites those strings; a stale pin is a
-   policy that will deny the next upgrade for anyone who applied the sample as-is.
-   See [Verifying release artifacts](docs/operations/verifying-artifacts.md#admission-policy-samples).
+6. Check the published release, then announce it.
 
 Do not publish a draft release by hand. A draft left behind by a failed `Verify release`
 is a release the pipeline determined it could not verify; publishing it from the UI is

--- a/config/samples/policy/kyverno-verify-images.yaml
+++ b/config/samples/policy/kyverno-verify-images.yaml
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kyverno ImageValidatingPolicy for the NVCRE manager image.
+#
+# WHY ImageValidatingPolicy (not ClusterPolicy / verifyImages)
+# -----------------------------------------------------------
+# NVCRE publishes Sigstore *new-bundle* signatures as OCI referrers
+# (https://sigstore.dev/cosign/sign/v1 and https://slsa.dev/provenance/v1).
+# There is no legacy `sha256-<digest>.sig` tag for current releases.
+# Kyverno's deprecated ClusterPolicy `verifyImages` looks only for that
+# legacy tag and reports "no signatures found" against a correctly signed
+# image. ImageValidatingPolicy reads the referrer / bundle path.
+#
+# BEFORE YOU APPLY
+# ----------------
+# 1. Edit `subject:` below so the tag matches the release you actually run.
+#    Applying a pin that does not match the image already in the cluster
+#    will deny the next upgrade, rollout restart, node drain, or crash
+#    replacement until you edit the policy again.
+# 2. Label the namespace that runs the controller (default `nvcre`):
+#      kubectl label namespace nvcre \
+#        kubernetes.nvcre.nvidia.com/image-admission=enforce
+# 3. Prefer deploying the manager by *index digest* (see verifying-artifacts.md).
+#    Provenance is attested to the multi-platform index digest only; a
+#    per-platform child manifest carries a signature + CycloneDX SBOM and
+#    no SLSA provenance, so requiring provenance against a platform digest
+#    correctly denies.
+#
+# PARKED FAILURE MODES THIS SAMPLE ADDRESSES (issue #272)
+# -------------------------------------------------------
+# 1. Namespace scoping — matchConstraints.namespaceSelector confines the
+#    ValidatingAdmissionPolicy / webhook to labeled namespaces. Without it,
+#    failurePolicy: Fail is effectively cluster-wide for every Pod /
+#    Deployment / Job create in every namespace except Kyverno's excludes.
+# 2. failurePolicy — Fail is intentional (fail closed), but only safe once
+#    namespace-scoped. matchImageReferences is evaluated *inside* Kyverno
+#    after the API server has already called the webhook; it cannot narrow
+#    which requests reach a Fail webhook. Namespace selectors can.
+# 3. Provenance — validations require verifyAttestationSignatures for
+#    https://slsa.dev/provenance/v1 in addition to the image signature,
+#    matching the human-run `cosign verify` + `verify-attestation --type
+#    slsaprovenance1` contract in docs/operations/verifying-artifacts.md.
+# 4. subject / glob — `subject:` is a STRICT match. Putting `refs/tags/.+`
+#    under `subject:` matches no real SAN and denies everything; the regexp
+#    form needs `subjectRegExp:`. The image globs name the repository path
+#    exactly (no `manager*` prefix wildcard that crosses path segments).
+#
+# Identity contract (ADR-074 / verifying-artifacts.md):
+#   issuer:  https://token.actions.githubusercontent.com
+#   subject: https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/<TAG>
+#
+# Requires Kyverno >= v1.19 (ImageValidatingPolicy stable on policies.kyverno.io/v1).
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: nvcre-manager-verify-images
+  labels:
+    app.kubernetes.io/name: cluster-readiness-engine
+    app.kubernetes.io/component: admission-sample
+spec:
+  validationActions: [Deny]
+  failurePolicy: Fail
+  webhookConfiguration:
+    timeoutSeconds: 20
+  evaluation:
+    background:
+      # Do not background-scan existing objects: a stale pin must not page
+      # operators for workloads that were admitted under a previous release.
+      enabled: false
+  matchConstraints:
+    # Confines webhook evaluation to namespaces the operator opted in.
+    # failurePolicy: Fail still fails closed — but only for these namespaces.
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.nvcre.nvidia.com/image-admission
+          operator: In
+          values: ["enforce"]
+    resourceRules:
+      # Include controllers that own pod templates. Matching only Pods lets a
+      # Deployment create succeed and then fail when the Pod is created.
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs", "cronjobs"]
+  matchImageReferences:
+    # Narrow globs on purpose. A trailing `manager*` can match manager-debug,
+    # managerial-tool, or manager/nested/extra depending on the glob library.
+    # Tag and digest forms are listed explicitly instead.
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager"
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager:*"
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager@*"
+  attestors:
+    - name: nvcreRelease
+      cosign:
+        keyless:
+          identities:
+            # EDIT THIS TAG to the release you run before applying.
+            # Exact identity — never a prefix regexp that also accepts
+            # publish.yml@refs/heads/main development images.
+            - issuer: "https://token.actions.githubusercontent.com"
+              subject: "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/v0.2.0"
+              # Loosening (operator choice, not the published contract):
+              # subject: is a STRICT string match. A value like
+              #   .../attest.yml@refs/tags/.+
+              # under subject: matches no certificate SAN and denies every
+              # image. To accept any release tag while still rejecting
+              # refs/heads/main, replace subject: with subjectRegExp:
+              #   subjectRegExp: "^https://github\\.com/NVIDIA/cluster-readiness-engine/\\.github/workflows/attest\\.yml@refs/tags/.+$"
+              # Do not use subjectRegExp that omits the workflow or the
+              # refs/tags/ anchor — that re-opens main-<sha> development images.
+        ctlog:
+          url: "https://rekor.sigstore.dev"
+  attestations:
+    # CamelCase name so CEL can use attestations.slsaProvenance (hyphens are not
+    # valid field selectors).
+    - name: slsaProvenance
+      intoto:
+        # Same predicate the docs verify with --type slsaprovenance1.
+        type: "https://slsa.dev/provenance/v1"
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.nvcreRelease])).all(e, e > 0)
+      message: >-
+        NVCRE manager image signature verification failed. Expected a new-bundle
+        cosign signature under attest.yml@refs/tags/<pinned-tag>. Legacy
+        ClusterPolicy/verifyImages cannot see these signatures.
+    - expression: >-
+        images.containers.map(image,
+          verifyAttestationSignatures(image, attestations.slsaProvenance,
+            [attestors.nvcreRelease])).all(e, e > 0)
+      message: >-
+        NVCRE manager image is missing a verified SLSA Build Provenance v1
+        attestation on the index digest (ADR-074). Per-platform manifests carry
+        an SBOM, not provenance — pin the index digest.

--- a/config/samples/policy/kyverno-verify-images.yaml
+++ b/config/samples/policy/kyverno-verify-images.yaml
@@ -26,6 +26,12 @@
 #    per-platform child manifest carries a signature + CycloneDX SBOM and
 #    no SLSA provenance, so requiring provenance against a platform digest
 #    correctly denies.
+# 4. If you mirrored the controller image off ghcr.io, rewrite every
+#    matchImageReferences glob below to your mirror repository path.
+#    Kyverno pre-filters images.* to glob matches and initialises an empty
+#    list when nothing matches — both validations then succeed vacuously
+#    (fail-open). A silent no-op on the documented air-gap path is worse
+#    than a deny.
 #
 # PARKED FAILURE MODES THIS SAMPLE ADDRESSES (issue #272)
 # -------------------------------------------------------
@@ -61,6 +67,17 @@ metadata:
 spec:
   validationActions: [Deny]
   failurePolicy: Fail
+  # Explicit CRD defaults (v1.19): each of these defaults to true. Setting them
+  # here documents that applying this sample also registers a *mutating*
+  # webhook that rewrites matching tags to digests (mutateDigest), and that
+  # required/verifyDigest run alongside the CEL validations below. required
+  # is load-bearing for init/ephemeral coverage even before the concatenations
+  # in validations: (EnforceRequired denies matched images that no validation
+  # checked).
+  validationConfigurations:
+    mutateDigest: true
+    verifyDigest: true
+    required: true
   webhookConfiguration:
     timeoutSeconds: 20
   evaluation:
@@ -82,7 +99,10 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["pods"]
+        # pods/ephemeralcontainers is required for kubectl debug / ephemeral
+        # coverage; images.ephemeralContainers is populated only when this
+        # subresource is in matchConstraints.
+        resources: ["pods", "pods/ephemeralcontainers"]
       - apiGroups: ["apps"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
@@ -95,6 +115,8 @@ spec:
     # Narrow globs on purpose. A trailing `manager*` can match manager-debug,
     # managerial-tool, or manager/nested/extra depending on the glob library.
     # Tag and digest forms are listed explicitly instead.
+    # Hard-pinned to ghcr.io for the public default. Mirror / air-gap installs
+    # must rewrite these (see BEFORE YOU APPLY #4) — unmatched globs fail open.
     - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager"
     - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager:*"
     - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager@*"
@@ -105,7 +127,9 @@ spec:
           identities:
             # EDIT THIS TAG to the release you run before applying.
             # Exact identity — never a prefix regexp that also accepts
-            # publish.yml@refs/heads/main development images.
+            # attest.yml@refs/heads/main development images (publish.yml now
+            # routes all signing through attest.yml; main builds carry
+            # attest.yml@refs/heads/main).
             - issuer: "https://token.actions.githubusercontent.com"
               subject: "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/v0.2.0"
               # Loosening (operator choice, not the published contract):
@@ -115,8 +139,9 @@ spec:
               # image. To accept any release tag while still rejecting
               # refs/heads/main, replace subject: with subjectRegExp:
               #   subjectRegExp: "^https://github\\.com/NVIDIA/cluster-readiness-engine/\\.github/workflows/attest\\.yml@refs/tags/.+$"
-              # Do not use subjectRegExp that omits the workflow or the
-              # refs/tags/ anchor — that re-opens main-<sha> development images.
+              # Do not use subjectRegExp that omits the repository path, the
+              # workflow, or the refs/tags/ anchor — that re-opens main-<sha>
+              # development images and foreign forks.
         ctlog:
           url: "https://rekor.sigstore.dev"
   attestations:
@@ -127,15 +152,23 @@ spec:
         # Same predicate the docs verify with --type slsaprovenance1.
         type: "https://slsa.dev/provenance/v1"
   validations:
+    # Concatenate containers + initContainers + ephemeralContainers. The three
+    # are distinct keys on images (pkg/cel/compiler/images.go); containers alone
+    # leaves init/ephemeral to validationConfigurations.required (deny with a
+    # "no policy performed a check" message). Explicit coverage keeps the deny
+    # message accurate. ephemeralContainers only appears when
+    # pods/ephemeralcontainers is in matchConstraints above.
     - expression: >-
-        images.containers.map(image,
+        (images.?containers.orValue([]) + images.?initContainers.orValue([]) +
+          images.?ephemeralContainers.orValue([])).map(image,
           verifyImageSignatures(image, [attestors.nvcreRelease])).all(e, e > 0)
       message: >-
         NVCRE manager image signature verification failed. Expected a new-bundle
         cosign signature under attest.yml@refs/tags/<pinned-tag>. Legacy
         ClusterPolicy/verifyImages cannot see these signatures.
     - expression: >-
-        images.containers.map(image,
+        (images.?containers.orValue([]) + images.?initContainers.orValue([]) +
+          images.?ephemeralContainers.orValue([])).map(image,
           verifyAttestationSignatures(image, attestations.slsaProvenance,
             [attestors.nvcreRelease])).all(e, e > 0)
       message: >-

--- a/config/samples/policy/kyverno-verify-images.yaml
+++ b/config/samples/policy/kyverno-verify-images.yaml
@@ -99,9 +99,12 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
-        # pods/ephemeralcontainers is required for kubectl debug / ephemeral
-        # coverage; images.ephemeralContainers is populated only when this
-        # subresource is in matchConstraints.
+        # pods/ephemeralcontainers is required so the API server routes
+        # kubectl debug / ephemeral-container patches to this policy. Without
+        # it, CREATE/UPDATE on pods alone never sees those requests.
+        # (images.ephemeralContainers is always present on built-in GVRs —
+        # initialised to [] — and can be non-empty on a plain pods UPDATE;
+        # the subresource rule is about interception, not key presence.)
         resources: ["pods", "pods/ephemeralcontainers"]
       - apiGroups: ["apps"]
         apiVersions: ["v1"]
@@ -156,8 +159,9 @@ spec:
     # are distinct keys on images (pkg/cel/compiler/images.go); containers alone
     # leaves init/ephemeral to validationConfigurations.required (deny with a
     # "no policy performed a check" message). Explicit coverage keeps the deny
-    # message accurate. ephemeralContainers only appears when
-    # pods/ephemeralcontainers is in matchConstraints above.
+    # message accurate. The pods/ephemeralcontainers matchConstraints rule above
+    # is what routes kubectl debug into these checks — the ephemeralContainers
+    # key itself is always populated (as [] when empty).
     - expression: >-
         (images.?containers.orValue([]) + images.?initContainers.orValue([]) +
           images.?ephemeralContainers.orValue([])).map(image,

--- a/config/samples/policy/policy-controller-verify-images.yaml
+++ b/config/samples/policy/policy-controller-verify-images.yaml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sigstore policy-controller ClusterImagePolicy for the NVCRE manager image.
+#
+# WHY signatureFormat: bundle
+# --------------------------
+# NVCRE publishes cosign *new-bundle* artifacts as OCI referrers (ADR-074 pins
+# cosign v3.1.3, where --new-bundle-format defaults to true). policy-controller
+# defaults to the legacy signature format and will not see our referrers unless
+# `signatureFormat: bundle` is set on the authority.
+#
+# In bundle mode, policy-controller verifies *attestations*, not the legacy
+# plain-signature path. The sample therefore requires:
+#   - https://sigstore.dev/cosign/sign/v1  (the signed identity, bundle form)
+#   - https://slsa.dev/provenance/v1      (the provenance the docs also check)
+# See sigstore/policy-controller#1899 for the bundle + cosign/sign/v1 shape.
+#
+# NAMESPACE SCOPING
+# -----------------
+# policy-controller is opt-in by namespace label (default chart behaviour):
+#   kubectl label namespace nvcre policy.sigstore.dev/include=true
+# Unlabeled namespaces are not evaluated, so a Fail / enforce mode here does
+# not strand workload creation cluster-wide. Do not flip the webhook to
+# opt-out without understanding the blast radius.
+#
+# BEFORE YOU APPLY
+# ----------------
+# 1. Edit the `subject:` pin to the release tag you run.
+# 2. Label the namespace (above).
+# 3. Deploy the manager by index digest — provenance is on the index only.
+#
+# Tested versions to prefer when re-checking: policy-controller >= v0.15.0
+# (vendors cosign v3). Chart-default older versions may still work with
+# signatureFormat: bundle; do not treat a default-settings failure as a
+# format incompatibility without that field set.
+#
+# Identity contract (ADR-074 / verifying-artifacts.md):
+#   issuer:  https://token.actions.githubusercontent.com
+#   subject: https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/<TAG>
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: nvcre-manager-verify-images
+  labels:
+    app.kubernetes.io/name: cluster-readiness-engine
+    app.kubernetes.io/component: admission-sample
+spec:
+  mode: enforce
+  images:
+    # golang filepath globs; `**` matches across `/`. Do not use a bare
+    # `manager*` suffix — that over-matches manager-debug and nested paths.
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager"
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager:*"
+    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager@sha256:*"
+  authorities:
+    - name: nvcre-release
+      keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          # EDIT THIS TAG to the release you run before applying.
+          - issuer: "https://token.actions.githubusercontent.com"
+            subject: "https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/v0.2.0"
+            # Loosening: subject is a STRICT match. A pattern under subject
+            # such as refs/tags/.+ matches no SAN. Use subjectRegExp instead:
+            #   subjectRegExp: "^https://github\\.com/NVIDIA/cluster-readiness-engine/\\.github/workflows/attest\\.yml@refs/tags/.+$"
+            # Still reject refs/heads/main and any identity that omits attest.yml.
+      # Required for NVCRE's referrer / new-bundle layout. Without this field
+      # the authority looks for legacy .sig tags we do not publish on current
+      # release digests.
+      signatureFormat: bundle
+      ctlog:
+        url: https://rekor.sigstore.dev
+      attestations:
+        # Bundle format exposes the cosign signature as this predicate type
+        # (not as a separate legacy signature object).
+        - name: signature
+          predicateType: https://sigstore.dev/cosign/sign/v1
+        # Same predicate docs/operations/verifying-artifacts.md checks with
+        # cosign verify-attestation --type slsaprovenance1.
+        - name: provenance
+          predicateType: https://slsa.dev/provenance/v1

--- a/config/samples/policy/policy-controller-verify-images.yaml
+++ b/config/samples/policy/policy-controller-verify-images.yaml
@@ -20,20 +20,32 @@
 # -----------------
 # policy-controller is opt-in by namespace label (default chart behaviour):
 #   kubectl label namespace nvcre policy.sigstore.dev/include=true
-# Unlabeled namespaces are not evaluated, so a Fail / enforce mode here does
-# not strand workload creation cluster-wide. Do not flip the webhook to
-# opt-out without understanding the blast radius.
+# Unlabeled namespaces are not evaluated. Labelling a namespace does *not*
+# narrow enforcement to images that match this ClusterImagePolicy alone:
+# chart-default `no-match-policy` is `deny`, so every image in a labeled
+# namespace that matches no ClusterImagePolicy is rejected. A Fail / enforce
+# mode here therefore does not strand workload creation cluster-wide, but it
+# *does* deny non-NVCRE images inside the labeled namespace unless the
+# operator has separately set `no-match-policy` to `allow` or `warn`. Do not
+# flip the webhook to opt-out without understanding the blast radius.
 #
 # BEFORE YOU APPLY
 # ----------------
 # 1. Edit the `subject:` pin to the release tag you run.
-# 2. Label the namespace (above).
+# 2. Label the namespace (above) — and decide `no-match-policy` if that
+#    namespace runs any non-NVCRE images.
 # 3. Deploy the manager by index digest — provenance is on the index only.
+# 4. If you mirrored the controller image off ghcr.io, rewrite every
+#    `images[].glob` below to your mirror repository path. Globs that match
+#    nothing leave the image under no-match-policy (deny by default), which
+#    is a hard deny rather than Kyverno's empty-list fail-open — still wrong
+#    for a mirrored manager image you intended to admit under this policy.
 #
 # Tested versions to prefer when re-checking: policy-controller >= v0.15.0
 # (vendors cosign v3). Chart-default older versions may still work with
 # signatureFormat: bundle; do not treat a default-settings failure as a
-# format incompatibility without that field set.
+# format incompatibility without that field set. This sample shape has not
+# been re-tested end-to-end for issue #272; see verifying-artifacts.md.
 #
 # Identity contract (ADR-074 / verifying-artifacts.md):
 #   issuer:  https://token.actions.githubusercontent.com
@@ -48,9 +60,14 @@ metadata:
 spec:
   mode: enforce
   images:
-    # golang filepath globs; `**` matches across `/`. Do not use a bare
-    # `manager*` suffix — that over-matches manager-debug and nested paths.
-    - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager"
+    # policy-controller compiles globs in pkg/apis/glob/glob.go (not
+    # filepath.Match): `.` → `\.`, `**` → `.*`, `*` → `[^/]*`. So `*` cannot
+    # cross `/` and a bare `manager*` suffix still over-matches manager-debug
+    # in the final path segment — avoid it. Patterns are matched against
+    # ref.Name(), which is always fully qualified with a tag or digest, so a
+    # bare `.../manager` glob (no `:` / `@`) never matches and is omitted.
+    # Hard-pinned to ghcr.io for the public default; rewrite on mirror installs
+    # (see BEFORE YOU APPLY #4).
     - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager:*"
     - glob: "ghcr.io/nvidia/cluster-readiness-engine/manager@sha256:*"
   authorities:
@@ -64,13 +81,16 @@ spec:
             # Loosening: subject is a STRICT match. A pattern under subject
             # such as refs/tags/.+ matches no SAN. Use subjectRegExp instead:
             #   subjectRegExp: "^https://github\\.com/NVIDIA/cluster-readiness-engine/\\.github/workflows/attest\\.yml@refs/tags/.+$"
-            # Still reject refs/heads/main and any identity that omits attest.yml.
+            # Still reject refs/heads/main and any identity that omits attest.yml
+            # or the NVIDIA/cluster-readiness-engine repository path.
       # Required for NVCRE's referrer / new-bundle layout. Without this field
       # the authority looks for legacy .sig tags we do not publish on current
       # release digests.
       signatureFormat: bundle
-      ctlog:
-        url: https://rekor.sigstore.dev
+      # ctlog.url is not read in bundle mode — verification material comes from
+      # the TUF trusted root; only ctlog.trustRootRef is compared to
+      # keyless.trustRootRef. Omitted here on purpose (Kyverno's ctlog.url is
+      # live and stays set in that sample).
       attestations:
         # Bundle format exposes the cosign signature as this predicate type
         # (not as a separate legacy signature object).

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -407,7 +407,7 @@ provenance (`emit_provenance: false` on those legs); pin the index digest in Hel
 2. **Label the namespace** that runs the controller (default `nvcre`) so enforcement is
    opt-in, not cluster-wide:
 
-   ```bash
+   ```shell
    # Kyverno sample (matchConstraints.namespaceSelector)
    kubectl label namespace nvcre \
      kubernetes.nvcre.nvidia.com/image-admission=enforce
@@ -418,7 +418,7 @@ provenance (`emit_provenance: false` on those legs); pin the index digest in Hel
 
 3. Apply the sample that matches the admission controller you already run:
 
-   ```bash
+   ```shell
    kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
    # or
    kubectl apply -f config/samples/policy/policy-controller-verify-images.yaml
@@ -442,7 +442,7 @@ These constraints are load-bearing; a first attempt that skipped them was parked
 This environment may not have Docker or Kind. On a machine that does, the intended check
 is server-side dry-run so the admission webhook actually runs:
 
-```bash
+```shell
 TAG=v0.2.0
 IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
 DIGEST="$(crane digest "${IMAGE}:${TAG}")"
@@ -474,7 +474,7 @@ kubectl run nvcre-other --image="busybox:1.36" -n nvcre \
   --dry-run=server --restart=Never -o name
 ```
 
-CI does **not** reproduce live admission: it needs a cluster and registry access. Structural
+These repro steps are fenced as `shell` rather than `bash` so Docs Verify (which extracts and runs every `bash` block on this page) does not try them without a cluster. CI does **not** reproduce live admission: it needs a cluster and registry access. Structural
 tests under `test/docspolicy` pin the kind, fail-closed policy, issuer, identity prefix,
 namespace selector, provenance attestation, narrow globs, and `signatureFormat: bundle`
 so the samples cannot silently rot into the parked shape.

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -374,8 +374,110 @@ using the `cosign` provider, matching the same OIDC issuer and identity used abo
 Whether that path works end to end against a real Flux version is still being confirmed
 (issue #267), so this page does not yet publish a manifest for it — an untested
 verification config is exactly the kind of false assurance the rest of this page exists to
-avoid. Admission-policy samples for Kyverno and the Sigstore policy-controller are tracked
-in issue #272.
+avoid.
+
+### Admission-policy samples
+
+Samples under [`config/samples/policy/`](https://github.com/NVIDIA/cluster-readiness-engine/tree/main/config/samples/policy)
+pin the same issuer and `attest.yml@refs/tags/<TAG>` identity as the commands above, and
+they expect the **new-bundle / OCI referrer** layout ADR-074 publishes (not a legacy
+`sha256-<digest>.sig` tag).
+
+| Verifier | Reads our format? | Sample |
+|---|---|---|
+| `cosign verify` / `verify-attestation` (v3.1.3) | Yes | this page |
+| Kyverno `ImageValidatingPolicy` (v1.19+) | Yes — referrer / bundle path | `config/samples/policy/kyverno-verify-images.yaml` |
+| Kyverno `ClusterPolicy` / `verifyImages` | **No** — looks for legacy `.sig` tags | do not use |
+| Sigstore policy-controller with `signatureFormat: bundle` | Yes — attestations in bundle form | `config/samples/policy/policy-controller-verify-images.yaml` |
+| Sigstore policy-controller at chart default (legacy format) | **No** against current release digests | set `signatureFormat: bundle` |
+| Flux `OCIRepository` `spec.verify.provider: cosign` | Unconfirmed (issue #267) | — |
+
+Both samples require a signature **and** SLSA Build Provenance v1 on the image **index**
+digest, matching the two `cosign` commands in [Verifying the container image](#verifying-the-container-image).
+A per-platform child manifest is signed and carries a CycloneDX SBOM but **not**
+provenance (`emit_provenance: false` on those legs); pin the index digest in Helm with
+`manager.image.digest`, as above.
+
+#### Apply runbook
+
+1. **Edit the pinned tag** in the sample so `subject:` names the release you run. Nothing
+   in CI rewrites that string when a new tag ships. Applying a pin that does not match the
+   image already in the cluster will deny the next upgrade, `rollout restart`, node drain,
+   or crash-loop replacement until you edit the policy.
+2. **Label the namespace** that runs the controller (default `nvcre`) so enforcement is
+   opt-in, not cluster-wide:
+
+   ```bash
+   # Kyverno sample (matchConstraints.namespaceSelector)
+   kubectl label namespace nvcre \
+     kubernetes.nvcre.nvidia.com/image-admission=enforce
+
+   # policy-controller sample (chart-default opt-in)
+   kubectl label namespace nvcre policy.sigstore.dev/include=true
+   ```
+
+3. Apply the sample that matches the admission controller you already run:
+
+   ```bash
+   kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
+   # or
+   kubectl apply -f config/samples/policy/policy-controller-verify-images.yaml
+   ```
+
+#### Why the samples look the way they do
+
+These constraints are load-bearing; a first attempt that skipped them was parked (issue
+#272) because it would break an operator's cluster.
+
+| Concern | What the samples do |
+|---|---|
+| Namespace scoping | Kyverno: `matchConstraints.namespaceSelector` on an opt-in label. policy-controller: namespace must carry `policy.sigstore.dev/include=true`. |
+| `failurePolicy` / enforce mode | Fail-closed on purpose, but only after the namespace opt-in above. Image globs are evaluated *inside* the controller and cannot narrow which requests hit a Fail webhook. |
+| Provenance | Both require a verified `https://slsa.dev/provenance/v1` attestation, not signature-only. |
+| Identity matching | Live field is exact `subject:` for one release tag. A regexp belongs under `subjectRegExp:` — putting `refs/tags/.+` under `subject:` matches no SAN and denies everything. Image globs name `.../manager`, `.../manager:*`, and `.../manager@*` (or `@sha256:*`); they deliberately avoid a `manager*` prefix wildcard. |
+| Bundle format | policy-controller sets `signatureFormat: bundle` and checks the `cosign/sign/v1` + `slsa.dev/provenance/v1` attestations that referrers expose. |
+
+#### Kind reproduction (operator / maintainer)
+
+This environment may not have Docker or Kind. On a machine that does, the intended check
+is server-side dry-run so the admission webhook actually runs:
+
+```bash
+TAG=v0.2.0
+IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
+DIGEST="$(crane digest "${IMAGE}:${TAG}")"
+ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
+
+# Cluster with Kyverno >= v1.19 (or policy-controller >= v0.15.0 + signatureFormat: bundle)
+kubectl create namespace nvcre --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace nvcre \
+  kubernetes.nvcre.nvidia.com/image-admission=enforce \
+  policy.sigstore.dev/include=true --overwrite
+
+# Edit the sample's subject pin to ${TAG}, then:
+kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
+
+# Admitted: signed release index by digest
+kubectl run nvcre-admit --image="${IMAGE}@${DIGEST}" -n nvcre \
+  --dry-run=server --restart=Never -o name
+
+# Denied: signed under publish.yml@refs/heads/main (development image)
+kubectl run nvcre-deny-main --image="${IMAGE}:main" -n nvcre \
+  --dry-run=server --restart=Never -o name
+
+# Denied: unsigned tag under our repository (not a real release digest)
+kubectl run nvcre-deny-unsigned --image="${IMAGE}:not-a-release" -n nvcre \
+  --dry-run=server --restart=Never -o name
+
+# Untouched: image outside the glob, even in the labeled namespace
+kubectl run nvcre-other --image="busybox:1.36" -n nvcre \
+  --dry-run=server --restart=Never -o name
+```
+
+CI does **not** reproduce live admission: it needs a cluster and registry access. Structural
+tests under `test/docspolicy` pin the kind, fail-closed policy, issuer, identity prefix,
+namespace selector, provenance attestation, narrow globs, and `signatureFormat: bundle`
+so the samples cannot silently rot into the parked shape.
 
 ## Troubleshooting
 

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -459,7 +459,8 @@ IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
 DIGEST="$(crane digest "${IMAGE}:${TAG}")"
 ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
 # Live main-<sha7> tag from GHCR (publish.yml does not publish a floating :main).
-# Replace with any current main-<sha7> if this example ages out.
+# List a current one when this example ages out:
+#   crane ls ghcr.io/nvidia/cluster-readiness-engine/manager | grep '^main-' | head -n1
 DEV_TAG=main-c2d4d47
 
 # --- Kyverno path (primary for issue #272) ---
@@ -504,7 +505,7 @@ kubectl run nvcre-other --image="busybox:1.36" -n nvcre \
 These repro steps are fenced as `shell` rather than `bash` so Docs Verify (which extracts and runs every `bash` block on this page) does not try them without a cluster. CI does **not** reproduce live admission: it needs a cluster and registry access. Structural
 tests under `test/docspolicy` pin the kind, `validationActions: [Deny]`, fail-closed
 `failurePolicy`, issuer, identity prefix (and anchored repository path), single
-authority, namespace selector, provenance attestation, narrow globs, and
+attestor / authority, namespace selector, provenance attestation, narrow globs, and
 `signatureFormat: bundle` so the samples cannot silently rot into the parked shape.
 
 ## Troubleshooting

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -388,7 +388,7 @@ they expect the **new-bundle / OCI referrer** layout ADR-074 publishes (not a le
 | `cosign verify` / `verify-attestation` (v3.1.3) | Yes | this page |
 | Kyverno `ImageValidatingPolicy` (v1.19+) | Yes — referrer / bundle path | `config/samples/policy/kyverno-verify-images.yaml` |
 | Kyverno `ClusterPolicy` / `verifyImages` | **No** — looks for legacy `.sig` tags | do not use |
-| Sigstore policy-controller with `signatureFormat: bundle` | Yes — attestations in bundle form | `config/samples/policy/policy-controller-verify-images.yaml` |
+| Sigstore policy-controller with `signatureFormat: bundle` | Schema/format yes; **this sample shape unconfirmed** end-to-end (issue #272 asked for a re-test before ruling it in) | `config/samples/policy/policy-controller-verify-images.yaml` |
 | Sigstore policy-controller at chart default (legacy format) | **No** against current release digests | set `signatureFormat: bundle` |
 | Flux `OCIRepository` `spec.verify.provider: cosign` | Unconfirmed (issue #267) | — |
 
@@ -404,7 +404,14 @@ provenance (`emit_provenance: false` on those legs); pin the index digest in Hel
    in CI rewrites that string when a new tag ships. Applying a pin that does not match the
    image already in the cluster will deny the next upgrade, `rollout restart`, node drain,
    or crash-loop replacement until you edit the policy.
-2. **Label the namespace** that runs the controller (default `nvcre`) so enforcement is
+2. **If you mirrored the controller image** off `ghcr.io` (see
+   [deployment.md](./deployment.md#air-gapped-and-disconnected-environments)), rewrite every
+   image glob in the sample (`matchImageReferences` for Kyverno, `images[].glob` for
+   policy-controller) to your mirror repository path before applying. Kyverno fails *open*
+   when no glob matches (`images.*` becomes `[]` and `[].all(...)` is true); policy-controller
+   chart-default `no-match-policy: deny` fails *closed* on unmatched images — either way a
+   stale `ghcr.io/...` glob does not protect the mirrored manager image you meant to admit.
+3. **Label the namespace** that runs the controller (default `nvcre`) so enforcement is
    opt-in, not cluster-wide:
 
    ```shell
@@ -412,11 +419,13 @@ provenance (`emit_provenance: false` on those legs); pin the index digest in Hel
    kubectl label namespace nvcre \
      kubernetes.nvcre.nvidia.com/image-admission=enforce
 
-   # policy-controller sample (chart-default opt-in)
+   # policy-controller sample (chart-default opt-in). Labelling puts the whole
+   # namespace under deny-by-default for images that match no ClusterImagePolicy
+   # unless you set no-match-policy to allow|warn.
    kubectl label namespace nvcre policy.sigstore.dev/include=true
    ```
 
-3. Apply the sample that matches the admission controller you already run:
+4. Apply the sample that matches the admission controller you already run:
 
    ```shell
    kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
@@ -431,11 +440,13 @@ These constraints are load-bearing; a first attempt that skipped them was parked
 
 | Concern | What the samples do |
 |---|---|
-| Namespace scoping | Kyverno: `matchConstraints.namespaceSelector` on an opt-in label. policy-controller: namespace must carry `policy.sigstore.dev/include=true`. |
+| Namespace scoping | Kyverno: `matchConstraints.namespaceSelector` on an opt-in label. policy-controller: namespace must carry `policy.sigstore.dev/include=true`. On policy-controller that label is deny-by-default for *every* image in the namespace (chart-default `no-match-policy: deny`), not a narrowing to NVCRE images alone. |
 | `failurePolicy` / enforce mode | Fail-closed on purpose, but only after the namespace opt-in above. Image globs are evaluated *inside* the controller and cannot narrow which requests hit a Fail webhook. |
+| Mutating webhook (Kyverno) | `validationConfigurations` is set explicitly (`mutateDigest` / `verifyDigest` / `required: true`). Applying the Kyverno sample therefore also registers a mutating webhook that rewrites matching tags to digests — CRD defaults, called out so it is a decision rather than a surprise. |
 | Provenance | Both require a verified `https://slsa.dev/provenance/v1` attestation, not signature-only. |
-| Identity matching | Live field is exact `subject:` for one release tag. A regexp belongs under `subjectRegExp:` — putting `refs/tags/.+` under `subject:` matches no SAN and denies everything. Image globs name `.../manager`, `.../manager:*`, and `.../manager@*` (or `@sha256:*`); they deliberately avoid a `manager*` prefix wildcard. |
+| Identity matching | Live field is exact `subject:` for one release tag. A regexp belongs under `subjectRegExp:` — putting `refs/tags/.+` under `subject:` matches no SAN and denies everything. Kyverno globs name `.../manager`, `.../manager:*`, and `.../manager@*`; policy-controller omits the bare form (it matches `ref.Name()`, which always has a tag or digest) and uses `.../manager:*` + `.../manager@sha256:*`. Both deliberately avoid a `manager*` prefix wildcard. Mirror installs must rewrite the `ghcr.io` prefix. |
 | Bundle format | policy-controller sets `signatureFormat: bundle` and checks the `cosign/sign/v1` + `slsa.dev/provenance/v1` attestations that referrers expose. |
+| Container coverage (Kyverno) | Validations concatenate `images.containers` + `initContainers` + `ephemeralContainers`, and `matchConstraints` includes `pods/ephemeralcontainers` so `kubectl debug` is in scope. `validationConfigurations.required` already denied unchecked init images; the concatenation makes the deny message name the real check. |
 
 #### Kind reproduction (operator / maintainer)
 
@@ -447,12 +458,14 @@ TAG=v0.2.0
 IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
 DIGEST="$(crane digest "${IMAGE}:${TAG}")"
 ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
+# Live main-<sha7> tag from GHCR (publish.yml does not publish a floating :main).
+# Replace with any current main-<sha7> if this example ages out.
+DEV_TAG=main-c2d4d47
 
-# Cluster with Kyverno >= v1.19 (or policy-controller >= v0.15.0 + signatureFormat: bundle)
+# --- Kyverno path (primary for issue #272) ---
 kubectl create namespace nvcre --dry-run=client -o yaml | kubectl apply -f -
 kubectl label namespace nvcre \
-  kubernetes.nvcre.nvidia.com/image-admission=enforce \
-  policy.sigstore.dev/include=true --overwrite
+  kubernetes.nvcre.nvidia.com/image-admission=enforce --overwrite
 
 # Edit the sample's subject pin to ${TAG}, then:
 kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
@@ -461,23 +474,38 @@ kubectl apply -f config/samples/policy/kyverno-verify-images.yaml
 kubectl run nvcre-admit --image="${IMAGE}@${DIGEST}" -n nvcre \
   --dry-run=server --restart=Never -o name
 
-# Denied: signed under publish.yml@refs/heads/main (development image)
-kubectl run nvcre-deny-main --image="${IMAGE}:main" -n nvcre \
+# Denied: signed under attest.yml@refs/heads/main (development image).
+# Uses a real published main-<sha7> tag so admission resolves the manifest and
+# exercises the subject: identity pin (a floating :main tag is not published).
+kubectl run nvcre-deny-main --image="${IMAGE}:${DEV_TAG}" -n nvcre \
   --dry-run=server --restart=Never -o name
 
-# Denied: unsigned tag under our repository (not a real release digest)
+# Denied: unpublished tag under our repository. We do not ship unsigned manager
+# images, so this is the practical stand-in for "no signature material" (manifest
+# lookup fails). It is not an identity-pin test — that is the DEV_TAG case above.
 kubectl run nvcre-deny-unsigned --image="${IMAGE}:not-a-release" -n nvcre \
   --dry-run=server --restart=Never -o name
 
-# Untouched: image outside the glob, even in the labeled namespace
+# Untouched on Kyverno: image outside matchImageReferences, even in the labeled
+# namespace (validations never see it).
 kubectl run nvcre-other --image="busybox:1.36" -n nvcre \
   --dry-run=server --restart=Never -o name
+
+# --- policy-controller caveat ---
+# If you apply the policy-controller sample instead, labelling with
+# policy.sigstore.dev/include=true puts the namespace under chart-default
+# no-match-policy=deny. The busybox create above is then DENIED (not untouched)
+# because busybox matches no ClusterImagePolicy. Untouched only holds if
+# no-match-policy is allow|warn, or the namespace is unlabeled. Prefer a
+# separate namespace for that check, and treat the policy-controller sample
+# as format guidance until the #272 re-test lands.
 ```
 
 These repro steps are fenced as `shell` rather than `bash` so Docs Verify (which extracts and runs every `bash` block on this page) does not try them without a cluster. CI does **not** reproduce live admission: it needs a cluster and registry access. Structural
-tests under `test/docspolicy` pin the kind, fail-closed policy, issuer, identity prefix,
-namespace selector, provenance attestation, narrow globs, and `signatureFormat: bundle`
-so the samples cannot silently rot into the parked shape.
+tests under `test/docspolicy` pin the kind, `validationActions: [Deny]`, fail-closed
+`failurePolicy`, issuer, identity prefix (and anchored repository path), single
+authority, namespace selector, provenance attestation, narrow globs, and
+`signatureFormat: bundle` so the samples cannot silently rot into the parked shape.
 
 ## Troubleshooting
 

--- a/docs/operations/verifying-artifacts.md
+++ b/docs/operations/verifying-artifacts.md
@@ -459,8 +459,9 @@ IMAGE=ghcr.io/nvidia/cluster-readiness-engine/manager
 DIGEST="$(crane digest "${IMAGE}:${TAG}")"
 ID="https://github.com/NVIDIA/cluster-readiness-engine/.github/workflows/attest.yml@refs/tags/${TAG}"
 # Live main-<sha7> tag from GHCR (publish.yml does not publish a floating :main).
-# List a current one when this example ages out:
-#   crane ls ghcr.io/nvidia/cluster-readiness-engine/manager | grep '^main-' | head -n1
+# GHCR lists tags oldest-first, so `crane ls | grep '^main-' | head -n1` returns
+# an unsigned early build. publish.yml computes the tag as main-${GITHUB_SHA::7}:
+#   DEV_TAG="main-$(git rev-parse --short=7 origin/main)"
 DEV_TAG=main-c2d4d47
 
 # --- Kyverno path (primary for issue #272) ---
@@ -481,10 +482,11 @@ kubectl run nvcre-admit --image="${IMAGE}@${DIGEST}" -n nvcre \
 kubectl run nvcre-deny-main --image="${IMAGE}:${DEV_TAG}" -n nvcre \
   --dry-run=server --restart=Never -o name
 
-# Denied: unpublished tag under our repository. We do not ship unsigned manager
-# images, so this is the practical stand-in for "no signature material" (manifest
-# lookup fails). It is not an identity-pin test — that is the DEV_TAG case above.
-kubectl run nvcre-deny-unsigned --image="${IMAGE}:not-a-release" -n nvcre \
+# Denied: published but unsigned. Pre-dates release signing, which starts at
+# v0.1.0-rc.9, so admission resolves the manifest and fails on missing
+# signature material rather than on the lookup. (These old tags could be GC'd;
+# a 404 then is obvious. :not-a-release is a lookup failure, not this criterion.)
+kubectl run nvcre-deny-unsigned --image="${IMAGE}:v0.1.0-rc.1" -n nvcre \
   --dry-run=server --restart=Never -o name
 
 # Untouched on Kyverno: image outside matchImageReferences, even in the labeled

--- a/test/docspolicy/policy_samples_test.go
+++ b/test/docspolicy/policy_samples_test.go
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package docspolicy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Policy samples are copy-pasted into clusters. A structural test cannot prove
+// live admission (that needs Kind + registry), but it can stop the samples
+// rotting back into the shapes that parked issue #272: cluster-wide Fail
+// without a namespace selector, signature-only checks, a regexp stuffed into
+// subject:, an over-broad manager* glob, or policy-controller without
+// signatureFormat: bundle.
+const (
+	kyvernoSample          = "../../config/samples/policy/kyverno-verify-images.yaml"
+	policyControllerSample = "../../config/samples/policy/policy-controller-verify-images.yaml"
+)
+
+const (
+	wantIssuer  = "https://token.actions.githubusercontent.com"
+	wantSubject = "https://github.com/NVIDIA/cluster-readiness-engine" +
+		"/.github/workflows/attest.yml@refs/tags/"
+	wantProvenanceType = "https://slsa.dev/provenance/v1"
+	wantSignType       = "https://sigstore.dev/cosign/sign/v1"
+	wantNSLabel        = "kubernetes.nvcre.nvidia.com/image-admission"
+)
+
+func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
+	t.Run("kyverno", func(t *testing.T) {
+		doc := mustLoadYAML(t, kyvernoSample)
+
+		if got := asString(doc["kind"]); got != "ImageValidatingPolicy" {
+			t.Fatalf("kind = %q, want ImageValidatingPolicy — ClusterPolicy/verifyImages "+
+				"cannot see new-bundle referrer signatures", got)
+		}
+
+		spec := asMap(t, doc["spec"], "spec")
+		if got := asString(spec["failurePolicy"]); got != "Fail" {
+			t.Errorf("failurePolicy = %q, want Fail (fail closed)", got)
+		}
+
+		match := asMap(t, spec["matchConstraints"], "spec.matchConstraints")
+		ns := asMap(t, match["namespaceSelector"], "spec.matchConstraints.namespaceSelector")
+		if !namespaceSelectorPinsOptIn(ns) {
+			t.Error("matchConstraints.namespaceSelector must opt in via " + wantNSLabel +
+				"=enforce; without it failurePolicy: Fail is cluster-wide")
+		}
+
+		globs := imageGlobs(t, spec["matchImageReferences"], "matchImageReferences")
+		assertNarrowManagerGlobs(t, globs)
+
+		identities := kyvernoIdentities(t, spec)
+		assertExactReleaseIdentity(t, identities)
+
+		atts := asSlice(t, spec["attestations"], "spec.attestations")
+		if !attestationTypePresent(atts, wantProvenanceType) {
+			t.Errorf("attestations must require %s (signature-only was parked)", wantProvenanceType)
+		}
+
+		vals := asSlice(t, spec["validations"], "spec.validations")
+		joined := expressionsJoined(vals)
+		if !strings.Contains(joined, "verifyImageSignatures") {
+			t.Error("validations must call verifyImageSignatures")
+		}
+		if !strings.Contains(joined, "verifyAttestationSignatures") {
+			t.Error("validations must call verifyAttestationSignatures for provenance")
+		}
+		if !strings.Contains(joined, "slsaProvenance") {
+			t.Error("validations must reference attestations.slsaProvenance")
+		}
+	})
+
+	t.Run("policy-controller", func(t *testing.T) {
+		doc := mustLoadYAML(t, policyControllerSample)
+
+		if got := asString(doc["kind"]); got != "ClusterImagePolicy" {
+			t.Fatalf("kind = %q, want ClusterImagePolicy", got)
+		}
+
+		spec := asMap(t, doc["spec"], "spec")
+		if got := asString(spec["mode"]); got != "enforce" {
+			t.Errorf("mode = %q, want enforce", got)
+		}
+
+		images := asSlice(t, spec["images"], "spec.images")
+		var globs []string
+		for _, img := range images {
+			m := asMap(t, img, "images[]")
+			if g := asString(m["glob"]); g != "" {
+				globs = append(globs, g)
+			}
+		}
+		assertNarrowManagerGlobs(t, globs)
+
+		authorities := asSlice(t, spec["authorities"], "spec.authorities")
+		if len(authorities) == 0 {
+			t.Fatal("spec.authorities is empty")
+		}
+		auth := asMap(t, authorities[0], "authorities[0]")
+		if got := asString(auth["signatureFormat"]); got != "bundle" {
+			t.Errorf("signatureFormat = %q, want bundle — chart-default legacy format "+
+				"cannot see NVCRE referrer signatures", got)
+		}
+
+		keyless := asMap(t, auth["keyless"], "authorities[0].keyless")
+		ids := asSlice(t, keyless["identities"], "keyless.identities")
+		assertExactReleaseIdentity(t, ids)
+
+		atts := asSlice(t, auth["attestations"], "authorities[0].attestations")
+		if !attestationPredicatePresent(atts, wantSignType) {
+			t.Errorf("attestations must include %s (bundle-format signature)", wantSignType)
+		}
+		if !attestationPredicatePresent(atts, wantProvenanceType) {
+			t.Errorf("attestations must include %s", wantProvenanceType)
+		}
+	})
+}
+
+func TestPolicySamplesAreMentionedOnVerificationPage(t *testing.T) {
+	raw, err := os.ReadFile(verificationPage)
+	if err != nil {
+		t.Fatalf("read %s: %v", verificationPage, err)
+	}
+	page := string(raw)
+	for _, path := range []string{
+		"config/samples/policy/kyverno-verify-images.yaml",
+		"config/samples/policy/policy-controller-verify-images.yaml",
+	} {
+		if !strings.Contains(page, path) {
+			t.Errorf("%s does not link %s", verificationPage, path)
+		}
+	}
+	if !strings.Contains(page, "signatureFormat: bundle") {
+		t.Error("verification page must tell operators about signatureFormat: bundle")
+	}
+	if !strings.Contains(page, "ImageValidatingPolicy") {
+		t.Error("verification page must name ImageValidatingPolicy, not only ClusterPolicy")
+	}
+	if !strings.Contains(page, "ClusterPolicy") {
+		t.Error("verification page must warn that ClusterPolicy/verifyImages cannot see our format")
+	}
+}
+
+func mustLoadYAML(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	// Samples may be multi-doc; take the first non-empty document.
+	for _, part := range strings.Split(string(raw), "\n---\n") {
+		part = strings.TrimSpace(part)
+		if part == "" || strings.HasPrefix(part, "#") && !strings.Contains(part, "\nkind:") {
+			// Still try to unmarshal; comments before kind are fine.
+		}
+		var doc map[string]any
+		if err := yaml.Unmarshal([]byte(part), &doc); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if asString(doc["kind"]) != "" {
+			return doc
+		}
+	}
+	t.Fatalf("%s has no Kubernetes document with a kind", path)
+	return nil
+}
+
+func asMap(t *testing.T, v any, what string) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok || m == nil {
+		t.Fatalf("%s: want map, got %T", what, v)
+	}
+	return m
+}
+
+func asSlice(t *testing.T, v any, what string) []any {
+	t.Helper()
+	s, ok := v.([]any)
+	if !ok {
+		t.Fatalf("%s: want slice, got %T", what, v)
+	}
+	return s
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func namespaceSelectorPinsOptIn(ns map[string]any) bool {
+	if labels, ok := ns["matchLabels"].(map[string]any); ok {
+		if asString(labels[wantNSLabel]) == "enforce" {
+			return true
+		}
+	}
+	exprs, _ := ns["matchExpressions"].([]any)
+	for _, e := range exprs {
+		m, _ := e.(map[string]any)
+		if asString(m["key"]) != wantNSLabel {
+			continue
+		}
+		if asString(m["operator"]) != "In" {
+			continue
+		}
+		for _, v := range asStringSlice(m["values"]) {
+			if v == "enforce" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func asStringSlice(v any) []string {
+	raw, _ := v.([]any)
+	out := make([]string, 0, len(raw))
+	for _, x := range raw {
+		out = append(out, asString(x))
+	}
+	return out
+}
+
+func imageGlobs(t *testing.T, v any, what string) []string {
+	t.Helper()
+	refs := asSlice(t, v, what)
+	var out []string
+	for _, r := range refs {
+		m := asMap(t, r, what+"[]")
+		if g := asString(m["glob"]); g != "" {
+			out = append(out, g)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s has no glob entries", what)
+	}
+	return out
+}
+
+func assertNarrowManagerGlobs(t *testing.T, globs []string) {
+	t.Helper()
+	const repo = "ghcr.io/nvidia/cluster-readiness-engine/manager"
+	var sawRepo bool
+	for _, g := range globs {
+		if g == repo || strings.HasPrefix(g, repo+":") || strings.HasPrefix(g, repo+"@") {
+			sawRepo = true
+		}
+		// The parked sample used manager* and over-matched. Reject any glob
+		// that keeps a wildcard immediately after "manager" without a
+		// separator — manager* / manager** — while still allowing manager:* .
+		if strings.Contains(g, "manager*") && !strings.Contains(g, "manager:*") &&
+			!strings.Contains(g, "manager@") {
+			t.Errorf("glob %q uses manager* and can over-match manager-debug / nested paths", g)
+		}
+	}
+	if !sawRepo {
+		t.Errorf("globs %v do not pin %s", globs, repo)
+	}
+}
+
+func kyvernoIdentities(t *testing.T, spec map[string]any) []any {
+	t.Helper()
+	atts := asSlice(t, spec["attestors"], "spec.attestors")
+	if len(atts) == 0 {
+		t.Fatal("spec.attestors is empty")
+	}
+	attestor := asMap(t, atts[0], "attestors[0]")
+	cosign := asMap(t, attestor["cosign"], "attestors[0].cosign")
+	keyless := asMap(t, cosign["keyless"], "attestors[0].cosign.keyless")
+	return asSlice(t, keyless["identities"], "keyless.identities")
+}
+
+func assertExactReleaseIdentity(t *testing.T, identities []any) {
+	t.Helper()
+	if len(identities) == 0 {
+		t.Fatal("no keyless identities")
+	}
+	found := false
+	for _, id := range identities {
+		m := asMap(t, id, "identity")
+		if asString(m["issuer"]) != wantIssuer {
+			t.Errorf("issuer = %q, want %q", asString(m["issuer"]), wantIssuer)
+		}
+		subject := asString(m["subject"])
+		subjectRE := asString(m["subjectRegExp"])
+		if subject != "" {
+			if !strings.HasPrefix(subject, wantSubject) {
+				t.Errorf("subject = %q, want prefix %q", subject, wantSubject)
+			}
+			if strings.Contains(subject, ".+") || strings.Contains(subject, ".*") {
+				t.Errorf("subject = %q looks like a regexp; use subjectRegExp: for patterns "+
+					"(a regexp under subject: matches no SAN)", subject)
+			}
+			found = true
+		}
+		if subjectRE != "" {
+			// Optional loosening is fine in comments; a live subjectRegExp must
+			// still name attest.yml and refs/tags.
+			if !strings.Contains(subjectRE, "attest\\.yml") && !strings.Contains(subjectRE, "attest.yml") {
+				t.Errorf("subjectRegExp = %q does not name attest.yml", subjectRE)
+			}
+			if !strings.Contains(subjectRE, "refs/tags") {
+				t.Errorf("subjectRegExp = %q does not anchor refs/tags", subjectRE)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no identity pins subject or subjectRegExp")
+	}
+}
+
+func attestationTypePresent(atts []any, want string) bool {
+	for _, a := range atts {
+		m, _ := a.(map[string]any)
+		if intoto, ok := m["intoto"].(map[string]any); ok {
+			if asString(intoto["type"]) == want {
+				return true
+			}
+		}
+		if asString(m["predicateType"]) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func attestationPredicatePresent(atts []any, want string) bool {
+	for _, a := range atts {
+		m, _ := a.(map[string]any)
+		if asString(m["predicateType"]) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func expressionsJoined(vals []any) string {
+	var b strings.Builder
+	for _, v := range vals {
+		m, _ := v.(map[string]any)
+		b.WriteString(asString(m["expression"]))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Ensure the sample files exist where the docs say they do — a rename that
+// updates only one side would otherwise leave a 404 link.
+func TestPolicySampleFilesExist(t *testing.T) {
+	for _, p := range []string{kyvernoSample, policyControllerSample} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("%s: %v", filepath.Clean(p), err)
+		}
+	}
+}

--- a/test/docspolicy/policy_samples_test.go
+++ b/test/docspolicy/policy_samples_test.go
@@ -6,6 +6,7 @@ package docspolicy
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -30,6 +31,7 @@ const (
 	wantProvenanceType = "https://slsa.dev/provenance/v1"
 	wantSignType       = "https://sigstore.dev/cosign/sign/v1"
 	wantNSLabel        = "kubernetes.nvcre.nvidia.com/image-admission"
+	wantEnforceMode    = "enforce"
 )
 
 func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
@@ -85,7 +87,7 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		}
 
 		spec := asMap(t, doc["spec"], "spec")
-		if got := asString(spec["mode"]); got != "enforce" {
+		if got := asString(spec["mode"]); got != wantEnforceMode {
 			t.Errorf("mode = %q, want enforce", got)
 		}
 
@@ -154,11 +156,11 @@ func mustLoadYAML(t *testing.T, path string) map[string]any {
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
-	// Samples may be multi-doc; take the first non-empty document.
-	for _, part := range strings.Split(string(raw), "\n---\n") {
+	// Samples may be multi-doc; take the first document with a kind.
+	for part := range strings.SplitSeq(string(raw), "\n---\n") {
 		part = strings.TrimSpace(part)
-		if part == "" || strings.HasPrefix(part, "#") && !strings.Contains(part, "\nkind:") {
-			// Still try to unmarshal; comments before kind are fine.
+		if part == "" {
+			continue
 		}
 		var doc map[string]any
 		if err := yaml.Unmarshal([]byte(part), &doc); err != nil {
@@ -197,7 +199,7 @@ func asString(v any) string {
 
 func namespaceSelectorPinsOptIn(ns map[string]any) bool {
 	if labels, ok := ns["matchLabels"].(map[string]any); ok {
-		if asString(labels[wantNSLabel]) == "enforce" {
+		if asString(labels[wantNSLabel]) == wantEnforceMode {
 			return true
 		}
 	}
@@ -210,10 +212,8 @@ func namespaceSelectorPinsOptIn(ns map[string]any) bool {
 		if asString(m["operator"]) != "In" {
 			continue
 		}
-		for _, v := range asStringSlice(m["values"]) {
-			if v == "enforce" {
-				return true
-			}
+		if slices.Contains(asStringSlice(m["values"]), wantEnforceMode) {
+			return true
 		}
 	}
 	return false

--- a/test/docspolicy/policy_samples_test.go
+++ b/test/docspolicy/policy_samples_test.go
@@ -47,6 +47,11 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		if got := asString(spec["failurePolicy"]); got != "Fail" {
 			t.Errorf("failurePolicy = %q, want Fail (fail closed)", got)
 		}
+		// failurePolicy is webhook-failure behaviour; enforcement is validationActions.
+		actions := asStringSlice(spec["validationActions"])
+		if len(actions) != 1 || actions[0] != "Deny" {
+			t.Errorf("validationActions = %v, want [Deny] (Audit would stop denying)", actions)
+		}
 
 		match := asMap(t, spec["matchConstraints"], "spec.matchConstraints")
 		ns := asMap(t, match["namespaceSelector"], "spec.matchConstraints.namespaceSelector")
@@ -77,6 +82,16 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		if !strings.Contains(joined, "slsaProvenance") {
 			t.Error("validations must reference attestations.slsaProvenance")
 		}
+		for _, key := range []string{"initContainers", "ephemeralContainers"} {
+			if !strings.Contains(joined, key) {
+				t.Errorf("validations must include images.%s (containers alone is incomplete)", key)
+			}
+		}
+		// Ephemeral coverage also needs the subresource in matchConstraints.
+		rules := asSlice(t, match["resourceRules"], "spec.matchConstraints.resourceRules")
+		if !resourceRulesInclude(rules, "pods/ephemeralcontainers") {
+			t.Error("matchConstraints.resourceRules must include pods/ephemeralcontainers")
+		}
 	})
 
 	t.Run("policy-controller", func(t *testing.T) {
@@ -102,25 +117,29 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		assertNarrowManagerGlobs(t, globs)
 
 		authorities := asSlice(t, spec["authorities"], "spec.authorities")
-		if len(authorities) == 0 {
-			t.Fatal("spec.authorities is empty")
+		// policy-controller admits if *any* authority verifies. A second looser
+		// authority would neuter the pin while index-0 checks still pass.
+		if len(authorities) != 1 {
+			t.Fatalf("spec.authorities has %d entries, want exactly 1", len(authorities))
 		}
-		auth := asMap(t, authorities[0], "authorities[0]")
-		if got := asString(auth["signatureFormat"]); got != "bundle" {
-			t.Errorf("signatureFormat = %q, want bundle — chart-default legacy format "+
-				"cannot see NVCRE referrer signatures", got)
-		}
+		for i, raw := range authorities {
+			auth := asMap(t, raw, "authorities[]")
+			if got := asString(auth["signatureFormat"]); got != "bundle" {
+				t.Errorf("authorities[%d].signatureFormat = %q, want bundle — chart-default legacy format "+
+					"cannot see NVCRE referrer signatures", i, got)
+			}
 
-		keyless := asMap(t, auth["keyless"], "authorities[0].keyless")
-		ids := asSlice(t, keyless["identities"], "keyless.identities")
-		assertExactReleaseIdentity(t, ids)
+			keyless := asMap(t, auth["keyless"], "authorities[].keyless")
+			ids := asSlice(t, keyless["identities"], "keyless.identities")
+			assertExactReleaseIdentity(t, ids)
 
-		atts := asSlice(t, auth["attestations"], "authorities[0].attestations")
-		if !attestationPredicatePresent(atts, wantSignType) {
-			t.Errorf("attestations must include %s (bundle-format signature)", wantSignType)
-		}
-		if !attestationPredicatePresent(atts, wantProvenanceType) {
-			t.Errorf("attestations must include %s", wantProvenanceType)
+			atts := asSlice(t, auth["attestations"], "authorities[].attestations")
+			if !attestationPredicatePresent(atts, wantSignType) {
+				t.Errorf("authorities[%d] attestations must include %s (bundle-format signature)", i, wantSignType)
+			}
+			if !attestationPredicatePresent(atts, wantProvenanceType) {
+				t.Errorf("authorities[%d] attestations must include %s", i, wantProvenanceType)
+			}
 		}
 	})
 }
@@ -282,39 +301,54 @@ func assertExactReleaseIdentity(t *testing.T, identities []any) {
 	if len(identities) == 0 {
 		t.Fatal("no keyless identities")
 	}
-	found := false
-	for _, id := range identities {
+	// Every identity must be tight. policy-controller / Kyverno accept if any
+	// identity matches, so a wide-open second entry next to a good one neuters
+	// the pin while a "found one good identity" check would still pass.
+	for i, id := range identities {
 		m := asMap(t, id, "identity")
 		if asString(m["issuer"]) != wantIssuer {
-			t.Errorf("issuer = %q, want %q", asString(m["issuer"]), wantIssuer)
+			t.Errorf("identities[%d].issuer = %q, want %q", i, asString(m["issuer"]), wantIssuer)
 		}
 		subject := asString(m["subject"])
 		subjectRE := asString(m["subjectRegExp"])
+		if subject == "" && subjectRE == "" {
+			t.Errorf("identities[%d] pins neither subject nor subjectRegExp", i)
+			continue
+		}
 		if subject != "" {
 			if !strings.HasPrefix(subject, wantSubject) {
-				t.Errorf("subject = %q, want prefix %q", subject, wantSubject)
+				t.Errorf("identities[%d].subject = %q, want prefix %q", i, subject, wantSubject)
 			}
 			if strings.Contains(subject, ".+") || strings.Contains(subject, ".*") {
-				t.Errorf("subject = %q looks like a regexp; use subjectRegExp: for patterns "+
-					"(a regexp under subject: matches no SAN)", subject)
+				t.Errorf("identities[%d].subject = %q looks like a regexp; use subjectRegExp: for patterns "+
+					"(a regexp under subject: matches no SAN)", i, subject)
 			}
-			found = true
 		}
 		if subjectRE != "" {
-			// Optional loosening is fine in comments; a live subjectRegExp must
-			// still name attest.yml and refs/tags.
-			if !strings.Contains(subjectRE, "attest\\.yml") && !strings.Contains(subjectRE, "attest.yml") {
-				t.Errorf("subjectRegExp = %q does not name attest.yml", subjectRE)
+			if !strings.Contains(subjectRE, "NVIDIA/cluster-readiness-engine") {
+				t.Errorf("identities[%d].subjectRegExp = %q does not name NVIDIA/cluster-readiness-engine", i, subjectRE)
+			}
+			if !strings.Contains(subjectRE, `attest\.yml`) && !strings.Contains(subjectRE, "attest.yml") {
+				t.Errorf("identities[%d].subjectRegExp = %q does not name attest.yml", i, subjectRE)
 			}
 			if !strings.Contains(subjectRE, "refs/tags") {
-				t.Errorf("subjectRegExp = %q does not anchor refs/tags", subjectRE)
+				t.Errorf("identities[%d].subjectRegExp = %q does not require refs/tags", i, subjectRE)
 			}
-			found = true
+			if !strings.HasPrefix(subjectRE, "^") || !strings.HasSuffix(subjectRE, "$") {
+				t.Errorf("identities[%d].subjectRegExp = %q must be anchored with ^...$", i, subjectRE)
+			}
 		}
 	}
-	if !found {
-		t.Error("no identity pins subject or subjectRegExp")
+}
+
+func resourceRulesInclude(rules []any, resource string) bool {
+	for _, r := range rules {
+		m, _ := r.(map[string]any)
+		if slices.Contains(asStringSlice(m["resources"]), resource) {
+			return true
+		}
 	}
+	return false
 }
 
 func attestationTypePresent(atts []any, want string) bool {

--- a/test/docspolicy/policy_samples_test.go
+++ b/test/docspolicy/policy_samples_test.go
@@ -6,6 +6,7 @@ package docspolicy
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -63,8 +64,7 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		globs := imageGlobs(t, spec["matchImageReferences"], "matchImageReferences")
 		assertNarrowManagerGlobs(t, globs)
 
-		identities := kyvernoIdentities(t, spec)
-		assertExactReleaseIdentity(t, identities)
+		attestorName := assertKyvernoSingleTightAttestor(t, spec)
 
 		atts := asSlice(t, spec["attestations"], "spec.attestations")
 		if !attestationTypePresent(atts, wantProvenanceType) {
@@ -82,15 +82,23 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		if !strings.Contains(joined, "slsaProvenance") {
 			t.Error("validations must reference attestations.slsaProvenance")
 		}
-		for _, key := range []string{"initContainers", "ephemeralContainers"} {
-			if !strings.Contains(joined, key) {
-				t.Errorf("validations must include images.%s (containers alone is incomplete)", key)
+		assertValidationsReferenceOnlyAttestor(t, joined, attestorName)
+		// Per expression, not across the joined set: one validation covering
+		// init/ephemeral must not paper over another that dropped back to
+		// images.containers alone.
+		for i, raw := range vals {
+			expr := asString(asMap(t, raw, "validations[]")["expression"])
+			for _, key := range []string{"initContainers", "ephemeralContainers"} {
+				if !strings.Contains(expr, key) {
+					t.Errorf("validations[%d] must include images.%s (containers alone is incomplete)", i, key)
+				}
 			}
 		}
-		// Ephemeral coverage also needs the subresource in matchConstraints.
+		// Ephemeral coverage also needs the subresource routed to this policy.
 		rules := asSlice(t, match["resourceRules"], "spec.matchConstraints.resourceRules")
-		if !resourceRulesInclude(rules, "pods/ephemeralcontainers") {
-			t.Error("matchConstraints.resourceRules must include pods/ephemeralcontainers")
+		if !resourceRuleCoversEphemeralContainers(rules) {
+			t.Error("matchConstraints.resourceRules must cover pods/ephemeralcontainers " +
+				`on ""/v1 with UPDATE, alongside pods in the same rule`)
 		}
 	})
 
@@ -284,16 +292,44 @@ func assertNarrowManagerGlobs(t *testing.T, globs []string) {
 	}
 }
 
-func kyvernoIdentities(t *testing.T, spec map[string]any) []any {
+// assertKyvernoSingleTightAttestor mirrors the policy-controller len==1 pin:
+// Kyverno admits if any listed attestor verifies, so a second looser attestor
+// would neuter the release identity while attestors[0]-only checks stayed green.
+func assertKyvernoSingleTightAttestor(t *testing.T, spec map[string]any) string {
 	t.Helper()
 	atts := asSlice(t, spec["attestors"], "spec.attestors")
-	if len(atts) == 0 {
-		t.Fatal("spec.attestors is empty")
+	if len(atts) != 1 {
+		t.Fatalf("spec.attestors has %d entries, want exactly 1", len(atts))
 	}
-	attestor := asMap(t, atts[0], "attestors[0]")
-	cosign := asMap(t, attestor["cosign"], "attestors[0].cosign")
-	keyless := asMap(t, cosign["keyless"], "attestors[0].cosign.keyless")
-	return asSlice(t, keyless["identities"], "keyless.identities")
+	var name string
+	for i, raw := range atts {
+		attestor := asMap(t, raw, "attestors[]")
+		name = asString(attestor["name"])
+		if name == "" {
+			t.Fatalf("attestors[%d].name is empty", i)
+		}
+		cosign := asMap(t, attestor["cosign"], "attestors[].cosign")
+		keyless := asMap(t, cosign["keyless"], "attestors[].cosign.keyless")
+		ids := asSlice(t, keyless["identities"], "keyless.identities")
+		assertExactReleaseIdentity(t, ids)
+	}
+	return name
+}
+
+var attestorSelector = regexp.MustCompile(`attestors\.([A-Za-z_][A-Za-z0-9_]*)`)
+
+func assertValidationsReferenceOnlyAttestor(t *testing.T, joined, wantName string) {
+	t.Helper()
+	wantRef := "attestors." + wantName
+	if !strings.Contains(joined, wantRef) {
+		t.Errorf("validations must reference %s", wantRef)
+	}
+	for _, m := range attestorSelector.FindAllStringSubmatch(joined, -1) {
+		if m[1] != wantName {
+			t.Errorf("validations reference attestors.%s; only %s is defined "+
+				"(a second looser attestor in CEL would neuter the pin)", m[1], wantRef)
+		}
+	}
 }
 
 func assertExactReleaseIdentity(t *testing.T, identities []any) {
@@ -341,12 +377,30 @@ func assertExactReleaseIdentity(t *testing.T, identities []any) {
 	}
 }
 
-func resourceRulesInclude(rules []any, resource string) bool {
+// resourceRuleCoversEphemeralContainers requires the subresource on the core
+// v1 Pod rule with UPDATE (the operation kubectl debug uses), and pods in the
+// same rule so a tidy-up that relocates the subresource under apps cannot keep
+// the assertion green while the API server never routes it to the policy.
+func resourceRuleCoversEphemeralContainers(rules []any) bool {
 	for _, r := range rules {
 		m, _ := r.(map[string]any)
-		if slices.Contains(asStringSlice(m["resources"]), resource) {
-			return true
+		resources := asStringSlice(m["resources"])
+		if !slices.Contains(resources, "pods/ephemeralcontainers") {
+			continue
 		}
+		if !slices.Contains(resources, "pods") {
+			return false
+		}
+		if !slices.Contains(asStringSlice(m["apiGroups"]), "") {
+			return false
+		}
+		if !slices.Contains(asStringSlice(m["apiVersions"]), "v1") {
+			return false
+		}
+		if !slices.Contains(asStringSlice(m["operations"]), "UPDATE") {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/test/docspolicy/policy_samples_test.go
+++ b/test/docspolicy/policy_samples_test.go
@@ -86,6 +86,7 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 		// Per expression, not across the joined set: one validation covering
 		// init/ephemeral must not paper over another that dropped back to
 		// images.containers alone.
+		allPositive := regexp.MustCompile(`all\(\s*\w+\s*,\s*\w+\s*>\s*0\s*\)`)
 		for i, raw := range vals {
 			expr := asString(asMap(t, raw, "validations[]")["expression"])
 			for _, key := range []string{"initContainers", "ephemeralContainers"} {
@@ -93,12 +94,17 @@ func TestPolicySamplePinsTheReleaseIdentity(t *testing.T) {
 					t.Errorf("validations[%d] must include images.%s (containers alone is incomplete)", i, key)
 				}
 			}
+			// `.all(e, e >= 0)` / `.exists(...)` / a dropped `.all` are all
+			// vacuously true for zero verified signatures — fail-open rot.
+			if !allPositive.MatchString(expr) {
+				t.Errorf("validations[%d] must require all(..., e > 0); >= 0 or exists() fail open", i)
+			}
 		}
 		// Ephemeral coverage also needs the subresource routed to this policy.
 		rules := asSlice(t, match["resourceRules"], "spec.matchConstraints.resourceRules")
 		if !resourceRuleCoversEphemeralContainers(rules) {
 			t.Error("matchConstraints.resourceRules must cover pods/ephemeralcontainers " +
-				`on ""/v1 with UPDATE, alongside pods in the same rule`)
+				`on ""/v1 with CREATE+UPDATE (or *), alongside pods in the same rule`)
 		}
 	})
 
@@ -316,18 +322,24 @@ func assertKyvernoSingleTightAttestor(t *testing.T, spec map[string]any) string 
 	return name
 }
 
-var attestorSelector = regexp.MustCompile(`attestors\.([A-Za-z_][A-Za-z0-9_]*)`)
+// attestorSelector matches dotted and bracket CEL selectors. len(attestors)==1
+// is the load-bearing pin; this is defence in depth on the CEL side.
+var attestorSelector = regexp.MustCompile(
+	`attestors(?:\.([A-Za-z_][A-Za-z0-9_]*)|\["([^"]+)"\]|\['([^']+)'\])`)
 
 func assertValidationsReferenceOnlyAttestor(t *testing.T, joined, wantName string) {
 	t.Helper()
 	wantRef := "attestors." + wantName
-	if !strings.Contains(joined, wantRef) {
+	if !strings.Contains(joined, wantRef) &&
+		!strings.Contains(joined, `attestors["`+wantName+`"]`) &&
+		!strings.Contains(joined, `attestors['`+wantName+`']`) {
 		t.Errorf("validations must reference %s", wantRef)
 	}
 	for _, m := range attestorSelector.FindAllStringSubmatch(joined, -1) {
-		if m[1] != wantName {
+		got := m[1] + m[2] + m[3]
+		if got != wantName {
 			t.Errorf("validations reference attestors.%s; only %s is defined "+
-				"(a second looser attestor in CEL would neuter the pin)", m[1], wantRef)
+				"(a second looser attestor in CEL would neuter the pin)", got, wantRef)
 		}
 	}
 }
@@ -377,10 +389,11 @@ func assertExactReleaseIdentity(t *testing.T, identities []any) {
 	}
 }
 
-// resourceRuleCoversEphemeralContainers requires the subresource on the core
-// v1 Pod rule with UPDATE (the operation kubectl debug uses), and pods in the
-// same rule so a tidy-up that relocates the subresource under apps cannot keep
-// the assertion green while the API server never routes it to the policy.
+// resourceRuleCoversEphemeralContainers requires the subresource on a core
+// v1 Pod rule with CREATE+UPDATE (or *), and pods in the same rule so a
+// tidy-up that relocates the subresource under apps cannot keep the assertion
+// green while the API server never routes it to the policy. A broken earlier
+// rule must continue so a later correct core rule still counts.
 func resourceRuleCoversEphemeralContainers(rules []any) bool {
 	for _, r := range rules {
 		m, _ := r.(map[string]any)
@@ -389,20 +402,27 @@ func resourceRuleCoversEphemeralContainers(rules []any) bool {
 			continue
 		}
 		if !slices.Contains(resources, "pods") {
-			return false
+			continue
 		}
 		if !slices.Contains(asStringSlice(m["apiGroups"]), "") {
-			return false
+			continue
 		}
 		if !slices.Contains(asStringSlice(m["apiVersions"]), "v1") {
-			return false
+			continue
 		}
-		if !slices.Contains(asStringSlice(m["operations"]), "UPDATE") {
-			return false
+		if !operationsCoverPodAdmission(asStringSlice(m["operations"])) {
+			continue
 		}
 		return true
 	}
 	return false
+}
+
+func operationsCoverPodAdmission(ops []string) bool {
+	if slices.Contains(ops, "*") {
+		return true
+	}
+	return slices.Contains(ops, "CREATE") && slices.Contains(ops, "UPDATE")
 }
 
 func attestationTypePresent(atts []any, want string) bool {


### PR DESCRIPTION
Closes #272

## Summary
Revive and land admission-policy samples for verifying NVCRE release artifacts with Kyverno and Sigstore policy-controller, aligned to the current ADR-074 / verifying-artifacts identity contract (`signatureFormat: bundle`, exact subject pin).

## What’s included
- Kyverno ImageValidatingPolicy sample (namespace opt-in, Fail after opt-in, provenance required, exact subject / no manager*)
- Sigstore policy-controller ClusterImagePolicy sample with `signatureFormat: bundle`
- Docs updates in verifying-artifacts.md + RELEASE.md pin note
- Structural tests in `test/docspolicy/policy_samples_test.go`
- Kind admit/deny repro documented (full Kind not required to merge structural coverage)

## Test plan
- [x] `make test` / package tests for `test/docspolicy`
- [x] Samples match current published identity contract
- [ ] Maintainer `/ok to test` for NVIDIA runners if required
- [ ] Optional Kind admit/deny smoke per docs

## Risk
Docs + sample YAML + structural tests only. No runtime controller changes. Misconfigured Fail policies can block pulls if applied cluster-wide — samples stay namespace-opt-in with Fail after opt-in as documented.